### PR TITLE
QAE1015

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -151,8 +151,10 @@ class FormController < ApplicationController
   end
 
   def check_trade_count_limit
-    if current_account.has_trade_award?
-      redirect_to dashboard_url, flash: { alert: "You can not submit more than one trade form" }
+    if current_account.has_trade_award_in_this_year?
+      redirect_to dashboard_url, flash: {
+        alert: "You can not submit more than one trade form per year"
+      }
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -27,7 +27,9 @@ class Account < ActiveRecord::Base
     users.excluding(user).by_email
   end
 
-  def has_trade_award?
-    form_answers.where(award_type: 'trade').any?
+  def has_trade_award_in_this_year?
+    form_answers.for_year("20#{FormAnswer::CURRENT_AWARD_YEAR}".to_i)
+                .for_award_type(:trade)
+                .present?
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -28,8 +28,8 @@ class Account < ActiveRecord::Base
   end
 
   def has_trade_award_in_this_year?
-    form_answers.for_year("20#{FormAnswer::CURRENT_AWARD_YEAR}".to_i)
-                .for_award_type(:trade)
-                .present?
+    form_answers.for_year("20#{FormAnswer::CURRENT_AWARD_YEAR}".to_i).
+                 for_award_type(:trade).
+                 present?
   end
 end

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -11,6 +11,8 @@ class FormAnswer < ActiveRecord::Base
     :user_full_name
   ]
 
+  CURRENT_AWARD_YEAR = "14"
+
   POSSIBLE_AWARDS = [
     "trade", # International Trade Award
     "innovation", # Innovation Award
@@ -54,6 +56,7 @@ class FormAnswer < ActiveRecord::Base
 
   begin :scopes
     scope :for_award_type, -> (award_type) { where award_type: award_type }
+    scope :for_year, -> (year) { where current_award_year: year }
   end
 
   begin :callbacks

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -56,7 +56,7 @@ class FormAnswer < ActiveRecord::Base
 
   begin :scopes
     scope :for_award_type, -> (award_type) { where award_type: award_type }
-    scope :for_year, -> (year) { where current_award_year: year }
+    scope :for_year, -> (year) { where award_year: year }
   end
 
   begin :callbacks

--- a/app/views/shared/_application_awards_status.html.slim
+++ b/app/views/shared/_application_awards_status.html.slim
@@ -17,7 +17,7 @@
 /* action:    Download PDF of your application
 
 ul.applications-list
-  - unless current_account.has_trade_award?
+  - unless current_account.has_trade_award_in_this_year?
     li
       h3
         ' International Trade Award

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -3,17 +3,24 @@ require 'rails_helper'
 describe Account do
   let(:user) { FactoryGirl.build(:user) }
   let(:account) { user.account }
+  let(:current_year) { "20#{FormAnswer::CURRENT_AWARD_YEAR}".to_i}
+  let(:previous_year) { current_year - 1 }
 
-  describe '#has_trade_award?' do
+  describe '#has_trade_award_in_this_year?' do
     let!(:innovation_award) { create(:form_answer, :innovation, user: user) }
 
     it 'returns false when there is no trade award' do
-      expect(account).not_to have_trade_award
+      expect(account.reload.has_trade_award_in_this_year?).to be_falsey
     end
 
-    it 'returns true when there is a trade award' do
-      create(:form_answer, :trade, user: user)
-      expect(account).to have_trade_award
+    it 'returns false when there is trade award, but for previous year' do
+      create(:form_answer, :trade, user: user, current_award_year: previous_year)
+      expect(account.reload.has_trade_award_in_this_year?).to be_falsey
+    end
+
+    it 'returns true when there is a trade award for current year' do
+      create(:form_answer, :trade, user: user, current_award_year: current_year)
+      expect(account.reload.has_trade_award_in_this_year?).to be_truthy
     end
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,24 +1,24 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe Account do
   let(:user) { FactoryGirl.build(:user) }
   let(:account) { user.account }
-  let(:current_year) { "20#{FormAnswer::CURRENT_AWARD_YEAR}".to_i}
+  let(:current_year) { "20#{FormAnswer::CURRENT_AWARD_YEAR}".to_i }
   let(:previous_year) { current_year - 1 }
 
-  describe '#has_trade_award_in_this_year?' do
+  describe "#has_trade_award_in_this_year?" do
     let!(:innovation_award) { create(:form_answer, :innovation, user: user) }
 
-    it 'returns false when there is no trade award' do
+    it "returns false when there is no trade award" do
       expect(account.reload.has_trade_award_in_this_year?).to be_falsey
     end
 
-    it 'returns false when there is trade award, but for previous year' do
+    it "returns false when there is trade award, but for previous year" do
       create(:form_answer, :trade, user: user, current_award_year: previous_year)
       expect(account.reload.has_trade_award_in_this_year?).to be_falsey
     end
 
-    it 'returns true when there is a trade award for current year' do
+    it "returns true when there is a trade award for current year" do
       create(:form_answer, :trade, user: user, current_award_year: current_year)
       expect(account.reload.has_trade_award_in_this_year?).to be_truthy
     end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -14,12 +14,12 @@ describe Account do
     end
 
     it "returns false when there is trade award, but for previous year" do
-      create(:form_answer, :trade, user: user, current_award_year: previous_year)
+      create(:form_answer, :trade, user: user, award_year: previous_year)
       expect(account.reload.has_trade_award_in_this_year?).to be_falsey
     end
 
     it "returns true when there is a trade award for current year" do
-      create(:form_answer, :trade, user: user, current_award_year: current_year)
+      create(:form_answer, :trade, user: user, award_year: current_year)
       expect(account.reload.has_trade_award_in_this_year?).to be_truthy
     end
   end


### PR DESCRIPTION
[Podio Story](https://podio.com/bitzesty/app-qae/apps/stories/items/15)

```
Only submit 1 int trade form per year
```

* Added restriction by year
* Returned back CURRENT_AWARD_YEAR
  looks like we still need it in terms to know
  at the backend side current award year
  (for example in view conditions or before filters)