### PR TITLE
Extract assessor to separated relation

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -2,7 +2,7 @@ class Admin::AdminsController < Admin::UsersController
   def index
     params[:search] ||= AdminSearch::DEFAULT_SEARCH
     authorize Admin, :index?
-    @search = AdminSearch.new(Admin.admins).
+    @search = AdminSearch.new(Admin.all).
                          search(params[:search])
     @resources = @search.results.page(params[:page])
   end
@@ -14,7 +14,6 @@ class Admin::AdminsController < Admin::UsersController
 
   def create
     @resource = Admin.new(resource_params)
-    @resource.role = "admin"
     authorize @resource, :create?
 
     @resource.save
@@ -24,7 +23,7 @@ class Admin::AdminsController < Admin::UsersController
   private
 
   def find_resource
-    @resource = Admin.admins.find(params[:id])
+    @resource = Admin.find(params[:id])
   end
 
   def resource_params

--- a/app/controllers/admin/assessors_controller.rb
+++ b/app/controllers/admin/assessors_controller.rb
@@ -3,18 +3,18 @@ class Admin::AssessorsController < Admin::UsersController
     params[:search] ||= AssessorSearch::DEFAULT_SEARCH
     authorize :assessor, :index?
 
-    @search = AssessorSearch.new(Admin.assessors).
+    @search = AssessorSearch.new(Assessor.all).
                              search(params[:search])
     @resources = @search.results.page(params[:page])
   end
 
   def new
-    @resource = Admin.new
+    @resource = Assessor.new
     authorize @resource, :create?
   end
 
   def create
-    @resource = Admin.new(resource_params)
+    @resource = Assessor.new(resource_params)
     authorize @resource, :create?
 
     @resource.save
@@ -43,7 +43,7 @@ class Admin::AssessorsController < Admin::UsersController
   private
 
   def find_resource
-    @resource = Admin.assessors.find(params[:id])
+    @resource = Assessor.find(params[:id])
   end
 
   def resource_params

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -12,6 +12,7 @@ class Admin::CommentsController < Admin::BaseController
     @comment = form_answer.comments.build(create_params)
     authorize @comment, :create?
 
+    @comment.authorable = current_admin
     @comment.save
 
     respond_to do |format|
@@ -38,9 +39,7 @@ class Admin::CommentsController < Admin::BaseController
   helper_method :form_answer
 
   def create_params
-    attrs             = params.require(:comment).permit :body
-    attrs[:author_id] = current_admin.id
-    attrs
+    params.require(:comment).permit :body
   end
 
   def form_answer

--- a/app/controllers/assessor/base_controller.rb
+++ b/app/controllers/assessor/base_controller.rb
@@ -1,0 +1,17 @@
+class Assessor::BaseController < ApplicationController
+  include Pundit
+
+  layout "application-assessor"
+
+  before_action :authenticate_assessor!
+  after_action :verify_authorized
+
+  skip_before_action :authenticate_user!
+  skip_before_action :restrict_access_if_admin_in_read_only_mode!
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  def pundit_user
+    current_assessor
+  end
+end

--- a/app/controllers/assessor/dashboard_controller.rb
+++ b/app/controllers/assessor/dashboard_controller.rb
@@ -1,0 +1,5 @@
+class Assessor::DashboardController < Assessor::BaseController
+  def index
+    authorize :dashboard, :index?
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -23,7 +23,4 @@ class Admin < ActiveRecord::Base
                       prefix: true
                     }
                   }
-  def admin?
-    true # REMOVEME
-  end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -8,11 +8,7 @@ class Admin < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
 
-  enumerize :role, in: %w[admin lead_assessor assessor], predicates: true
-  validates :role, :first_name, :last_name, presence: true
-
-  scope :admins, -> { where(role: "admin") }
-  scope :assessors, -> { where(role: %w[lead_assessor assessor]) }
+  validates :first_name, :last_name, presence: true
 
   has_many :form_answer_attachments, as: :attachable
 
@@ -27,4 +23,7 @@ class Admin < ActiveRecord::Base
                       prefix: true
                     }
                   }
