### PR TITLE
Add global flags per applications.

### DIFF
--- a/app/assets/javascripts/admin/comments.js.coffee
+++ b/app/assets/javascripts/admin/comments.js.coffee
@@ -27,9 +27,13 @@ toggleFlagged = ->
     flagged = "comment-flagged"
     newComment = $(this).closest(".comment-actions")
     newComment.toggleClass(flagged)
-    newComment.closest(".comment-new").
-      find(".flag-comment-checkbox").
-      prop("checked", newComment.hasClass(flagged))
+    toggleGlobalFlag =(id, commentBox, flagged) ->
+      checkbox = commentBox.closest(".comments-container").find(id)
+      checkbox.prop("checked", commentBox.hasClass(flagged))
+      checkbox.closest("form").submit()
+
+    toggleGlobalFlag("#_assessor_importance_flag", newComment, flagged)
+    toggleGlobalFlag("#_admin_importance_flag", newComment, flagged)
 
     editComment = $(this).closest(".comment")
     editComment.toggleClass(flagged)
@@ -38,6 +42,7 @@ toggleFlagged = ->
       prop("checked", editComment.hasClass(flagged))
     form = editComment.find(".edit_comment")
     form.submit()
+
 deleteCommentAlert = ->
   $(document).on "click", ".link-delete-comment", (e) ->
     e.preventDefault()

--- a/app/controllers/admin/flags_controller.rb
+++ b/app/controllers/admin/flags_controller.rb
@@ -1,16 +1,3 @@
 class Admin::FlagsController < Admin::BaseController
-  def toggle
-    form_answer.toggle_importance_flag
-    authorize :flag, :toggle?
-    respond_to do |format|
-      format.html{ redirect_to admin_form_answer_path(form_answer) }
-      format.js{ render json: {}}
-    end
-  end
-
-  private
-
-  def form_answer
-    @form_answer ||= FormAnswer.find(params[:form_answer_id])
-  end
+  include ::FormAnswerFlagsMixin
 end

--- a/app/controllers/assessor/flags_controller.rb
+++ b/app/controllers/assessor/flags_controller.rb
@@ -1,0 +1,3 @@
+class Assessor::FlagsController < Assessor::BaseController
+  include ::FormAnswerFlagsMixin
+end

--- a/app/controllers/concerns/form_answer_flags_mixin.rb
+++ b/app/controllers/concerns/form_answer_flags_mixin.rb
@@ -1,0 +1,35 @@
+module FormAnswerFlagsMixin
+  def toggle
+    authorize :flag, :toggle?
+
+    if assessor_flag.present?
+      authorize form_answer, :toggle_assessor_flag?
+      form_answer.assessor_importance_flag = assessor_flag
+    end
+
+    if admin_flag.present?
+      authorize form_answer, :toggle_admin_flag?
+      form_answer.admin_importance_flag = admin_flag
+    end
+    form_answer.save
+
+    respond_to do |format|
+      format.html { redirect_to [namespace_name, form_answer] }
+      format.js { render json: {} }
+    end
+  end
+
+  private
+
+  def assessor_flag
+    params[:assessor_importance_flag]
+  end
+
+  def admin_flag
+    params[:admin_importance_flag]
+  end
+
+  def form_answer
+    @form_answer ||= FormAnswer.find(params[:form_answer_id])
+  end
+end

--- a/app/helpers/form_answer_helper.rb
+++ b/app/helpers/form_answer_helper.rb
@@ -1,12 +1,20 @@
 module FormAnswerHelper
-  def application_flags(comments)
+  def application_flags(fa)
+    comments = fa.comments
     content_tag :span, class: "icon-flagged" do
       content_tag :span, class: "flag-count" do
-        comments.select do |c|
+        c_size = comments.select do |c|
           c.main_for?(current_subject) && c.flagged?
-        end.size.to_s
+        end.size
+
+        c_size += 1 if importance_flag?(fa)
+        c_size.to_s
       end
     end
