### PR TITLE
Admin attach doc restyle

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -22,10 +22,19 @@ ready = ->
       errors += error
 
     form.find(".errors-holder").text(errors)
-  $('#new_form_answer_attachment').fileupload
+  $("#new_form_answer_attachment").fileupload
     success: (result, textStatus, jqXHR)->
-      $('.document-list .p-empty').remove()
-      $('.document-list ul').append(result)
+      $("#new_form_answer_attachment").addClass("uploaded-file")
+      $("#new_form_answer_attachment ul").append(result)
+
+  # Show/hide the attach document form
+  $(".js-attachment-link").on "click", (e) ->
+    e.preventDefault()
+    $(this).closest(".sidebar-section").addClass("show-attachment-form")
+
+  $(".js-attachment-form .btn-cancel").on "click", (e) ->
+    e.preventDefault()
+    $(this).closest(".sidebar-section").removeClass("show-attachment-form")
 
   formClass = '.edit_form_answer_attachment'
 

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -33,7 +33,8 @@ ready = ->
   # Move the attach document button
   $(".attachment-link").removeClass("if-js-hide")
   $(".attachment-link").addClass("btn btn-default btn-block btn-attachment")
-  $(".attachment-link").prepend("<span class='glyphicon glyphicon-paperclip'></span> Attach Document")
+  $(".attachment-link").prepend("Attach Document")
+  $(".attachment-link").prepend("<span class='glyphicon glyphicon-paperclip'></span>")
   $(".attachment-link").prependTo("#new_form_answer_attachment")
 
   $(".js-attachment-form .btn-cancel").on "click", (e) ->

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -27,14 +27,13 @@ ready = ->
       $("#new_form_answer_attachment").addClass("uploaded-file")
       $("#new_form_answer_attachment ul").append(result)
 
-  # Show/hide the attach document form
-  $(".js-attachment-link").on "click", (e) ->
-    e.preventDefault()
-    $(this).closest(".sidebar-section").addClass("show-attachment-form")
+      # Show/hide the attach document form
+      $("#new_form_answer_attachment").closest(".sidebar-section").addClass("show-attachment-form")
 
   $(".js-attachment-form .btn-cancel").on "click", (e) ->
     e.preventDefault()
     $(this).closest(".sidebar-section").removeClass("show-attachment-form")
+    $("#new_form_answer_attachment").removeClass("uploaded-file")
 
   formClass = '.edit_form_answer_attachment'
 

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -30,6 +30,12 @@ ready = ->
       # Show/hide the attach document form
       $("#new_form_answer_attachment").closest(".sidebar-section").addClass("show-attachment-form")
 
+  # Move the attach document button
+  $(".attachment-link").removeClass("if-js-hide")
+  $(".attachment-link").addClass("btn btn-default btn-block btn-attachment")
+  $(".attachment-link").prepend("<span class='glyphicon glyphicon-paperclip'></span> Attach Document")
+  $(".attachment-link").prependTo("#new_form_answer_attachment")
+
   $(".js-attachment-form .btn-cancel").on "click", (e) ->
     e.preventDefault()
     $(this).closest(".sidebar-section").removeClass("show-attachment-form")

