### PR TITLE
Review audit certificate

### DIFF
--- a/app/assets/javascripts/admin/financial_data.js.coffee
+++ b/app/assets/javascripts/admin/financial_data.js.coffee
@@ -1,6 +1,6 @@
 jQuery ->
-  if ($ "#financial-summary form").length
-    form = ($ "#financial-summary form")
+  if ($ "#financial-summary form:not(#new_review_audit_certificate)").length
+    form = ($ "#financial-summary form:not(#new_review_audit_certificate)")
     timer = null
     benchmarksTable = ($ "#financial-benchmarks")
     overallBenchmarksTable = ($ "#overall-financial-benchmarks")

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -6,6 +6,18 @@ ready = ->
   bindRags("#section-appraisal-form-moderated .edit_assessor_assignment")
   bindRags("#section-case-summary .edit_assessor_assignment")
 
+  $("#new_review_audit_certificate").on "ajax:success", (e, data, status, xhr) ->
+    $(this).find(".form-group").removeClass("form-edit")
+    $(this).find(".form-edit-link").remove()
+    area = $(".audit-cert-description textarea")
+    unless area.val()
+      $(this).find(".form-value").html($("<p>No change necessary</p>"))
+    else
+      div = "<div><label>Changes made</label><p class='control-label'>#{area.val()}</p></div>"
+      $(this).find(".form-value").html(div)
+  $("#new_review_audit_certificate").on "click", ".save-review-audit", (e) ->
+    e.preventDefault()
+    $("#new_review_audit_certificate").submit()
   $(".section-applicant-status").on "click", "a", (e) ->
     e.preventDefault()
     state = $(this).data("state")
@@ -93,19 +105,12 @@ ready = ->
     if area.length
       formGroup.find(".form-value p").text(area.val())
       $(formGroup).closest("form").submit()
-
-  # Show the audit certificates `changes made` textarea
-  # TODO temp
-  $("[name='radio-audit-cert']").on "change", ->
-    $(".audit-cert-changed-val p").text($(".audit-cert-description textarea").val())
-
-    if $("#radio-audit-cert2:checked").size() > 0
-      $(this).closest(".panel-body").addClass("audit-cert-changes-made")
-      $(this).closest(".panel-body").removeClass("audit-cert-no-change")
+  $("#new_review_audit_certificate input[type='radio']").on "change", ->
+    area = $(".audit-cert-description")
+    if $(this).val() == "confirmed_changes"
+      area.show()
     else
-      $(this).closest(".panel-body").removeClass("audit-cert-changes-made")
-      $(this).closest(".panel-body").addClass("audit-cert-no-change")
-
+      area.hide()
   $(document).on "submit", "#new_assessor_assignment_collection", (e) ->
     form = $(this)
     ids = ""

--- a/app/controllers/admin/review_audit_certificates_controller.rb
+++ b/app/controllers/admin/review_audit_certificates_controller.rb
@@ -1,0 +1,3 @@
+class Admin::ReviewAuditCertificatesController < Admin::BaseController
+  include ReviewAuditCertificatesMixin
+end

--- a/app/controllers/assessor/review_audit_certificates_controller.rb
+++ b/app/controllers/assessor/review_audit_certificates_controller.rb
@@ -1,0 +1,3 @@
+class Assessor::ReviewAuditCertificatesController < Assessor::BaseController
+  include ReviewAuditCertificatesMixin
+end

--- a/app/controllers/concerns/review_audit_certificates_mixin.rb
+++ b/app/controllers/concerns/review_audit_certificates_mixin.rb
@@ -1,0 +1,27 @@
+module ReviewAuditCertificatesMixin
+  def create
+    @review_audit_certificate = ReviewAuditCertificate.new(create_params)
+    @review_audit_certificate.subject = current_subject
+
+    authorize @review_audit_certificate, :create?
+
+    @review_audit_certificate.save
+
+    respond_to do |format|
+      format.js { render(nothing: true) }
+      format.html do
+        redirect_to [namespace_name, @review_audit_certificate.form_answer]
+      end
+    end
+  end
+
+  private
+
+  def create_params
+    params.require(:review_audit_certificate).permit(
+      :changes_description,
+      :form_answer_id,
+      :status
+    )
+  end
+end

