### PR TITLE
Add form answer state machine.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'sinatra', require: false
 gem 'foreman'
 gem 'jquery.fileupload-rails'
 gem 'carrierwave'
+gem 'statesman'
 
 group :assets do
   gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,7 @@ GEM
       colorize
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    statesman (1.1.0)
     temple (0.6.10)
     thor (0.19.1)
     thread_safe (0.3.4)
@@ -394,6 +395,7 @@ DEPENDENCIES
   sinatra
   slackistrano
   slim-rails (~> 2.1)
+  statesman
   turnip
   uglifier (>= 1.3.0)
   wicked (~> 1.1)

--- a/app/models/form_answer_state_machine.rb
+++ b/app/models/form_answer_state_machine.rb
@@ -1,0 +1,76 @@
+class FormAnswerStateMachine
+
+  include Statesman::Machine
+
+  # Prior to End of September Deadline (phase I)
+  state :in_progress1, initial: true
+  state :submitted1
+  state :not_eligible1
+  state :withdrawn1
+  state :eligible1
+
+  # After September Deadline (phase II)
+  state :not_submitted2
+  state :not_eligible2
+  state :assessment_in_progress2
+  state :withdrawn2
+
+  # After Initial Assessment has been made (phase III)
+  state :recommended3
+  state :reserved3
+  state :not_recommended3
+  state :withdrawn3
+
+  # After Judges Panel (phase IV)
+  state :recommended4
+  state :reserved4
+  state :not_recommended4
+  state :withdrawn4
+
+  # After PM's Committee (phase V)
+  state :recommended5
+  state :reserved5
+  state :not_recommended5
+  state :withdrawn5
+
+  # After Queen's Decision
+  state :awarded6
+  state :not_awarded6
+  state :not_eligible6
+  state :not_submitted6
+
+  # let's enable all transitions for now
+  STATES = [
+    :in_progress1,
+    :submitted1,
+    :not_eligible1,
+    :withdrawn1,
+    :eligible1,
+    :not_submitted2,
+    :not_eligible2,
+    :assessment_in_progress2,
+    :withdrawn2,
+    :recommended3,
+    :reserved3,
+    :not_recommended3,
+    :withdrawn3,
+    :recommended4,
+    :reserved4,
+    :not_recommended4,
+    :withdrawn4,
+    :recommended5,
+    :reserved5,
+    :not_recommended5,
+    :withdrawn5,
+    :awarded6,
+    :not_awarded6,
+    :not_eligible6,
+    :not_submitted6
+  ]
+
+  STATES.each do |state1|
+    STATES.each do |state2|
+      transition from: state1, to: state2
+    end
+  end
+end

--- a/app/models/form_answer_transition.rb
+++ b/app/models/form_answer_transition.rb
@@ -1,0 +1,6 @@
+class FormAnswerTransition < ActiveRecord::Base
+  include Statesman::Adapters::ActiveRecordTransition
+
+  
+  belongs_to :form_answer, inverse_of: :form_answer_transitions
+end

--- a/config/initializers/statesman.rb
+++ b/config/initializers/statesman.rb
@@ -1,0 +1,3 @@
+Statesman.configure do
+  storage_adapter(Statesman::Adapters::ActiveRecord)
+end

--- a/db/migrate/20150218132412_add_state_to_form_answers.rb
+++ b/db/migrate/20150218132412_add_state_to_form_answers.rb
@@ -1,0 +1,5 @@
+class AddStateToFormAnswers < ActiveRecord::Migration
+  def change
+    add_column :form_answers, :state, :string, null: false, default: 'in_progress'
+  end
+end

--- a/db/migrate/20150218141547_create_form_answer_transitions.rb
+++ b/db/migrate/20150218141547_create_form_answer_transitions.rb
@@ -1,0 +1,14 @@
+class CreateFormAnswerTransitions < ActiveRecord::Migration
+  def change
+    create_table :form_answer_transitions do |t|
+      t.string :to_state, null: false
+      t.text :metadata, default: "{}"
+      t.integer :sort_key, null: false
+      t.integer :form_answer_id, null: false
+      t.timestamps
+    end
+
+    add_index :form_answer_transitions, :form_answer_id
+    add_index :form_answer_transitions, [:sort_key, :form_answer_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150217114106) do
+ActiveRecord::Schema.define(version: 20150218141547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,18 @@ ActiveRecord::Schema.define(version: 20150217114106) do
 
   add_index "form_answer_attachments", ["form_answer_id"], name: "index_form_answer_attachments_on_form_answer_id", using: :btree
 
+  create_table "form_answer_transitions", force: true do |t|
+    t.string   "to_state",                      null: false
+    t.text     "metadata",       default: "{}"
+    t.integer  "sort_key",                      null: false
+    t.integer  "form_answer_id",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "form_answer_transitions", ["form_answer_id"], name: "index_form_answer_transitions_on_form_answer_id", using: :btree
+  add_index "form_answer_transitions", ["sort_key", "form_answer_id"], name: "index_form_answer_transitions_on_sort_key_and_form_answer_id", unique: true, using: :btree
+
   create_table "form_answers", force: true do |t|
     t.integer  "user_id"
     t.datetime "created_at"
@@ -90,6 +102,7 @@ ActiveRecord::Schema.define(version: 20150217114106) do
     t.boolean  "submitted",       default: false
     t.float    "fill_progress"
     t.boolean  "importance_flag", default: false
+    t.string   "state",           default: "in_progress", null: false
   end
 
   add_index "form_answers", ["account_id"], name: "index_form_answers_on_account_id", using: :btree


### PR DESCRIPTION
Initial implementation of the application state machine.
All transitions are permitted for now as flow is not sorted yet.
Transition triggers need to be added in appropriate places.
States are grouped with indices which represents the phase (based on documentation).

My thinking is to use it for filtering purposes first and then add the transitions triggers to relevant places.
Transitions table stores all historical data.