--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -298,9 +298,10 @@ table .ellipsis {
     input[type="file"] {
       position: absolute;
       top: 0;
-      left: 0;
       right: 0;
       bottom: 0;
+      left: 0;
+      width: 100%;
       cursor: pointer;
       -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
       filter: alpha(opacity=0);

--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -681,7 +681,8 @@ table .ellipsis {
     }
 
     h1,
-    h2 {
+    h2,
+    h3 {
       &:first-child {
         margin-top: 0;
       }
@@ -726,6 +727,16 @@ table .ellipsis {
       }
     }
 
+    h3 {
+      margin-bottom: 20px;
+      font-size: 16px;
+      font-weight: bold;
+
+      @include screen-md-max {
+        font-size: 15px;
+      }
+    }
+
     .well {
       margin: 0;
       padding: 20px 0;
@@ -742,6 +753,18 @@ table .ellipsis {
       &:last-child {
         padding-bottom: 0;
         border-bottom: none;
+      }
+
+      .well {
+        padding: 19px;
+        border: 1px solid $grey;
+        border-radius: 4px;
+      }
+    }
+
+    .form-actions {
+      .btn:first-child {
+        margin-right: 10px;
       }
     }
 

--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -763,8 +763,8 @@ table .ellipsis {
     }
 
     .form-actions {
-      .btn:first-child {
-        margin-right: 10px;
+      .btn:last-child {
+        margin-right: 0;
       }
     }
 

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -356,6 +356,14 @@
   }
 }
 
+.js-attachment-form .form-group {
+  margin-top: 15px;
+
+  .form-control {
+    display: block;
+  }
+}
+
 .uploaded-file .btn-attachment {
   display: none;
 }

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -341,3 +341,21 @@
     display: block;
   }
 }
+
+.js .js-attachment-form {
+  display: none;
+}
+
+.show-attachment-form {
+  .js-attachment-link {
+    display: none;
+  }
+
+  .js-attachment-form {
+    display: block;
+  }
+}
+
+.uploaded-file .btn-attachment {
+  display: none;
+}

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -347,7 +347,7 @@
 }
 
 .show-attachment-form {
-  .js-attachment-link {
+  .attachment-link {
     display: none;
   }
 

--- a/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
+++ b/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
@@ -1,10 +1,12 @@
 li.form_answer_attachment
-  = link_to [:admin, form_answer_attachment.form_answer, form_answer_attachment], target: '_blank'
+  = link_to [:admin, form_answer_attachment.form_answer, form_answer_attachment],
+            target: "_blank",
+            class: "ellipsis"
     span.action-title
       span.glyphicon.glyphicon-file
       = form_answer_attachment.filename
-  small.pull-right
-    - if policy(form_answer_attachment).destroy?
+  - if policy(form_answer_attachment).destroy?
+    small.pull-right
       = form_for(form_answer_attachment, url: admin_form_answer_form_answer_attachment_path(form_answer_attachment.form_answer, form_answer_attachment), html: {method: :delete, style: 'display:inline-block;'}) do |f|
         = f.submit 'Remove', class: 'if-js-hide'
 

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -60,4 +60,4 @@
 
         .form-actions.text-right
           = link_to "Cancel", "#", class: "btn btn-default btn-cancel"
-          = form.submit "Attach", class: "btn btn-primary btn-submit"
+          = form.submit "Attach", class: "btn btn-primary btn-submit spec-submit"

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -39,24 +39,25 @@
           = render(partial: "admin/form_answer_attachments/form_answer_attachment", collection: @form_answer.form_answer_attachments)
       br
 
-    = link_to "#", class: "btn btn-default btn-block js-attachment-link if-no-js-hide"
+    = form_for [namespace_name, @form_answer, @form_answer.form_answer_attachments.build], html: { multipart: true} do |form|
+
+      span.btn.btn-default.btn-block.btn-attachment.attachment-link.if-no-js-hide
         span.glyphicon.glyphicon-paperclip
         ' Attach Document
+        = form.file_field :file
 
-    = form_for [namespace_name, @form_answer, @form_answer.form_answer_attachments.build], html: { multipart: true} do |form|
       .well.js-attachment-form
         h3 Attach Document
 
         ul.list-unstyled
-        span.btn.btn-default.btn-block.btn-attachment
-          ' + Upload Document
+        .if-js-hide
           = form.file_field :file
 
         .form-group
           label.form-label Document title
           input.form-control type="text"
 
-        - if current_user.role == "account_admin"
+        / Only admin can see/set this
           .checkbox
             label
               input type="checkbox"

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -56,10 +56,12 @@
           label.form-label Document title
           input.form-control type="text"
 
-        .checkbox
-          label
-            input type="checkbox"
-            ' Only admin can view this document
+        - if current_user.role == "account_admin"
+          .checkbox
+            label
+              input type="checkbox"
+              ' Only admin can view this document
+
         .form-actions.text-right
           = link_to "Cancel", "#", class: "btn btn-default btn-cancel"
           = form.submit "Attach", class: "btn btn-primary btn-submit"

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -38,10 +38,24 @@
         - if @form_answer.form_answer_attachments.any?
           = render(partial: "admin/form_answer_attachments/form_answer_attachment", collection: @form_answer.form_answer_attachments)
       br
+
+    = link_to "#", class: "btn btn-default btn-block js-attachment-link if-no-js-hide"
+        span.glyphicon.glyphicon-paperclip
+        ' Attach Document
+
     = form_for [namespace_name, @form_answer, @form_answer.form_answer_attachments.build], html: { multipart: true} do |form|
-      span.btn.btn-default.btn-attachment
-        span.attachment-text
-          span.glyphicon.glyphicon-paperclip
-          ' Attach Document
-        = form.file_field :file
-      = form.submit 'Attach Document', class: 'if-js-hide'
+      .well.js-attachment-form
+        h3 Attach Document
+
+        ul.list-unstyled
+        span.btn.btn-default.btn-block.btn-attachment
+          ' + Upload Document
+          = form.file_field :file
+
+        .checkbox
+          label
+            input type="checkbox"
+            ' Only admin can view this document
+        .form-actions.text-right
+          = link_to "Cancel", "#", class: "btn btn-default btn-cancel"
+          = form.submit "Attach", class: "btn btn-primary btn-submit"

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -60,4 +60,4 @@
 
         .form-actions.text-right
           = link_to "Cancel", "#", class: "btn btn-default btn-cancel"
-          = form.submit "Attach", class: "btn btn-primary btn-submit spec-submit"
+          = form.submit "Attach", class: "btn btn-primary btn-submit"

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -52,6 +52,10 @@
           ' + Upload Document
           = form.file_field :file
 
+        .form-group
+          label.form-label Document title
+          input.form-control type="text"
+
         .checkbox
           label
             input type="checkbox"

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -41,16 +41,11 @@
 
     = form_for [namespace_name, @form_answer, @form_answer.form_answer_attachments.build], html: { multipart: true} do |form|
 
-      span.btn.btn-default.btn-block.btn-attachment.attachment-link.if-no-js-hide
-        span.glyphicon.glyphicon-paperclip
-        ' Attach Document
-        = form.file_field :file
-
       .well.js-attachment-form
         h3 Attach Document
 
         ul.list-unstyled
-        .if-js-hide
+        .if-js-hide.attachment-link
           = form.file_field :file
 
         .form-group

--- a/spec/features/admin/form_answers/attachments_management_spec.rb
+++ b/spec/features/admin/form_answers/attachments_management_spec.rb
@@ -17,7 +17,7 @@ describe 'Form answer attachments management', %q{
   it "adds the attachment" do
     within "#new_form_answer_attachment" do
       attach_file "form_answer_attachment_file", "#{Rails.root}/spec/fixtures/cat.jpg"
-      find(".spec-submit").click
+      find("input[type='submit']").click
     end
     expect(page).to have_selector(".form_answer_attachment", count: 1)
   end

--- a/spec/features/admin/form_answers/attachments_management_spec.rb
+++ b/spec/features/admin/form_answers/attachments_management_spec.rb
@@ -15,8 +15,10 @@ describe 'Form answer attachments management', %q{
   end
 
   it "adds the attachment" do
-    attach_file "form_answer_attachment_file", "#{Rails.root}/spec/fixtures/cat.jpg"
-    click_button "Attach"
+    within "#new_form_answer_attachment" do 
+      attach_file "form_answer_attachment_file", "#{Rails.root}/spec/fixtures/cat.jpg"
+      find(".spec-submit").click
+    end
     expect(page).to have_selector(".form_answer_attachment", count: 1)
   end
 

--- a/spec/features/admin/form_answers/attachments_management_spec.rb
+++ b/spec/features/admin/form_answers/attachments_management_spec.rb
@@ -15,7 +15,7 @@ describe 'Form answer attachments management', %q{
   end
 
   it "adds the attachment" do
-    within "#new_form_answer_attachment" do 
+    within "#new_form_answer_attachment" do
       attach_file "form_answer_attachment_file", "#{Rails.root}/spec/fixtures/cat.jpg"
       find(".spec-submit").click
     end

--- a/spec/features/admin/form_answers/attachments_management_spec.rb
+++ b/spec/features/admin/form_answers/attachments_management_spec.rb
@@ -14,10 +14,10 @@ describe 'Form answer attachments management', %q{
     visit admin_form_answer_path(form_answer)
   end
 
-  it 'adds the attachment' do
-    attach_file 'form_answer_attachment_file', "#{Rails.root}/spec/fixtures/cat.jpg"
-    click_button 'Attach Document'
-    expect(page).to have_selector('.form_answer_attachment', count: 1)
+  it "adds the attachment" do
+    attach_file "form_answer_attachment_file", "#{Rails.root}/spec/fixtures/cat.jpg"
+    click_button "Attach"
+    expect(page).to have_selector(".form_answer_attachment", count: 1)
   end
 
   context "with existing attachment" do


### PR DESCRIPTION
Somethings aren't working correctly/not implemented since this restyle

- Firstly the title and the admin only checkbox are placeholder
- the admin only checkbox is for admins only
- the upload button uploads a file but if you did not click the final attach and refresh the file is uploaded anyways
- same with the cancel button, currently it just closes the pop up, it does not remove the uploaded file