+  end
+
+  def importance_flag?(fa)
+    fa.public_send("#{current_subject.class.to_s.downcase}_importance_flag?")
   end
 
   def application_comments(comments)

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -137,14 +137,6 @@ class FormAnswer < ActiveRecord::Base
     super || {}
   end
 
-  def important?
-    importance_flag?
-  end
-
-  def toggle_importance_flag
-    update_attributes(importance_flag: !(self.importance_flag))
-  end
-
   def company_or_nominee_from_document
     comp_attr = promotion? ? 'organization_name' : 'company_name'
     name = document[comp_attr]

--- a/app/policies/flag_policy.rb
+++ b/app/policies/flag_policy.rb
@@ -1,5 +1,5 @@
 class FlagPolicy < ApplicationPolicy
   def toggle?
-    admin?
+    admin? || assessor?
   end
 end

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -27,4 +27,12 @@ class FormAnswerPolicy < ApplicationPolicy
   def assign_assessor?
     admin? || subject.lead?(record)
   end
+
+  def toggle_admin_flag?
+    admin?
+  end
+
+  def toggle_assessor_flag?
+    admin? || subject.lead_or_assigned?(record)
+  end
 end

--- a/app/views/admin/comments/_form.html.slim
+++ b/app/views/admin/comments/_form.html.slim
@@ -2,10 +2,8 @@
   label
     ' Add a comment
   = f.hidden_field :section
-  = f.check_box :flagged, class: "flag-comment-checkbox if-js-hide"
-
   = f.text_area :body, class: 'form-control', rows: 4
-  .comment-actions
+  .comment-actions class=("comment-flagged" if section_flagged)
     = link_to "#flag-comment", class: "link-flag-comment"
       span.unflagged-visible
         ' Mark as flagged

--- a/app/views/admin/form_answers/_section_admin_comments.html.slim
+++ b/app/views/admin/form_answers/_section_admin_comments.html.slim
@@ -6,7 +6,12 @@
   #section-admin-comments.section-admin-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="admin-comments-heading"
     .panel-body
       .comments-container data-comment-form=new_admin_form_answer_comment_path(@form_answer)
+        = form_tag [:toggle, namespace_name, @form_answer, :flags], remote: true, class: "critical-flag" do
+          - checked = "checked" if @form_answer.admin_importance_flag?
+          = check_box nil, :admin_importance_flag, { class: "flag-comment-checkbox if-js-hide", checked: checked}, 1, 0
+
+          = submit_tag :update, class: "if-js-hide"
         = form_for([:admin, @form_answer, Comment.new(commentable: @form_answer, section: "admin")]) do |f|
-          = render('admin/comments/form', f: f)
+          = render('admin/comments/form', f: f, section_flagged: @form_answer.admin_importance_flag?)
         .comment-insert
         = render(collection: @form_answer.comments.admin, partial: 'comment')

--- a/app/views/admin/form_answers/_section_critical_comments.html.slim
+++ b/app/views/admin/form_answers/_section_critical_comments.html.slim
@@ -6,7 +6,12 @@
   #section-critical-comments.section-critical-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="critical-comments-heading"
     .panel-body
       .comments-container.comment-assessor
+        = form_tag [:toggle, namespace_name, @form_answer, :flags], remote: true, class: "critical-flag" do
+          - checked = "checked" if @form_answer.assessor_importance_flag?
+          = check_box nil, :assessor_importance_flag, { class: "flag-comment-checkbox if-js-hide", checked: checked}, 1, 0
+
+          = submit_tag :update, class: "if-js-hide"
         = form_for([namespace_name, @form_answer, Comment.new(commentable: @form_answer, section: "critical")]) do |f|
-          = render("admin/comments/form", f: f)
+          = render("admin/comments/form", f: f, section_flagged: @form_answer.assessor_importance_flag?)
         .comment-insert
         = render(collection: @form_answer.comments.critical, partial: "admin/form_answers/comment")

--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -87,11 +87,11 @@
               tr
                 td.status-label class="#{obj.state_machine.categorized_state + '-label'}" alt="#{obj.state_machine.categorized_state.capitalize}" title="#{obj.state_machine.categorized_state.capitalize}"
                 td.td-title