+  def admin?
+    true # REMOVEME
+  end
 end

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -1,0 +1,30 @@
+class Assessor < ActiveRecord::Base
+  include PgSearch
+  extend Enumerize
+
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+
+  validates :first_name, :last_name, :role, presence: true
+  has_many :form_answer_attachments, as: :attachable
+
+  enumerize :role, in: %w[lead regular]
+
+  pg_search_scope :basic_search,
+                against: [
+                  :first_name,
+                  :last_name,
+                  :email
+                ],
+                using: {
+                  tsearch: {
+                    prefix: true
+                  }
+                }
+
+  def self.roles_for_collection
+    [["Lead Assessor", "lead"], ["Basic Assessor", "regular"]]
+  end
+end

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -13,16 +13,16 @@ class Assessor < ActiveRecord::Base
   enumerize :role, in: %w[lead regular]
 
   pg_search_scope :basic_search,
-                against: [
-                  :first_name,
-                  :last_name,
-                  :email
-                ],
-                using: {
-                  tsearch: {
-                    prefix: true
+                  against: [
+                    :first_name,
+                    :last_name,
+                    :email
+                  ],
+                  using: {
+                    tsearch: {
+                      prefix: true
+                    }
                   }
-                }
 
   def self.roles_for_collection
     [["Lead Assessor", "lead"], ["Assessor", "regular"]]

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -5,7 +5,7 @@ class Assessor < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   validates :first_name, :last_name, :role, presence: true
   has_many :form_answer_attachments, as: :attachable
@@ -25,6 +25,6 @@ class Assessor < ActiveRecord::Base
                 }
 
   def self.roles_for_collection
-    [["Lead Assessor", "lead"], ["Basic Assessor", "regular"]]
+    [["Lead Assessor", "lead"], ["Assessor", "regular"]]
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,13 +1,12 @@
 class Comment < ActiveRecord::Base
   belongs_to :commentable, polymorphic: true
-  belongs_to :author, class_name: 'Admin', foreign_key: :author_id
+  belongs_to :authorable, polymorphic: true
 
-  validates :author_id, presence: true
   validates :body, presence: true
 
-  delegate :email, to: :author, prefix: :author
+  delegate :email, to: :authorable, prefix: :author
 
-  def author?(admin)
-    author_id == admin.id
+  def author?(subject)
+    authorable == subject
   end
 end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,5 +1,5 @@
 class AdminPolicy < UserPolicy
   def destroy?
-    admin.admin? && admin != record
+    admin? && subject != record
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,8 +1,8 @@
 class ApplicationPolicy
-  attr_reader :admin, :record
+  attr_reader :subject, :record
 
-  def initialize(admin, record)
-    @admin = admin
+  def initialize(subject, record)
+    @subject = subject
     @record = record
   end
 
@@ -32,5 +32,11 @@ class ApplicationPolicy
 
   def destroy?
     false
+  end
+
+  private
+
+  def admin?
+    subject.is_a?(Admin)
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -4,6 +4,6 @@ class CommentPolicy < ApplicationPolicy
   def update?; true; end
 
   def destroy?
-    record.author?(admin)
+    record.author?(subject)
   end
 end

--- a/app/policies/flag_policy.rb
+++ b/app/policies/flag_policy.rb
@@ -1,5 +1,5 @@
 class FlagPolicy < ApplicationPolicy
   def toggle?
-    admin.admin?
+    admin?
   end
 end

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -1,17 +1,17 @@
 class FormAnswerPolicy < ApplicationPolicy
   def index?
-    admin.admin?
+    admin?
   end
 
   def withdraw?
-    admin.admin?
+    admin?
   end
 
   def review?
-    admin.admin?
+    admin?
   end
 
   def show?
-    admin.admin?
+    admin?
   end
 end

--- a/app/policies/notification_policy.rb
+++ b/app/policies/notification_policy.rb
@@ -1,5 +1,5 @@
 class NotificationPolicy < ApplicationPolicy
   def create?
-    admin.admin?
+    admin?
   end
 end

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -1,5 +1,5 @@
 class ReportPolicy < ApplicationPolicy
   def show?
-    admin.admin?
+    admin?
   end
 end

--- a/app/policies/setting_policy.rb
+++ b/app/policies/setting_policy.rb
@@ -1,5 +1,5 @@
 class SettingPolicy < ApplicationPolicy
   def index?
-    admin.admin?
+    admin?
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,7 +1,7 @@
 class UserPolicy < ApplicationPolicy
   %w[index? update? create? destroy? show? new?].each do |method|
     define_method method do
-      admin && admin.admin?
+      admin?
     end
   end
 end

--- a/app/views/admin/assessors/_form.html.slim
+++ b/app/views/admin/assessors/_form.html.slim
@@ -10,7 +10,7 @@
       = f.input :role,
                 wrapper_html: { class: 'form-group' },
                 input_html: { class: 'form-control' },
