### PR TITLE
[Security Headers] let's disable it on local

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  ensure_security_headers
+  unless (Rails.env.test? || Rails.env.development?)
+    ensure_security_headers
+  end
 
   before_filter :configure_permitted_parameters, if: :devise_controller?
 


### PR DESCRIPTION
I suppose that we can disable gem 'secure_headers'.
We do not need it on dev env.
for Dev env as it adds a lot of warning in chrome /firebug consoles and also increases time on loading pages for dev.
I also thinking that it makes angry frontend guys when they try to debug smth in chrome console.