--- a/app/models/audit_certificate.rb
+++ b/app/models/audit_certificate.rb
@@ -3,6 +3,7 @@ class AuditCertificate < ActiveRecord::Base
 
   begin :associations
     belongs_to :form_answer
+    belongs_to :reviewable, polymorphic: true
   end
 
   begin :validations
@@ -12,5 +13,19 @@ class AuditCertificate < ActiveRecord::Base
                            file_size: {
                              maximum: 25.megabytes.to_i
                            }
+    validates :reviewable_type,
+              :reviewable_id,
+              :reviewed_at,
+              presence: true,
+              if: :reviewed?
+  end
+
+  enum status: {
+    no_changes_necessary: 0,
+    confirmed_changes: 1
+  }
+
+  def reviewed?
+    reviewed_at.present?
   end
 end

--- a/app/models/review_audit_certificate.rb
+++ b/app/models/review_audit_certificate.rb
@@ -1,0 +1,31 @@
+class ReviewAuditCertificate
+  include Virtus.model
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+  include ActiveModel::Validations
+
+  attribute :changes_description, String
+  attribute :status, String
+  attribute :form_answer_id, Integer
+
+  attr_accessor :subject
+
+  def persisted?
+    false
+  end
+
+  def save
+    audit = form_answer.audit_certificate
+    return false if audit.blank? || audit.try(:reviewed?)
+
+    audit.reviewable = subject
+    audit.changes_description = changes_description
+    audit.reviewed_at = DateTime.now
+    audit.status = status
+    audit.save
+  end
+
+  def form_answer
+    @form_answer ||= FormAnswer.find(form_answer_id)
+  end
+end

--- a/app/policies/review_audit_certificate_policy.rb
+++ b/app/policies/review_audit_certificate_policy.rb
@@ -1,0 +1,6 @@
+class ReviewAuditCertificatePolicy < ApplicationPolicy
+  def create?
+    fa = record.form_answer
+    admin? || subject.lead?(fa) || subject.primary?(fa)
+  end
+end

--- a/app/views/admin/form_answers/_section_financial_summary.html.slim
+++ b/app/views/admin/form_answers/_section_financial_summary.html.slim
@@ -9,41 +9,49 @@
             small
               ' Updated by
               = @form_answer.financial_summary_updated_by
-              ' - 
+              ' -
               = l @form_answer.financial_summary_updated_at.to_datetime, format: :date_at_time
 
     #financial-summary.section-financial-summary.panel-collapse.collapse role="tabpanel" aria-labelledby="financial-summary-heading"
       .panel-body
-        / TODO placeholder
-        .form-group
-          label.form-label Audit Certificate
-          p = link_to "View Audit Certificate", "#", target: "_blank"
-          .form-value
-            p.audit-cert-nil-val Not confirmed yet.
-            p.audit-cert-no-change-val No change necessary
-            .audit-cert-changed-val
-              label.control-label Changes made
-              p Test
-          .input.form-group.form-fields
-            .radio
-              label
-                input type="radio" name="radio-audit-cert" id="radio-audit-cert1" value="no-change"
-                ' No change necessary
-            .radio
-              label
-                input type="radio" name="radio-audit-cert" id="radio-audit-cert2" value="confirm-changes"
-                ' Confirmed changes
+        = simple_form_for([namespace_name, ReviewAuditCertificate.new(form_answer_id: resource.id)], remote: true, authenticity_token: true) do |f|
+          = f.input :form_answer_id, as: :hidden
 