-                collection: Admin.role.options.delete_if { |o| o.last == 'admin' }
+                collection: Assessor.roles_for_collection
 
   .row
     .col-sm-4

--- a/app/views/assessor/dashboard/index.html.slim
+++ b/app/views/assessor/dashboard/index.html.slim
@@ -1,0 +1,26 @@
+.row
+  .col-md-4
+    .show-sidebar
+      .well
+        h2
+          span.glyphicon.glyphicon-file
+          ' Resources
+        ul.list-unstyled.list-actions
+          - ["sample-application-form.pdf", "audit-certification-template.pdf", "lorem-ipsum-document.pdf"].each do |resources|
+            li
+              = link_to "#"
+                span.action-title
+                  span.glyphicon.glyphicon-file
+                  = resources
+              small.pull-right
+                = link_to "#"
+                  span.glyphicon.glyphicon-download-alt
+                  span.visible-lg.visible-md
+                    ' Download
+
+  .col-md-8
+    .panel-group#dashboard-details role="tablist" aria-multiselectable="true"
+      .panel.panel-default
+        .panel-heading#stage-one-application-heading role="tab"
+          h4.panel-title
+            a data-toggle="collapse" data-parent="#dashboard-details" href="#stage-one-application" aria-expanded="true" aria-controls="stage-one-application"

--- a/app/views/assessors/confirmations/new.html.slim
+++ b/app/views/assessors/confirmations/new.html.slim
@@ -1,0 +1,2 @@
+= render(template: "admins/confirmations/new")
+

--- a/app/views/assessors/mailer/confirmation_instructions.html.slim
+++ b/app/views/assessors/mailer/confirmation_instructions.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/mailer/confirmation_instructions")

--- a/app/views/assessors/mailer/reset_password_instructions.html.slim
+++ b/app/views/assessors/mailer/reset_password_instructions.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/mailer/reset_password_instructions")

--- a/app/views/assessors/mailer/unlock_instructions.html.slim
+++ b/app/views/assessors/mailer/unlock_instructions.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/mailer/unlock_instructions")

--- a/app/views/assessors/passwords/edit.html.slim
+++ b/app/views/assessors/passwords/edit.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/passwords/edit")

--- a/app/views/assessors/passwords/new.html.slim
+++ b/app/views/assessors/passwords/new.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/passwords/new")

--- a/app/views/assessors/registrations/edit.html.slim
+++ b/app/views/assessors/registrations/edit.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/registrations/edit")

--- a/app/views/assessors/registrations/new.html.slim
+++ b/app/views/assessors/registrations/new.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/registrations/new")

--- a/app/views/assessors/sessions/new.html.slim
+++ b/app/views/assessors/sessions/new.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/sessions/new")

--- a/app/views/assessors/unlocks/new.html.slim
+++ b/app/views/assessors/unlocks/new.html.slim
@@ -1,0 +1,1 @@
+= render(template: "admins/unlocks/new")

