### PR TITLE
limit count of trade form per account not per user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def current_account
+    current_user && current_user.account
+  end
+  helper_method :current_account
+
   protected
 
   def load_eligibilities

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -107,7 +107,7 @@ class FormController < ApplicationController
   end
 
   def check_trade_count_limit
-    if current_user.has_trade_award?
+    if current_account.has_trade_award?
       redirect_to dashboard_url, flash: { alert: 'You can not submit more than one trade form' }
     end
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -6,7 +6,10 @@ class Account < ActiveRecord::Base
   validates :owner, presence: true
 
   def collaborators_without(user)
-    users.excluding(user)
-         .by_email
+    users.excluding(user).by_email
+  end
+
+  def has_trade_award?
+    form_answers.where(award_type: 'trade').any?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,10 +75,6 @@ class User < ActiveRecord::Base
     @current_step = step
   end
 
-  def has_trade_award?
-    form_answers.where(award_type: 'trade').any?
-  end
-
   private
 
   def first_step?

--- a/app/views/shared/_application_awards_status.html.slim
+++ b/app/views/shared/_application_awards_status.html.slim
@@ -17,7 +17,7 @@
 /* action:    Download PDF of your application
 
 ul.applications-list
-  - unless current_user.has_trade_award?
+  - unless current_account.has_trade_award?
     li
       h3
         ' International Trade Award

--- a/spec/mailers/users/collaboration_mailer_spec.rb
+++ b/spec/mailers/users/collaboration_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Users::CollaborationMailer do
   let!(:account_admin) do
-    FactoryGirl.create :user, :completed_profile, 
+    FactoryGirl.create :user, :completed_profile,
                               first_name: "Account Admin John",
                               role: "account_admin"
   end
@@ -12,7 +12,7 @@ describe Users::CollaborationMailer do
   describe "#access_granted" do
     describe "New user created and added to collaborators" do
       let!(:new_account_admin) do
-        FactoryGirl.create :user, :completed_profile, 
+        FactoryGirl.create :user, :completed_profile,
                                   first_name: "New Account Admin Mike",
                                   account: account,
                                   role: "account_admin"
@@ -22,11 +22,11 @@ describe Users::CollaborationMailer do
       let(:generated_password) { "strongpass" }
       let(:confirmation_token) { "12345678" }
 
-      let(:mail) { 
+      let(:mail) {
         Users::CollaborationMailer.access_granted(
-          account_admin, 
-          new_account_admin, 
-          new_user, 
+          account_admin,
+          new_account_admin,
+          new_user,
           generated_password,
           confirmation_token
         )
@@ -44,13 +44,13 @@ describe Users::CollaborationMailer do
         expect(mail.body.encoded).to match(new_account_admin.role.humanize)
         expect(mail.body.encoded).to match(new_account_admin.email)
         expect(mail.body.encoded).to match(generated_password)
-        mail.body.encoded.should have_link("Confirm", href: user_confirmation_url(confirmation_token: confirmation_token))
+        expect(mail.body.encoded).to have_link("Confirm", href: user_confirmation_url(confirmation_token: confirmation_token))
       end
     end
 
     describe "Existing user added to collaborators" do
       let!(:new_account_admin) do
-        FactoryGirl.create :user, :completed_profile, 
+        FactoryGirl.create :user, :completed_profile,
                                   first_name: "New Account Admin Mike",
                                   account: account,
                                   role: "account_admin"
@@ -58,10 +58,10 @@ describe Users::CollaborationMailer do
 
       let(:new_user) { false }
 
-      let(:mail) { 
+      let(:mail) {
         Users::CollaborationMailer.access_granted(
-          account_admin, 
-          new_account_admin, 
+          account_admin,
+          new_account_admin,
           new_user
         )
       }
@@ -76,7 +76,7 @@ describe Users::CollaborationMailer do
 
       it "renders the body" do
         expect(mail.body.encoded).to match(new_account_admin.role.humanize)
-        mail.body.encoded.should have_link("View", href: dashboard_url)
+        expect(mail.body.encoded).to have_link("View", href: dashboard_url)
       end
     end
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Account do
+  let(:user) { FactoryGirl.build(:user) }
+  let(:account) { user.account }
+
+  describe '#has_trade_award?' do
+    let!(:innovation_award) { create(:form_answer, :innovation, user: user) }
+
+    it 'returns false when there is no trade award' do
+      expect(account).not_to have_trade_award
+    end
+
+    it 'returns true when there is a trade award' do
+      create(:form_answer, :trade, user: user)
+      expect(account).to have_trade_award
+    end
+  end
+end

--- a/spec/models/form_answer_spec.rb
+++ b/spec/models/form_answer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FormAnswer, type: :model do
         FormAnswer.connection.execute("ALTER SEQUENCE #{seq} RESTART")
       }
 
-      FormAnswer.any_instance.stub(:eligible?) { true }
+      allow_any_instance_of(FormAnswer).to receive(:eligible?) { true }
     end
     let!(:form_answer) { FactoryGirl.create(:form_answer, submitted: true) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,17 +13,4 @@ RSpec.describe User, :type => :model do
     expect(user.owned_account).to eq(account)
     expect(account.owner).to eq(user)
   end
-
-  describe '#has_trade_award?' do
-    let!(:innovation_award) { create(:form_answer, :innovation, user: user) }
-
-    it 'returns false when there is no trade award' do
-      expect(user).not_to have_trade_award
-    end
-
-    it 'returns true when there is a trade award' do
-      create(:form_answer, :trade, user: user)
-      expect(user).to have_trade_award
-    end
-  end
 end


### PR DESCRIPTION
The limit of the number of international trade applications is one per year per account.