### PR TITLE
Don't remove the withdrawn apps from scope.

### DIFF
--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -65,8 +65,7 @@ class Assessor < ActiveRecord::Base
     out.where("
       (award_type in (?) OR
       (assessor_assignments.position in (?) AND assessor_assignments.assessor_id = ?))
-      AND state NOT IN (?)
-    ", c, [0, 1], id, "withdrawn")
+    ", c, [0, 1], id)
   end
 
   def full_name


### PR DESCRIPTION
Apps with state withdrawn should be considered as normal apps, without excluding anything. Actually it breaks app resource when withdrawn state set up.