--- a/app/views/layouts/application-assessor.html.slim
+++ b/app/views/layouts/application-assessor.html.slim
@@ -1,0 +1,79 @@
+doctype html
+/[if lt IE 7]
+  <html class="ie ie6 lte9 lte8 lte7 no-js">
+/[if IE 7]
+  <html class="ie ie7 lte9 lte8 lte7 no-js">
+/[if IE 8]
+  <html class="ie ie8 lte9 lte8 no-js">
+/[if IE 9]
+  <html class="ie ie9 lte9 no-js">
+/[if gt IE 9]
+  <html class="ie no-js">
+| <!--[if !(IE)]<!-->
+html.no-js
+  | <!--<![endif]-->
+  head
+    title Queen's Awards for Enterprise - Assessor
+    meta content="minimal-ui, width=device-width, initial-scale=1.0, maximum-scale=1" name="viewport"
+    meta http-equiv="content-type" content="text/html; charset=UTF-8"
+
+    = stylesheet_link_tag "application-admin", media: "all"
+
+    = yield :section_meta_tags
+    = csrf_meta_tags
+
+    link href='http://fonts.googleapis.com/css?family=Lato:100,300,400,700,900' rel='stylesheet' type='text/css'
+
+    = yield(:head) if content_for?(:head)
+
+  body#assessor-layout class="#{controller_name}-page #{action_name}-page #{controller_name}-#{action_name}-page #{yield :page_class}"
+    #site-wrapper
+      #site-wrapper-margin
+        #site-header
+          nav.navbar role="navigation"
+            .container
+              .navbar-header
+                button.navbar-toggle.collapsed type="button" data-toggle="collapse" data-target="#nav-main-collapse"
+                  span.sr-only Toggle navigation
+                  span.icon-bar
+                  span.icon-bar
+                  span.icon-bar
+
+                = link_to "Queen's Awards for Enterprise - Assessor",
+                          assessor_root_path,
+                          class: 'navbar-brand'
+
+              .navbar-collapse.collapse#nav-main-collapse
+                ul.nav.navbar-nav role="navigation"
+                  li class=('active' if controller_name == 'dashboard')
+                    = link_to "Dashboard", assessor_dashboard_index_path
+
+                ul.nav.navbar-nav.navbar-right role="navigation"
+                  li.dropdown
+                    a.dropdown-toggle href="#" data-toggle="dropdown" role="button" aria-expanded="false"
+                      ' My account
+                      span.caret
+                    ul.dropdown-menu
+                      li
+                        = link_to "Log out",
+                                  destroy_assessor_session_path,
+                                  method: :delete
+
+
+        #main-container
+          .container
+            - unless notice.blank?
+              .alert-container
+                .alert.alert-success
+                  == notice
+            - unless alert.blank?
+              .alert-container
+                .alert.alert-danger
+                  == alert
+
+            = yield
+
+    footer#site-footer
+      .footer-container
+
+    = javascript_include_tag 'application-admin'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,11 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :assessor do
+    root to: "dashboard#index"
+    resources :dashboard, only: [:index]
+  end
+
   namespace :admin do
     root to: "dashboard#index"
     resources :dashboard, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     confirmations: 'devise/confirmations'
   }
 
+  devise_for :assessors
+
   get '/apply-for-queens-award-for-enterprise'          => "content_only#apply_for_queens_award_for_enterprise",          as: 'apply-for-queens-award-for-enterprise'
 
   get '/terms'                                          => "content_only#terms",                                          as: 'terms'

--- a/db/migrate/20150227124243_remove_role_from_admins.rb
+++ b/db/migrate/20150227124243_remove_role_from_admins.rb
@@ -1,0 +1,5 @@
+class RemoveRoleFromAdmins < ActiveRecord::Migration
+  def change
+    remove_column :admins, :role, :string
+  end
+end

--- a/db/migrate/20150227125140_devise_create_assessors.rb
+++ b/db/migrate/20150227125140_devise_create_assessors.rb
@@ -1,0 +1,42 @@
+class DeviseCreateAssessors < ActiveRecord::Migration
+  def change
+    create_table(:assessors) do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps
+    end
+
+    add_index :assessors, :email,                unique: true
+    add_index :assessors, :reset_password_token, unique: true
+    # add_index :assessors, :confirmation_token,   unique: true
+    # add_index :assessors, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20150227125226_add_first_last_name_to_assessors.rb
+++ b/db/migrate/20150227125226_add_first_last_name_to_assessors.rb
@@ -1,0 +1,6 @@
+class AddFirstLastNameToAssessors < ActiveRecord::Migration
+  def change
+    add_column :assessors, :first_name, :string
+    add_column :assessors, :last_name, :string
+  end
+end

--- a/db/migrate/20150227125421_add_role_to_assessors.rb
+++ b/db/migrate/20150227125421_add_role_to_assessors.rb
@@ -1,0 +1,5 @@
+class AddRoleToAssessors < ActiveRecord::Migration
+  def change
+    add_column :assessors, :role, :string, null: false
+  end
+end

--- a/db/migrate/20150227135432_add_confirmable_devise_fields_to_assessors.rb
+++ b/db/migrate/20150227135432_add_confirmable_devise_fields_to_assessors.rb
@@ -1,7 +1,7 @@
 class AddConfirmableDeviseFieldsToAssessors < ActiveRecord::Migration
   def change
     change_table(:assessors) do |t|
-      t.string   :confirmation_token
+      t.string :confirmation_token
       t.datetime :confirmed_at
       t.datetime :confirmation_sent_at
     end

--- a/db/migrate/20150227135432_add_confirmable_devise_fields_to_assessors.rb
+++ b/db/migrate/20150227135432_add_confirmable_devise_fields_to_assessors.rb
@@ -1,0 +1,11 @@
+class AddConfirmableDeviseFieldsToAssessors < ActiveRecord::Migration
+  def change
+    change_table(:assessors) do |t|
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+    end
+
+    add_index :assessors, :confirmation_token, unique: true
+  end
+end