-          .audit-cert-description
+          .form-group
+            label.form-label Audit Certificate
+            p = link_to "View Audit Certificate", "#", target: "_blank"
+            .form-value
+              - unless resource.audit_certificate.try(:reviewed?)
+                p.audit-cert-nil-val Not confirmed yet.
+              - else
+                - if resource.audit_certificate.try(:no_changes_necessary?)
+                  p No change necessary
+                - elsif resource.audit_certificate.try(:confirmed_changes?)
+                  .audit-cert-changed-val
+                    label.control-label Changes made
+                    p= resource.audit_certificate.changes_description
+
             .input.form-group.form-fields
-              label.control-label Changes made
-              textarea.form-control rows="5"
-              .clear
+              .radio
+                label
+                  input type="radio" name="review_audit_certificate[status]" id="radio-audit-cert1" value="no_changes_necessary"
+                  ' No change necessary
+              .radio
+                label
+                  input type="radio" name="review_audit_certificate[status]" id="radio-audit-cert2" value="confirmed_changes"
+                  ' Confirmed changes
+              = f.submit "Save", class: "if-js-hide"
 
-          = link_to "#", class: "form-edit-link pull-right"
-            span.glyphicon.glyphicon-pencil
-            ' Edit
-          = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
-          .clear
+            .audit-cert-description
+              .input.form-group.form-fields
+                = f.input :changes_description, as: :text, input_html: { rows: 5, class: "form-control" }, label: false
+                .clear
+            - if !resource.audit_certificate.try(:reviewed?)
+              = link_to "#", class: "form-edit-link pull-right"
+                span.glyphicon.glyphicon-pencil
+                ' Edit
+              = link_to "Save", "#", class: "btn btn-primary save-review-audit pull-right"
+
+            .clear
 
         = render 'admin/form_answers/financial_summary/list', financial_pointer: financial_pointer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       resources :form_answer_state_transitions, only: [:create]
       resources :comments
       resources :form_answer_attachments, only: [:create, :show, :destroy]
+      resources :review_audit_certificates, only: [:create]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit
@@ -130,6 +131,7 @@ Rails.application.routes.draw do
     resources :assessors
     resources :admins
     resources :reports, only: [:show]
+    resources :review_audit_certificates, only: [:create]
     resources :form_answers do
       resources :form_answer_state_transitions, only: [:create]
       resources :comments

--- a/db/migrate/20150327122904_add_reviewing_attributes_for_audit_certificates.rb
+++ b/db/migrate/20150327122904_add_reviewing_attributes_for_audit_certificates.rb
@@ -1,0 +1,9 @@
+class AddReviewingAttributesForAuditCertificates < ActiveRecord::Migration
+  def change
+    add_column :audit_certificates, :changes_description, :text
+    add_column :audit_certificates, :reviewable_type, :string
+    add_column :audit_certificates, :reviewable_id, :integer
+    add_column :audit_certificates, :reviewed_at, :datetime
+    add_column :audit_certificates, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150326221536) do
+ActiveRecord::Schema.define(version: 20150327122904) do
+
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,10 +94,15 @@ ActiveRecord::Schema.define(version: 20150326221536) do
   add_index "assessors", ["reset_password_token"], name: "index_assessors_on_reset_password_token", unique: true, using: :btree
 
   create_table "audit_certificates", force: :cascade do |t|
-    t.integer  "form_answer_id"
+    t.integer  "form_answer_id",      null: false
     t.string   "attachment"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.text     "changes_description"
+    t.string   "reviewable_type"
+    t.integer  "reviewable_id"
+    t.datetime "reviewed_at"
+    t.integer  "status"
   end
 
   add_index "audit_certificates", ["form_answer_id"], name: "index_audit_certificates_on_form_answer_id", using: :btree


### PR DESCRIPTION
Reviewing the certificate functionality.

Re: `+    t.integer  "form_answer_id",      null: false`

I see:

```
/home/leszek/Desktop/www/qae/db/migrate/20150228145247_create_audit_certificates.rb:
    1  class CreateAuditCertificates < ActiveRecord::Migration
    2    def change
    3:     create_table :audit_certificates do |t|
    4        t.references :form_answer, null: false, index: true
```

so seems that change above is fine.