### PR TITLE
[QAE1020] International-Trade-Award-Form

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -30,7 +30,7 @@ jQuery ->
         scrollTop: 0
       , 0)
       return false
-
+      
   # Hidden hints as seen on
   # https://www.gov.uk/service-manual/user-centred-design/resources/patterns/help-text
   # Creates the links and adds the arrows
@@ -64,7 +64,7 @@ jQuery ->
       answerVal = input.is(':checked').toString()
 
     question.each () ->
-      if $(this).attr('data-value') == answerVal || ($(this).attr('data-value') == "true" && (answerVal != 'false' && answerVal != false))
+      if $(this).attr('data-value') == answerVal || ($(this).attr('data-value') == "true" && (answerVal != 'false' && answerVal != false)) || ($(this).attr('data-type') == "in_clause_collection" && $(this).attr('data-value') <= answerVal)
         if clicked || (!clicked && input.attr('type') == 'radio' && input.is(':checked')) || (!clicked && input.attr('type') != 'radio')
           $(this).addClass("show-question")
       else
@@ -417,6 +417,11 @@ jQuery ->
       if can_add
         add_example = add_example.replace(/(form\[\w+\]\[)(\d+)\]/g, "$1#{list_size+1}]")
         question.find(".list-add").append("<li>#{add_example}</li>")
+
+        need_to_clear_example = question.find(".list-add").attr("data-need-to-clear-example")
+        if (typeof(need_to_clear_example) != typeof(undefined) && need_to_clear_example != false)
+          clearFormElements(question.find(".list-add li:last"))
+
   # Removing these added fields
   $(document).on "click", ".question-group .list-add .js-remove-link", (e) ->
     e.preventDefault()
@@ -502,3 +507,5 @@ jQuery ->
   $(document).on 'click', (e) ->
     if !$(e.target).closest('.dropdown').length
       $(".dropdown.dropdown-open").removeClass("dropdown-open")
+
+  OptionsWithPreselectedConditionsQuestion.init();

--- a/app/assets/javascripts/frontend/clear_form_elements.js.coffee
+++ b/app/assets/javascripts/frontend/clear_form_elements.js.coffee
@@ -1,0 +1,9 @@
+window.clearFormElements = (obj) ->
+  obj.find(':input').each ->
+    switch @type
+      when 'password', 'text', 'textarea', 'file', 'select-one', 'select-multiple'
+        $(this).val ''
+      when 'checkbox', 'radio'
+        @checked = false
+    return
+  return

--- a/app/assets/javascripts/frontend/custom_questions/options_with_preselected_conditions_question.js.coffee
+++ b/app/assets/javascripts/frontend/custom_questions/options_with_preselected_conditions_question.js.coffee
@@ -1,0 +1,51 @@
+window.OptionsWithPreselectedConditionsQuestion = init: ->
+  $(document).on 'change input', '.js-options-with-dependent-child-question', ->
+    selected_options = $(this).closest('.list-add').find('.js-options-with-dependent-child-question option:selected')
+    dependable_key = $(this).attr('data-parent-option-dependable-key')
+    dependable_values = $(this).attr('data-dependable-values').split(',')
+    dependable_option_suffix = $(this).attr('data-dependable-option-siffix')
+
+    dependable_children_div_block = $('.js-options-with-parent-dependency[data-depends-on=\'' + dependable_key + '\']')
+    dependable_sections = dependable_children_div_block.find('.js-option-by-preselected-condition')
+    dependable_controls = dependable_children_div_block.find('.selectable')
+
+    # Fetching all selected values in list
+    selected_values = []
+    $.each selected_options, (index, el) ->
+      selected_values.push $(el).val()
+      return
+    selected_values = $.unique(selected_values)
+
+    # Comparing dependable values with selected values
+    matched_conditional_value = ''
+    $.each dependable_values, (key, value) ->
+      if $.inArray(value, selected_values) != -1
+        matched_conditional_value = value
+        return false
+      return
+
+    dependable_sections.addClass 'display_none'
+    if matched_conditional_value.length > 1
+      # If there is at least of one matched condition value
+
+      # Then show related selected
+      data_preselected_condition = dependable_option_suffix + '_' + matched_conditional_value
+      selected_child_el = dependable_children_div_block.find('.js-option-by-preselected-condition[data-preselected-condition=\'' + data_preselected_condition + '\']')
+      selected_child_el.removeClass 'display_none'
+
+      # Hide related controles
+      dependable_controls.addClass 'display_none'
+
+      # And set selected value for related control
+      related_ui_control = dependable_children_div_block.find('.selectable input[data-preselected-condition=\'' + data_preselected_condition + '\']')
+      related_ui_control.click()
+    else
+      # In nothing in conditions are match
+
+      # Then show default section 
+      dependable_children_div_block.find('.js-option-by-preselected-condition[data-preselected-condition=\'default\']').removeClass 'display_none'
+
+      # And display controls
+      dependable_controls.removeClass 'display_none'
+    return
+  return

--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -9,6 +9,16 @@
   margin: 0;
 }
 