-                  = link_to [:admin, obj], class: "ellipsis"
+                  = link_to [namespace_name, obj], class: "ellipsis"
                     - unless obj.company_or_nominee_name.nil?
                       = link_to obj.company_or_nominee_name, [:admin, obj]
                     - else
-                      = link_to [:admin, obj] do
+                      = link_to [namespace_name, obj] do
                         em
                           ' Not found
                 td
@@ -104,9 +104,9 @@
                 td
                   - app_comments = application_comments(obj.comments)
                   - if app_comments.present?
-                    = link_to [:admin, obj]
+                    = link_to [namespace_name, obj]
                       = app_comments
-                td = application_flags(obj.comments)
+                td = application_flags(obj)
                 td = link_to "View", review_admin_form_answer_path(obj), target: "_blank", class: "icon-view"
 
   .row

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -81,9 +81,9 @@
                 td
                   - app_comments = application_comments(obj.comments)
                   - if app_comments.present?
-                    = link_to [:assessor, obj]
+                    = link_to [namespace_name, obj]
                       = app_comments
-                td = application_flags(obj.comments)
+                td = application_flags(obj)
 
   .row
     .col-xs-12.text-right

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,9 @@ Rails.application.routes.draw do
         end
       end
       member { get(:review) }
+      resources :flags, only: [] do
+        collection { post :toggle }
+      end
     end
     resources :assessor_assignments, only: [:update]
     resources :assessment_submissions, only: [:create]
@@ -121,7 +124,7 @@ Rails.application.routes.draw do
       end
 
       resources :flags, only: [] do
-        collection{ get :toggle }
+        collection { post :toggle }
       end
 
       member do

--- a/db/migrate/20150318123932_add_flags_for_form_answers.rb
+++ b/db/migrate/20150318123932_add_flags_for_form_answers.rb
@@ -1,0 +1,6 @@
+class AddFlagsForFormAnswers < ActiveRecord::Migration
+  def change
+    add_column :form_answers, :admin_importance_flag, :boolean, default: false
+    add_column :form_answers, :assessor_importance_flag, :boolean, default: false
+  end
+end

--- a/db/migrate/20150318142055_remove_importance_flag_from_form_answers.rb
+++ b/db/migrate/20150318142055_remove_importance_flag_from_form_answers.rb
@@ -1,0 +1,5 @@
+class RemoveImportanceFlagFromFormAnswers < ActiveRecord::Migration
+  def change
+    remove_column :form_answers, :importance_flag, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150317130146) do
+ActiveRecord::Schema.define(version: 20150318142055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,13 +191,12 @@ ActiveRecord::Schema.define(version: 20150317130146) do
     t.datetime "updated_at"
     t.hstore   "document"
     t.string   "award_type"
-    t.boolean  "withdrawn",               default: false
+    t.boolean  "withdrawn",                default: false
     t.integer  "account_id"
     t.string   "urn"
-    t.boolean  "submitted",               default: false
+    t.boolean  "submitted",                default: false
     t.float    "fill_progress"
-    t.boolean  "importance_flag",         default: false
-    t.string   "state",                   default: "in_progress1", null: false
+    t.string   "state",                    default: "in_progress1", null: false
     t.string   "company_or_nominee_name"
     t.integer  "award_year"
     t.string   "nominee_full_name"
@@ -206,6 +205,8 @@ ActiveRecord::Schema.define(version: 20150317130146) do
     t.string   "sic_code"
     t.string   "nickname"
     t.hstore   "financial_data"
+    t.boolean  "admin_importance_flag",    default: false
+    t.boolean  "assessor_importance_flag", default: false
   end
 
   add_index "form_answers", ["account_id"], name: "index_form_answers_on_account_id", using: :btree


### PR DESCRIPTION
Admin/Assessor can set up the global flag on the comments form. It should be taken into consideration in flags number indicator on the applications list. Admin importance flag is set up by Admin on the Admin comments section, the Assessor importance flag is set up by Assessor on Critical comments.