--- a/db/migrate/20150227141437_add_polymorphic_association_to_comments.rb
+++ b/db/migrate/20150227141437_add_polymorphic_association_to_comments.rb
@@ -1,0 +1,7 @@
+class AddPolymorphicAssociationToComments < ActiveRecord::Migration
+  def change
+    add_column :comments, :authorable_type, :string, null: false, index: true
+    add_column :comments, :authorable_id, :integer, null: false, index: true
+    remove_column :comments, :author_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20150227135432) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
@@ -84,13 +85,13 @@ ActiveRecord::Schema.define(version: 20150227135432) do
   create_table "comments", force: :cascade do |t|
     t.integer  "commentable_id",   null: false
     t.string   "commentable_type", null: false
-    t.integer  "author_id",        null: false
     t.text     "body",             null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "authorable_type",  null: false
+    t.integer  "authorable_id",    null: false
   end
 
-  add_index "comments", ["author_id"], name: "index_comments_on_author_id", using: :btree
   add_index "comments", ["commentable_id"], name: "index_comments_on_commentable_id", using: :btree
   add_index "comments", ["commentable_type"], name: "index_comments_on_commentable_type", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150228145247) do
-
+ActiveRecord::Schema.define(version: 20150227135432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
@@ -41,7 +40,6 @@ ActiveRecord::Schema.define(version: 20150228145247) do
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "role"
     t.string   "first_name"
     t.string   "last_name"
   end
@@ -57,6 +55,31 @@ ActiveRecord::Schema.define(version: 20150228145247) do
   end
 
   add_index "audit_certificates", ["form_answer_id"], name: "index_audit_certificates_on_form_answer_id", using: :btree
+
+  create_table "assessors", force: :cascade do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "role",                                null: false
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+  end
+
+  add_index "assessors", ["confirmation_token"], name: "index_assessors_on_confirmation_token", unique: true, using: :btree
+  add_index "assessors", ["email"], name: "index_assessors_on_email", unique: true, using: :btree
+  add_index "assessors", ["reset_password_token"], name: "index_assessors_on_reset_password_token", unique: true, using: :btree
 
   create_table "comments", force: :cascade do |t|
     t.integer  "commentable_id",   null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,17 @@ unless Admin.exists?
     tap(&:confirm!)
 end
 
+unless Assessor.exists?
+  assessor_args = {
+    email: "assessor@example.com",
+    password: "assessor123",
+    role: "lead",
+    first_name: "First name",
+    last_name: "Last name"
+  }
+
+  Assessor.create!(assessor_args).tap(&:confirm!)
+end
 # unless User.exists?
 #   5.times do |i|
 #     User.create!(

--- a/spec/factories/assessors.rb
+++ b/spec/factories/assessors.rb
@@ -1,13 +1,14 @@
 FactoryGirl.define do
-  sequence :email do |n|
-    "foo#{n}@example.com"
-  end
-
-  factory :admin do
+  factory :assessor do
+    role "regular"
     first_name "John"
     last_name "Doe"
     password { "strongpass" }
     email
     confirmed_at { Time.zone.now }
+
+    trait :lead do
+      role "lead"
+    end
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :comment do
     body 'Comment body'
-    author{ create(:admin)}
+    authorable { create(:admin) }
   end
 end

--- a/spec/models/assessor_spec.rb
+++ b/spec/models/assessor_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe Assessor, :type => :model do
+RSpec.describe Assessor, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/assessor_spec.rb
+++ b/spec/models/assessor_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Assessor, :type => :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Decided to extract the Assessor as separated resource.
Arguments for:
- simplifying the structure - physical separation between admin and assessor views, arch. is more open for extensions and differences on behaviour between Asses/Admin, decreasing the amount of `if` in the views.
- following the REST principles a bit more
- no diverged logic for Admin/Assessor: assessor can be assigned to category, admin can't; assessor can be primary secondary or lead assessor in the same time; some logic seems to be unique for the assessor: way of retrieving the comments, form answers, assessment module among others, a lot logic seems to be unique for admins (notifications, dashboard, reports, list of assessors/admins)

against:
- duplicating some of the structures, especially at the beginning (BaseControllers, some views)
It can be overcome with using a bit of abstraction in the views, service objects in controllers, and assigning controllers to proper namespaces (looks like comments/form answer attachments can be moved to the global namespace as resources not strictly related with Admin namespace).
- some code smells: rendering the templates of admin resource in assessor resource (devise views)
- slightly longer development overhead as need to add functionality explicitly for Assessor.