+// When standart question label need to have margins like sub-questions
+.question_label_with_5px_margins {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.display_none {
+  display: none !important;
+}
+
 // Error styling
 .errors-container {
   margin: 0;
@@ -655,11 +665,15 @@ input[type="file"] {
 
   &.js-add-default {
     display: block !important;
-
-    .js-remove-link {
-      display: none !important;
-    }
   }
+
+  &.hidden {
+    display: none !important;
+  }
+}
+
+.js-add-default .js-remove-link {
+  display: none !important;
 }
 
 // Styles and positions submit button in pagination

--- a/app/forms/qae_2014_forms/international_trade.rb
+++ b/app/forms/qae_2014_forms/international_trade.rb
@@ -3,22 +3,18 @@ require 'qae_2014_forms/international_trade/international_trade_step2'
 require 'qae_2014_forms/international_trade/international_trade_step3'
 require 'qae_2014_forms/international_trade/international_trade_step4'
 require 'qae_2014_forms/international_trade/international_trade_step5'
+require 'qae_2014_forms/international_trade/international_trade_step6'
 
 class QAE2014Forms
   class << self
     def trade
       @trade ||= QAEFormBuilder.build 'Apply for the International Trade Award' do
-
-        step 'Company Information', 'Company Info', &QAE2014Forms.trade_step1
-
-        step 'Description of Goods or Services', 'Description', &QAE2014Forms.trade_step2
-
-        step 'Commercial Performance', 'Commercial Performance', &QAE2014Forms.trade_step3
-
-        step 'Declaration of Corporate Responsibility', 'Corporate Responsibility', &QAE2014Forms.trade_step4
-
-        step 'Authorisation/Monitoring', 'Authorisation', &QAE2014Forms.trade_step5
-
+        step 'Company Information', "Company Info", &QAE2014Forms.trade_step1
+        step 'Description of Goods or Services, Markets and Marketing', "Description", &QAE2014Forms.trade_step2
+        step 'Commercial Performance', "Commercial Performance", &QAE2014Forms.trade_step3
+        step 'Declaration of Corporate Responsibility', "Corporate Responsibility", &QAE2014Forms.trade_step4
+        step 'Add Links/Documents', "Add Links/Documents", &QAE2014Forms.trade_step5
+        step 'Authorisation/Monitoring', "Authorisation", &QAE2014Forms.trade_step6
       end
     end
   end

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step1.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step1.rb
@@ -2,52 +2,65 @@ class QAE2014Forms
   class << self
     def trade_step1
       @trade_step1 ||= Proc.new {
-        # TODO Pre-filled from registration details
-        text :company_name, 'Full/legal name of your organisational unit' do
-          required
+        options :applying_for, "Are you applying on behalf of your:" do
           ref 'A 1'
-          help "What name should I write?", %Q{
-              <p>Your answer should reflect the title registered with Companies House. If applicable, include 'trading as', or any other name by which the business is known.</p>
+          option 'organisation', 'Whole organisation'
+          option 'division branch subsidiary', 'A division, branch or subsidiary'
+        end
+
+        header :business_division_header, '' do
+          context %Q{
+            <div class="application-notice help-notice">
+              <p>Where the form refers to your organisation, please enter the details of your division, branch or subsidiary.</p>
+            </div>
+          }
+          conditional :applying_for, 'division branch subsidiary'
+        end
+
+        text :company_name, 'Full/legal name of your organisation' do
+          required
+          ref 'A 2'
+          context %Q{
+            <p>If applicable, include 'trading as', or any other name your organisation uses.</p>
           }
         end
 
-        options :principal_business, 'Does your unit operate as a principal?' do
+        options :principal_business, 'Does your organisation operate as a principal?' do
           required
-          ref 'A 2'
+          ref 'A 3'
           context %Q{
             <p>We recommend that you apply as a principal. A principal invoices its customers (or their buying agents) and is the body to receive those payments.</p>
           }
           yes_no
         end
 
-        textarea :invoicing_unit_relations,
-          'Please explain the arrangements made, and your relationship with the invoicing unit.' do
+        textarea :invoicing_unit_relations, 'Please explain your relationship with the invoicing unit, and the arrangements made.' do
           classes "sub-question"
           required
           conditional :principal_business, :no
-          words_max 100
+          words_max 200
           rows 5
         end
 
         number :registration_number, 'Company/Charity Registration Number' do
           required
-          ref 'A 3'
-          help 'What if I do not have a Company/Charity Registration number?', %Q{
-            <p>Please enter 'N/A' if this is not applicable. If an unregistered subsidiary, please enter your parent company's number.</p>
+          ref 'A 4'
+          context %Q{
+            <p>If you don't have a Company/Charity Registration Number please enter 'N/A'. If you're an unregistered subsidiary, please enter your parent company's number.</p>
           }
           style "small"
         end
 
         date :started_trading, 'Date started trading' do
           required
-          ref 'A 4'
-          context '<p>Businesses which began trading after 01/10/2012 are not eligible for this award.</p>'
+          ref 'A 5'
+          context "<p>Organisations that began trading after 01/10/2012 aren't eligible for this award.</p>"
           date_max '01/10/2012'
         end
 
-        options :queen_award_holder, %Q{Are you a current Queen's Award holder (2010-2014)?} do
+        options :queen_award_holder, "Are you a current Queen's Award holder (2010-2014)?" do
           required
-          ref 'A 5'
+          ref 'A 6'
           yes_no
         end
 
@@ -68,9 +81,12 @@ class QAE2014Forms
           year 2012
           year 2013
           year 2014
+
+          children_options_depends_on :category
+          dependable_values [:international_trade_3, :international_trade_6]
         end
 
-        options :business_name_changed, 'Has the name of your organisation changed since your previous entry?' do
+        options :business_name_changed, 'Have you changed the name of your organisation since your last entry?' do
           classes "sub-question"
 
           conditional :queen_award_holder, :yes
@@ -78,54 +94,52 @@ class QAE2014Forms
           yes_no
         end
 
-        previous_name :previous_business_name, '' do
+        text :previous_business_name, 'Name used previously' do
+          classes "regular-question"
+          required
           conditional :business_name_changed, :yes
         end
 
-        options :other_awards_won, 'Have you won any other business or enterprise awards in the past?' do
-          ref 'A 6'
+        textarea :previous_business_ref_num, 'Reference number used previously' do
+          classes "regular-question"
+          required
+          conditional :business_name_changed, :yes
+          rows 5
+          words_max 100
+        end
+
+        options :other_awards_won, 'Have you won any other business awards in the past?' do
+          ref 'A 7'
           yes_no
         end
 
         textarea :other_awards_desc, 'Please describe them' do
           classes "sub-question"
-          context '<p>Only enter the awards you consider most notable.</p>'
+          context "<p>If you can't fit all of your awards below, then choose those you're most proud of.</p>"
           conditional :other_awards_won, :yes
           rows 5
           words_max 300
         end
 
-        options :joint_entry, 'Is this entry made jointly with any other organisation(s)?' do
-          ref 'A 7'
-          required
-          help "Should my entry be a joint entry?", %Q{
-            <p>Joint entires can be submitted if two (or more) companies developed the innovation and realised commercial success. Each organisation should submit separate, cross-referenced, entry forms. For more information, see the FAQ.</p>
-          }
-          yes_no
-        end
-
-        text :joint_entry_names, 'Please enter their name(s)' do
-          classes "sub-question"
-          required
-          conditional :joint_entry, :yes
-          style "largest"
-        end
-
-        # Prefilled from registration details
-        address :principal_address, 'Principal address of your organisational unit' do
+        address :principal_address, 'Principal address of your organisation' do
           required
           ref 'A 8'
         end
 
-        text :website_url, 'Website URL' do
+        text :org_telephone, 'Main telephone number' do
           required
           ref 'A 9'
-          type :url
+          style "small"
+        end
+
+        text :website_url, 'Website URL' do
+          required
+          ref 'A 10'
         end
 
         dropdown :business_sector, 'Business Sector' do
           required
-          ref 'A 10'
+          ref 'A 11'
           option '', 'Business Sector'
           option :other, 'Other'
         end
@@ -136,51 +150,53 @@ class QAE2014Forms
           conditional :business_sector, :other
         end
 
-        head_of_business :head_of_business, 'Head of your organisational unit' do
-          required
-          ref 'A 11'
-        end
-
-        text :head_job_title, 'Job title / Role in the organisation' do
-          classes "sub-question"
-          required
-        end
-
-        text :head_email, 'Email address' do
-          classes "sub-question"
-          required
-          type :email
-        end
-
-        options :is_division, 'Are you a division, branch or subsidiary?' do
+        header :parent_company_header, 'Parent Companies' do
           ref 'A 12'
-          yes_no
+          conditional :applying_for, 'true'
         end
 
         text :parent_company, 'Name of immediate parent company' do
-          classes "regular-question"
-          conditional :is_division, :yes
+          classes "sub-question"
+          conditional :applying_for, 'division branch subsidiary'
         end
 
         country :parent_company_country, 'Country of immediate parent company' do
           classes "regular-question"
-          conditional :is_division, :yes
-        end
+          conditional :applying_for, 'division branch subsidiary'
+        end        
 
-        options :parent_ultimate_control, 'Does the immediate parent company have ultimate control?' do
+        options :parent_ultimate_control, 'Does your immediate parent company have ultimate control?' do
           classes "sub-question"
-          conditional :is_division, :yes
+          conditional :applying_for, 'division branch subsidiary'
           yes_no
         end
 
         text :ultimate_control_company, 'Name of organisation with ultimate control' do
           classes "regular-question"
           conditional :parent_ultimate_control, :no
+          conditional :applying_for, 'division branch subsidiary'
         end
 
         country :ultimate_control_company_country, 'Country of organisation with ultimate control' do
           classes "regular-question"
           conditional :parent_ultimate_control, :no
+          conditional :applying_for, 'division branch subsidiary'
+        end
+
+        options :parent_group_entry, 'Are you a parent company making a group entry?' do
+          classes "sub-question"
+          conditional :applying_for, 'organisation'
+          context %Q{
+            <p>A 'group entry' is when you are applying on behalf of multiple divisions/branches/subsidiaries under your control.</p>
+          }
+          yes_no
+        end
+
+        options :pareent_group_excluding, 'Are you excluding any members of your group from this application?' do
+          classes "sub-question"
+          conditional :applying_for, 'organisation'
+          conditional :parent_group_entry, 'yes'
+          yes_no
         end
 
         options :trading_figures, 'Do you have any UK subsidiaries, associates or plants whose trading figures are included in this entry?' do
@@ -194,21 +210,15 @@ class QAE2014Forms
           conditional :trading_figures, :yes
         end
 
-        textarea :excluded_explanation, 'Parent companies making group entries should include figures for all UK subsidiaries. If any part of the group is excluded, please provide an explanation here.' do
-          classes "sub-question"
-          rows 5
-          words_max 200
-        end
-
         options :export_agent, 'Are you an export agent/merchant?' do
           ref 'A 14'
           required
           yes_no
           help 'What is an export agent?', %Q{
-            <p>An export agent is an individual or company that undertakes export activity on behalf of another company in return for payment by means of a commission.</p>
+            <p>An export agent undertakes exportation on behalf of another company in exchange for commission.</p>
           }
           help 'What is an export merchant?', %Q{
-            <p>An export merchant buys and takes ownership of merchandise to generate income by selling at a higher price. An export merchant may rebrand or repack goods before selling them on.</p>
+            <p>An export merchant buys merchandise to sell on at a higher price (sometimes rebranding/repacking in the process).</p>
           }
         end
 
@@ -217,7 +227,7 @@ class QAE2014Forms
           required
           yes_no
           help 'What is an export unit?', %Q{
-            <p>An export unit is a subsidiary or operating unit of a larger company that manages the company's export activities. </p>
+            <p>An export unit is a subsidiary or operating unit of a larger company that manages the company's export activities.</p>
           }
         end
 

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step2.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step2.rb
@@ -3,6 +3,10 @@ class QAE2014Forms
   class << self
     def trade_step2
       @trade_step2 ||= Proc.new {
+        context %Q{
+          <p>Please try to avoid using technical jargon in this section. </p>
+        }
+
         textarea :trade_desc_whole, 'Describe your business as a whole' do
           ref 'B 1'
           required
@@ -23,18 +27,17 @@ class QAE2014Forms
           option '5', '5'
         end
 
-        textarea :goods_desc_short, 'Brief description of the goods and/or services being traded overseas' do
+        by_trade_goods_and_services_label :trade_goods_and_services_explanations, 'Briefly describe each type of good/service you trade.' do
           classes "sub-question"
           required
           context %Q{
-            <p>e.g. 'design and manufacture of bespoke steel windows and doors'. If relevant, give details of material used or end use. </p>
+            <p>If relevant, give details of material used or end use. e.g. 'design and manufacture of bespoke steel windows and doors'.</p>
           }
           rows 2
           words_max 15
-        end
-
-        number :total_overseas_trade, '% of your total overseas trade' do
-          classes "sub-question"
+          min 0
+          max 100
+          conditional :trade_goods_amount, :true
         end
 
         textarea :trade_plans_desc, 'Describe your international and domestic trading strategies (plans), their vision/objectives for the future, their method of implementation, and how your actual performance compared to the plans set out.' do
@@ -54,13 +57,13 @@ class QAE2014Forms
           ref 'B 4'
           required
           context %Q{
-            <p>Include evidence of how you segment and manage geographical regions. Please supply market share information. </p>
+            <p>Include evidence of how you segment and manage geographical regions. Please supply market share information.</p>
           }
           rows 5
           words_max 500
         end
 
-        textarea :top_overseas_sales, "State the percentage of total overseas sales made to each of your top 5 overseas countries during the final year of your entry." do
+        textarea :top_overseas_sales, "State the percentage of total overseas sales made to each of your top 5 overseas markets (ie. individual countries) during the final year of your entry." do
           classes "sub-question"
           required
           rows 5
@@ -74,25 +77,11 @@ class QAE2014Forms
           words_max 300
         end
 
-        textarea :trade_factors, "Give details of any special challenges affecting your trade in goods or services, and how you overcame them." do
+        textarea :trade_factors, "Describe any special challenges affecting your trade in goods or services, and how you overcame them." do
           ref 'B 5'
           required
           rows 5
           words_max 200
-        end
-
-        upload :trade_materials, 'If there is additional material you feel would help us to assess your entry then you can add up to 4 files or links here.' do
-          ref 'B 7'
-          context %Q{
-            <p>We can't guarantee these will be reviewed, so inlcude any vital information within the form.</p>
-            <p>You may upload files of less than 5mb each in either MS Word Document, PDF, MS Excel Spreadsheet or MS Powerpoint Presentation formats. Or MP4 (video) files of up to TODOmb.</p>
-          } # TODO!
-          links
-          description
-          max_attachments 4
-          help 'Information we will not review', %Q{
-            <p>We will not consider business plans, annual accounts or company policy documents. Additional materials should not be used as a substitue for completing sections of the form.</p>
-          }
         end
       }
     end

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step3.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step3.rb
@@ -11,11 +11,23 @@ class QAE2014Forms
           required
           option '3 to 5', 'Outstanding growth over the last 3 years'
           option '6 plus', 'Continuous growth over the last 6 years'
-          placeholder_preselected_condition :queen_award_holder_details, :category, "international_trade_3", "international_trade_6", "6 plus", %Q{
-            As you currently hold a Queen's Award for Continuous Achievement in International Trade (3 years), you can only apply for the Outstanding Achievement Award (6 years).
+          placeholder_preselected_condition :queen_award_holder_details, {
+            question_suffix: :category, 
+            parent_question_answer_key: "international_trade_3", 
+            answer_key: "international_trade_6", 
+            question_value: "6 plus", 
+            placeholder_text: %Q{
+              As you currently hold a Queen's Award for Continuous Achievement in International Trade (3 years), you can only apply for the Outstanding Achievement Award (6 years).
+            }
           }
-          placeholder_preselected_condition :queen_award_holder_details, :category, "international_trade_6", "international_trade_3", "3 to 5", %Q{
-            As you currently hold a Queen's Award for Continuous Achievement in International Trade (6 years), you can only apply for the Outstanding Achievement Award (3 years).
+          placeholder_preselected_condition :queen_award_holder_details, {
+            question_suffix: :category,
+            parent_question_answer_key: "international_trade_6", 
+            answer_key: "international_trade_3", 
+            question_value: "3 to 5", 
+            placeholder_text: %Q{
+              As you currently hold a Queen's Award for Continuous Achievement in International Trade (6 years), you can only apply for the Outstanding Achievement Award (3 years).
+            }
           }
         end
 

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step4.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step4.rb
@@ -6,25 +6,25 @@ class QAE2014Forms
           ref 'D 1'
           required
           context %Q{
-            <p>This does not affect your chance of success.</p>
+            <p>This decision doesn't affect your chance of success.</p>
           }
           option :complete_now, 'Complete full corporate responsibility form now'
           option :declare_now, 'Complete declaration now, and full form once shortlisted'
         end
 
-        header :declaration_introduction_text, "" do
+        header :complete_now_header, "" do
           context %Q{
-            <p>Please outline the effects of the activities and practices of your whole business unit under the headings set out below.</p><p>If you have already provided relevant information in your entry, please refer to that information and give any additional information under the relevant heading(s) below.'</p><p>The associated Innovation guidance notes suggest some questions you might consider in preparing your responses.</p>
+            <p>The Declaration of Corporate Responsibility is a chance for you to outline your responsible business conduct, and its social, economic and environmental impact.</p>
+            <p>You don't have to demonstrate strength in all of the areas below.</p>
+            <p>If you have too many initiatives, just outline the ones you think are most relevant/important.</p>
           }
-          conditional :corp_responsibility_form, :complete_now
         end
 
         textarea :impact_on_society, "The impact of your business operations on society" do
           ref 'D 2'
-          conditional :corp_responsibility_form, :complete_now
           required
-          help "What should I include in this box?", %Q{
-            <p>What activies do you undertake to foster good relations with local communities? Outline how you evaluate and report on their impact.</p>
+          context %Q{
+            <p>What activities do you undertake to foster good relations with local communities? Outline how you evaluate and report on their impact.</p>
             <p>If you have operations in the third world or developing countries, are these conducted with proper regard for the current and future welfare of the people employed there?</p>
           }
           rows 5
@@ -35,19 +35,19 @@ class QAE2014Forms
           ref 'D 3'
           required
           conditional :corp_responsibility_form, :complete_now
-          help "What should I include in this box?", %Q{
-            <p>Description of any environmental considerations within your business eg. energy efficiency strategies, recycling policies, emissions reduction policies.</p>
-            <p>If, and how, you undertake environmental impact assessments of major projects. </p>
+          context %Q{
+            <p>Description of any environmental considerations within your business e.g. energy efficiency strategies, recycling policies, emissions reduction policies.</p>
+            <p>If, and how, you undertake environmental impact assessments of major projects.</p>
           }
           rows 5
-          words_max 500 
+          words_max 500
         end
 
         textarea :partners_relations, 'Relations with suppliers, partners and contractors' do
           ref 'D 4'
           required
           conditional :corp_responsibility_form, :complete_now
-          help "What should I include in this box?", %Q{
+          context %Q{
             <p>An outline of your selection criteria, if any, with regard to potential suppliers'/partners'/contractors' economic, social and environmental performance.</p>
             <p>Do you encourage best practice or require them to meet your own standards? To what extent are you succeeding?</p>
           }
@@ -59,10 +59,10 @@ class QAE2014Forms
           ref 'D 5'
           required
           conditional :corp_responsibility_form, :complete_now
-          help "What should I include in this box?", %Q{
-            <p>Do you have a code of conduct and/or employee policies eg. health and safety, training, staff welfare, whistleblowing and equal opportunities?</p>
-            <p>Outline any special employment conditions that you offer eg. flexible working, extended maternity pay.</p>
-            <p>How you keep your employees engaged eg. communication, assessments, incentives, opportunities for career development.</p>
+          context %Q{
+            <p>Do you have a code of conduct and/or employee policies e.g. health and safety, training, staff welfare, whistleblowing and equal opportunities?</p>
+            <p>Outline any special employment conditions that you offer e.g. flexible working, extended maternity pay.</p>
+            <p>How you keep your employees engaged e.g. communication, assessments, incentives, opportunities for career development.</p>
           }
           rows 5
           words_max 500 
@@ -72,7 +72,7 @@ class QAE2014Forms
           ref 'D 6'
           required
           conditional :corp_responsibility_form, :complete_now
-          help "What should I include in this box?", %Q{
+          context %Q{
             <p>What proportion of your sales consist of repeat purchases?</p>
             <p>How do you measure customer satisfaction, and what have been the results?</p>
             <p>The criteria by which you select clients and how you ensure they are appropriate for your services.</p>

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step5.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step5.rb
@@ -2,37 +2,17 @@ class QAE2014Forms
   class << self
     def trade_step5
       @trade_step5 ||= Proc.new {
-        options :agree_to_be_contacted, %Q{We will contact you regarding your entry. We may also wish to contact you about other issues relating to The Queen's Awards for Enterprise (eg. acting as a case study). Are you happy for us to do this?} do
+        upload :innovation_materials, 'If there is additional material you feel would help us to assess your entry then you can add up to 4 files or links here.' do
           ref 'E 1'
-          yes_no
-        end
-
-        confirm :confirmation_of_consent, 'Confirmation of consent' do
-          ref 'E 2'
-          required
-          text 'I confirm that I have the consent of the Head of the applicant business (as identified in A11) to submit this entry form.'
-        end
-
-        confirm :entry_confirmation, 'Confirmation of entry' do
-          ref 'E 3'
-          required
-          text %Q{
-            By ticking this box, I certify that all the particulars given and those in any accompanying statements are correct to the best of my knowledge and belief and that no material information has been withheld. I undertake to notify The Queen’s Awards Office of any changes to the information I have provided in this entry form.
-            <br>
-            <br>
-            I am not aware of any matter which might cast doubt upon the worthiness of this business unit to receive a Queen’s Award. I consent to all necessary enquiries being made by The Queen’s Awards Office in relation to this entry. This includes enquiries made of Government Departments and Agencies in discharging its responsibilities to vet any business unit which might be granted a Queen’s Award to ensure the highest standards of propriety.
-          }
-        end
-
-
-        submit "Submit application" do
-          notice %Q{
-            <p>If you have answered all the questions, you can submit your application now. You will be able to edit it any time before 23:59 on the last working day of September.</p>
-            <p>
-              If you are not ready to submit yet, you can save your application and come back later.
-            </p>
-          }
-          style "large"
+          context %Q{
+            <p>We can't guarantee these will be reviewed, so include any vital information within the form.</p>
+            <p>You can upload files in all common formats, as long as they're less than 5mb.</p>
+            <p>You may link to videos, websites or other media you feel relevant.</p>
+            <p>We won't consider business plans, annual accounts or company policy documents. Additional materials should not be used as a substitute for completing sections of the form.</p>
+          } # TODO!
+          max_attachments 4
+          links
+          description
         end
       }
     end

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step6.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step6.rb
@@ -1,7 +1,7 @@
 class QAE2014Forms
   class << self
-    def innovation_step6
-      @innovation_step6 ||= Proc.new {
+    def trade_step6
+      @trade_step6 ||= Proc.new {
         header :head_of_bussines_header, "Head of your organisation" do
           ref "F 1"
         end
@@ -44,24 +44,32 @@ class QAE2014Forms
           required
         end
 
-        # TODO Pull in info for A13
         confirm :confirmation_of_consent, 'Confirmation of consent' do
           ref 'F 2'
           required
-          text '“I confirm that I have the consent of the head of my organisation (as entered in F1 above) to submit this entry form.'
+          text 'I confirm that I have the consent of the head of my organisation (as identified above) to submit this entry form.'
+        end
+
+        confirm :agree_to_be_contacted, 'Confirmation of contact' do
+          ref 'F 3'
+          text "I am happy to be contacted about Queen's Award for Enterprise issues not related to my application (e.g. acting as a case study, newsletters, other info)."
+        end
+
+        confirm :agree_to_be_contacted_by_department, 'Confirmation of contact by Department of Business, Innovation and Skills' do
+          ref 'F 4'
+          text "I am happy to be contacted by the Department of Business, Innovation and Skills."
         end
 
         confirm :entry_confirmation, 'Confirmation of entry' do
-          ref 'F 3'
+          ref 'F 5'
           required
           text %Q{
             By ticking this box, I certify that all the particulars given and those in any accompanying statements are correct to the best of my knowledge and belief and that no material information has been withheld. I undertake to notify The Queen’s Awards Office of any changes to the information I have provided in this entry form.
             <br>
             <br>
-            I am not aware of any matter which might cast doubt upon the worthiness of this business unit to receive a Queen’s Award. I consent to all necessary enquiries being made by The Queen’s Awards Office in relation to this entry. This includes enquiries made of Government Departments and Agencies in discharging its responsibilities to vet any business unit which might be granted a Queen’s Award to ensure the highest standards of propriety. 
+            I am not aware of any matter which might cast doubt upon the worthiness of this business unit to receive a Queen’s Award. I consent to all necessary enquiries being made by The Queen’s Awards Office in relation to this entry. This includes enquiries made of Government Departments and Agencies in discharging its responsibilities to vet any business unit which might be granted a Queen’s Award to ensure the highest standards of propriety.
           }
         end
-
 
         submit "Submit application" do
           notice %Q{

--- a/app/views/qae_form/_award_holder_question.html.slim
+++ b/app/views/qae_form/_award_holder_question.html.slim
@@ -1,8 +1,8 @@
-ul.list-add
+ul.list-add data-add-limit="10"
   input name="form[awards][array]" value="true" type="hidden"
 
   - question.awards.each_with_index do |award, index|
-    li.js-add-example.js-add-default data-add-example="add-award"
+    li data-add-example=('add-award' if index == 0) class=('js-add-example js-add-default' if index == 0)
       = link_to "Remove", "#", class: "remove-link js-remove-link"
       input autocomplete="off" class="js-trigger-autosave medium" name="form[awards][#{index}][title]" type="text" value=award['title']
       select.inline name="form[awards][#{index}][year]"

--- a/app/views/qae_form/_by_trade_goods_and_services_label_question.html.slim
+++ b/app/views/qae_form/_by_trade_goods_and_services_label_question.html.slim
@@ -1,0 +1,23 @@
+.js-by-trade-goods-and-services-amount
+  - (1..5).each do |placement|
+    .js-conditional-question data-question=question.step.form[:trade_goods_amount].parameterized_title data-value=placement data-type="in_clause_collection"
+      h2
+        = "Good/Service #{placement}"
+      ul.errors-container
+      .question-group
+        label
+          span.visuallyhidden 
+            = "Good/Service #{placement}"
+        textarea.js-trigger-autosave.js-char-count rows=question.rows data-word-max=question.words_max name=question.input_name(suffix: "desc_short_#{placement}") *possible_read_only_ops
+          = question.input_value(suffix: "desc_short_#{placement}")
+        .clear
+
+      h2 % of your total overseas trade
+      ul.errors-container
+      .question-group
+        label
+          span.visuallyhidden % of your total overseas trade
+          input.js-trigger-autosave type="text" min=question.min max=question.max name=question.input_name(suffix: "total_overseas_trade_#{placement}") value=question.input_value(suffix: "total_overseas_trade_#{placement}") autocomplete="off" *possible_read_only_ops
+        .clear
+
+

--- a/app/views/qae_form/_head_of_business_question.html.slim
+++ b/app/views/qae_form/_head_of_business_question.html.slim
@@ -1,11 +1,6 @@
 .question-group
   label
     ul.errors-container
-    ' Title
-    input.js-trigger-autosave.small type="text" name=question.input_name(suffix: 'title') value=question.input_value(suffix: 'title') autocomplete="off" *possible_read_only_ops
-.question-group
-  label
-    ul.errors-container
     ' First name
     input.js-trigger-autosave.medium type="text" name=question.input_name(suffix: 'first_name') value=question.input_value(suffix: 'first_name') autocomplete="off" *possible_read_only_ops
 .question-group

--- a/app/views/qae_form/_options_with_preselected_conditions_question.html.slim
+++ b/app/views/qae_form/_options_with_preselected_conditions_question.html.slim
@@ -1,0 +1,21 @@
+- condition = question.preselected_condition
+
+.js-options-with-parent-dependency data-depends-on=question.depends_on
+  h2
+    - if question.ref
+      span class="steps step-#{question.ref.to_s.parameterize}"
+        span.visuallyhidden
+          = "Step #{question.ref.to_s}"
+        span.todo
+          = question.ref.to_s
+    .js-option-by-preselected-condition data-preselected-condition='default' class=("display_none" if condition.present?)
+      = question.main_header
+    - question.placeholder_preselected_conditions.each do |c|
+      .js-option-by-preselected-condition data-preselected-condition="#{c.question_suffix}_#{c.parent_question_answer_key}" class=("display_none" if condition.blank? || c.question_value != condition.question_value)
+        = c.placeholder_text
+
+  - question.options.each do |answer|
+    - c = question.preselected_condition_by_option(answer)
+    label.selectable class=("display_none" if condition.present?)
+      input.js-trigger-autosave type="radio" name=question.input_name value=answer.value data-preselected-condition="#{c.question_suffix}_#{c.parent_question_answer_key}" checked=(answer.value.to_s == ((condition.present? ? condition.question_value : question.input_value) || '').to_s) *possible_read_only_ops
+      = answer.text

--- a/app/views/qae_form/_queen_award_holder_question.html.slim
+++ b/app/views/qae_form/_queen_award_holder_question.html.slim
@@ -1,10 +1,13 @@
-ul.list-add
+- children_depends_on = question.children_options_depends_on
+- dependable_values = question.dependable_values
+
+ul.list-add data-add-limit="10"
   input name="form[queen_award_holder_details][array]" value="true" type="hidden"
 
   - question.awards.each_with_index do |award, index|
-    li.js-add-example.js-add-default data-add-example="add-award"
+    li data-add-example=('add-award' if index == 0) class=('js-add-example js-add-default' if index == 0)
       = link_to "Remove", "#", class: "remove-link js-remove-link"
-      select.inline name="form[queen_award_holder_details][#{index}][category]"
+      select.inline name="form[queen_award_holder_details][#{index}][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=('js-options-with-dependent-child-question' if children_depends_on.to_s == "category")
         option value="" Category
         - question.categories.each do |category|
           option value=category.value selected=(category.value.to_s == award['category']) = category.text
@@ -16,7 +19,7 @@ ul.list-add
   - if question.awards.none?
     li.js-add-example.js-add-default data-add-example="add-award"
       = link_to "Remove", "#", class: "remove-link js-remove-link"
-      select.inline name="form[queen_award_holder_details][0][category]"
+      select.inline name="form[queen_award_holder_details][0][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=('js-options-with-dependent-child-question' if children_depends_on.to_s == "category")
         option value="" Category
         - question.categories.each do |category|
           option value=category.value = category.text

--- a/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
+++ b/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
@@ -1,22 +1,40 @@
-ul.list-add
-  li.js-add-example.js-add-default data-add-example="add-subsid-assoc-plant"
-    = link_to "Remove", "#", class: "remove-link js-remove-link"
-    .clear
-    span.row
-      span.span-4
-        label.small
-          ' Name
-          input.medium type="text" autocomplete="off" *possible_read_only_ops
-      span.span-4
-        label.small
-          ' Location
-          input.medium type="text" autocomplete="off" *possible_read_only_ops
-      span.span-4
-        label.small
-          ' Number of UK Employees
-          input.small type="text" autocomplete="off" *possible_read_only_ops
+ul.list-add data-add-limit="10" data-need-to-clear-example="true"
+  input name="#{question.input_name}[array]" value="true" type="hidden"
 
-= link_to "+ Add subsidiary, associate or plant", "#", class: "button button-add js-button-add"
+  - question.subsidiaries.each_with_index do |subsidiary, index|
+    li data-add-example=('add-subsidiaries' if index == 0) class=('js-add-example js-add-default' if index == 0)
+      = link_to "Remove", "#", class: "remove-link js-remove-link"
+      .clear
+      span.row
+        span.span-4
+          label.small
+            ' Name
+            input.medium type="text" name="#{question.input_name}[#{index}][name]" value=subsidiary['name'] autocomplete="off" *possible_read_only_ops
+        span.span-4
+          label.small
+            ' Location
+            input.medium type="text" name="#{question.input_name}[#{index}][location]" value=subsidiary['location']  autocomplete="off" *possible_read_only_ops
+        span.span-4
+          label.small
+            ' Number of UK Employees
+            input.small type="text" name="#{question.input_name}[#{index}][employees]" value=subsidiary['employees']  autocomplete="off" *possible_read_only_ops
+  - if question.subsidiaries.none?
+    li.js-add-example.js-add-default data-add-example='add-subsidiaries'
+      = link_to "Remove", "#", class: "remove-link js-remove-link"
+      .clear
+      span.row
+        span.span-4
+          label.small
+            ' Name
+            input.medium type="text" name="#{question.input_name}[0][name]" autocomplete="off" *possible_read_only_ops
+        span.span-4
+          label.small
+            ' Location
+            input.medium type="text" name="#{question.input_name}[0][location]" autocomplete="off" *possible_read_only_ops
+        span.span-4
+          label.small
+            ' Number of UK Employees
+            input.small type="text" name="#{question.input_name}[0][employees]" autocomplete="off" *possible_read_only_ops
 
-a.button.button-add.js-button-add href="#" data-add-example="add-subsid-assoc-plant"
+a.button.button-add.js-button-add href="#" data-add-example="add-subsidiaries"
   | + Add subsidiary, associate or plant

--- a/lib/qae_form_builder.rb
+++ b/lib/qae_form_builder.rb
@@ -28,6 +28,9 @@ require 'qae_form_builder/confirm_question'
 require 'qae_form_builder/contact_email_question'
 require 'qae_form_builder/contact_question'
 
+require 'qae_form_builder/by_trade_goods_and_services_label_question'
+require 'qae_form_builder/options_with_preselected_conditions_question'
+
 class QAEFormBuilder
   class << self
 

--- a/lib/qae_form_builder/by_trade_goods_and_services_label_question.rb
+++ b/lib/qae_form_builder/by_trade_goods_and_services_label_question.rb
@@ -1,0 +1,34 @@
+class QAEFormBuilder
+
+  class ByTradeGoodsAndServicesLabelQuestionDecorator < QuestionDecorator
+  end
+
+  class ByTradeGoodsAndServicesLabelQuestionBuilder < QuestionBuilder
+    def rows num
+      @q.rows = num
+    end
+
+    def words_max num
+      @q.words_max = num
+    end
+
+    def min num
+      @q.min = num
+    end
+
+    def max num
+      @q.max = num
+    end
+  end
+
+  class ByAmountCondition
+    attr_accessor :question_key
+    def initialize question_key
+      @question_key = question_key
+    end
+  end
+
+  class ByTradeGoodsAndServicesLabelQuestion < Question
+    attr_accessor :rows, :words_max, :min, :max
+  end
+end

--- a/lib/qae_form_builder/head_of_business_question.rb
+++ b/lib/qae_form_builder/head_of_business_question.rb
@@ -2,7 +2,6 @@ class QAEFormBuilder
   class HeadOfBusinessQuestionDecorator < QuestionDecorator
     def required_sub_fields
       [
-        {title: "Title"},
         {first_name: "First name"},
         {last_name: "Last name"},
         {honours: "Personal Honours"}

--- a/lib/qae_form_builder/options_with_preselected_conditions_question.rb
+++ b/lib/qae_form_builder/options_with_preselected_conditions_question.rb
@@ -1,0 +1,74 @@
+class QAEFormBuilder
+  class PlaceholderPreselectedCondition
+    attr_accessor :question_key, 
+                  :question_suffix, 
+                  :parent_question_answer_key,
+                  :answer_key,
+                  :question_value, 
+                  :placeholder_text
+
+    def initialize(question_key, question_suffix, parent_question_answer_key, answer_key, question_value, placeholder_text)
+      @question_key = question_key
+      @question_suffix = question_suffix
+      @parent_question_answer_key = parent_question_answer_key
+      @answer_key = answer_key
+      @question_value = question_value
+      @placeholder_text = placeholder_text
+    end
+  end
+
+  class OptionsWithPreselectedConditionsQuestion < OptionsQuestion
+    attr_accessor :main_header, 
+                  :placeholder_preselected_conditions, 
+                  :options, 
+                  :question_key
+
+    def after_create
+      @placeholder_preselected_conditions = []
+      @options = []
+    end
+  end
+
+  class OptionsWithPreselectedConditionsQuestionBuilder < OptionsQuestionBuilder
+    def main_header text
+      @q.main_header = text
+    end
+
+    def placeholder_preselected_condition(q_key, q_suffix, p_answer_key, answer_key, q_value, placeholder_text)
+      @q.question_key = q_key
+      @q.placeholder_preselected_conditions << PlaceholderPreselectedCondition.new(
+        q_key, q_suffix, p_answer_key, answer_key, q_value, placeholder_text
+      )
+    end
+  end
+
+  class OptionsWithPreselectedConditionsQuestionDecorator < QuestionDecorator
+    def linked_answers
+      @linked_answers ||= JSON.parse(answers[delegate_obj.question_key.to_s] || '[]').map do |answer|
+        JSON.parse(answer)
+      end
+    end
+
+    def preselected_condition
+      @preselected_condition ||= placeholder_preselected_conditions.select do |c|
+        linked_answers.select do |a|
+          a[c.question_suffix.to_s] == c.parent_question_answer_key
+        end.present?
+      end.first
+    end
+
+    def placeholder_preselected_conditions
+      @placeholder_preselected_conditions ||= delegate_obj.placeholder_preselected_conditions
+    end
+
+    def preselected_condition_by_option(option)
+      placeholder_preselected_conditions.select do |condition|
+        condition.question_value == option.value
+      end.first
+    end
+
+    def depends_on
+      delegate_obj.question_key.to_s
+    end
+  end
+end

--- a/lib/qae_form_builder/options_with_preselected_conditions_question.rb
+++ b/lib/qae_form_builder/options_with_preselected_conditions_question.rb
@@ -2,18 +2,16 @@ class QAEFormBuilder
   class PlaceholderPreselectedCondition
     attr_accessor :question_key, 
                   :question_suffix, 
-                  :parent_question_answer_key,
-                  :answer_key,
-                  :question_value, 
+                  :parent_question_answer_key, 
+                  :answer_key, 
+                  :question_value,
                   :placeholder_text
 
-    def initialize(question_key, question_suffix, parent_question_answer_key, answer_key, question_value, placeholder_text)
+    def initialize(question_key, options={})
       @question_key = question_key
-      @question_suffix = question_suffix
-      @parent_question_answer_key = parent_question_answer_key
-      @answer_key = answer_key
-      @question_value = question_value
-      @placeholder_text = placeholder_text
+      options.each do |key, value|
+        instance_variable_set("@#{key}", value)
+      end
     end
   end
 
@@ -34,11 +32,9 @@ class QAEFormBuilder
       @q.main_header = text
     end
 
-    def placeholder_preselected_condition(q_key, q_suffix, p_answer_key, answer_key, q_value, placeholder_text)
+    def placeholder_preselected_condition(q_key, options={})
       @q.question_key = q_key
-      @q.placeholder_preselected_conditions << PlaceholderPreselectedCondition.new(
-        q_key, q_suffix, p_answer_key, answer_key, q_value, placeholder_text
-      )
+      @q.placeholder_preselected_conditions << PlaceholderPreselectedCondition.new(q_key, options)
     end
   end
 
@@ -50,11 +46,11 @@ class QAEFormBuilder
     end
 
     def preselected_condition
-      @preselected_condition ||= placeholder_preselected_conditions.select do |c|
+      @preselected_condition ||= placeholder_preselected_conditions.detect do |c|
         linked_answers.select do |a|
           a[c.question_suffix.to_s] == c.parent_question_answer_key
         end.present?
-      end.first
+      end
     end
 
     def placeholder_preselected_conditions
@@ -62,9 +58,9 @@ class QAEFormBuilder
     end
 
     def preselected_condition_by_option(option)
-      placeholder_preselected_conditions.select do |condition|
+      placeholder_preselected_conditions.detect do |condition|
         condition.question_value == option.value
-      end.first
+      end
     end
 
     def depends_on

--- a/lib/qae_form_builder/queen_award_holder_question.rb
+++ b/lib/qae_form_builder/queen_award_holder_question.rb
@@ -13,10 +13,19 @@ class QAEFormBuilder
     def category value, text
       @q.categories << QueenAwardHolderCategory.new(value, text)
     end
+
+    def children_options_depends_on str
+      @q.children_options_depends_on = str
+    end
+
+    def dependable_values values
+      @q.dependable_values = values.join(",")
+    end
   end
 
   class QueenAwardHolderQuestion < Question
     attr_reader :categories, :years
+    attr_accessor :children_options_depends_on, :dependable_values
 
     def after_create
       @categories = []

--- a/lib/qae_form_builder/question.rb
+++ b/lib/qae_form_builder/question.rb
@@ -1,3 +1,5 @@
+require "nokogiri"
+
 class QAEFormBuilder
 
   class QuestionDecorator < QAEDecorator

--- a/lib/qae_form_builder/subsidiaries_associates_plants_question.rb
+++ b/lib/qae_form_builder/subsidiaries_associates_plants_question.rb
@@ -6,7 +6,7 @@ class QAEFormBuilder
   class SubsidiariesAssociatesPlantsQuestion < Question
   end
 
-  class SubsidiariesAssociatesPlantsQuestionDecorator < MultiQuestionDecorator
+  class SubsidiariesAssociatesPlantsQuestionDecorator < QuestionDecorator
     def subsidiaries
       @subsidiaries ||= JSON.parse(answers[delegate_obj.key.to_s] || '[]').map do |answer| 
         JSON.parse(answer)

--- a/lib/qae_form_builder/subsidiaries_associates_plants_question.rb
+++ b/lib/qae_form_builder/subsidiaries_associates_plants_question.rb
@@ -6,4 +6,11 @@ class QAEFormBuilder
   class SubsidiariesAssociatesPlantsQuestion < Question
   end
 
+  class SubsidiariesAssociatesPlantsQuestionDecorator < MultiQuestionDecorator
+    def subsidiaries
+      @subsidiaries ||= JSON.parse(answers[delegate_obj.key.to_s] || '[]').map do |answer| 
+        JSON.parse(answer)
+      end
+    end
+  end
 end


### PR DESCRIPTION
"International Trade Award Form Draft 2" implementation

* Corrects of existing  InternationalTradeForm.

* Some corrects on QueenAwardHolderQuestion:
   1) Fixed UI / js issue with "Remove" button displaying
   2) Added some new attributes in app/views/qae_form/_queen_award_holder_question.html.slim:
       - data-dependable-values
       - data-parent-option-dependable-key
       - data-dependable-option-siffix
   They needs in in terms to realize C1 question requirements.
   In other words:

  If  "A6: QueenAwardHolderQuestion" has items in list for "Internation Trade" (3 or 6 years) - we need   to hide C1 controls and display specific header placeholder and off course change number for inputs for C1 related questions.

   Javascript part of this located in separated js class (app/assets/javascripts/frontend/custom_questions/options_with_preselected_conditions_question.js.coffee)

* Implemented "A13", based on A6 implementation
  By the way added ability to clean up new entry inputs on using "Add Another" js button.
  As by "add-example" template used in related js logic will be prefilled in case if there is at least of one existing entry.
  It's added to application.js file.
  Main idea is in optional "data-need-to-clear-example" data attribute for ".list-add" css selector

* Implemented javascript logic for "B 2.1"
  So it's new type of conditional questions, which should display N number of subquestion entries in list in dependency on selected amount (1,2,3 ... so on)
  For this reason I added optional "data-type" attribute with possible "in_clause_collection" value.

* Corrected displaying of "HeadOfTheBussiness" question block in F section.
  As now we need to use dropdown ("Mr/Mrs so on") with extra "Specify" field