### PR TITLE
Fix issue with form multiedit

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -183,7 +183,6 @@ bindRags =(klass) ->
         select = $(this).parents("select")
         select.val(ragClicked)
         section = select.data("updated-section")
-        console.log(section)
         if section
           input = form.find("input[name='updated_section']")
           if input.length

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -177,9 +177,17 @@ bindRags =(klass) ->
     ragClicked = $(this).closest("li").attr("class")
     ragClicked = ragClicked.replace("rag-", "")
     ragSection = $(this).parents(".form-group")
+    form       = $(klass)
     ragSection.find("option").each ->
       if $(this).val() == ragClicked
-        $(this).parents("select").val(ragClicked)
-    $(klass).submit()
+        select = $(this).parents("select")
+        select.val(ragClicked)
+        section = select.data("updated-section")
+        console.log(section)
+        if section
+          input = form.find("input[name='updated_section']")
+          if input.length
+            input.val(section)
+    form.submit()
 
 $(document).ready(ready)

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -100,14 +100,21 @@ ready = ->
     $(this).find("input:submit").remove()
 
   $(document).on "click", ".form-save-link", (e) ->
+    link = $(this)
     e.preventDefault()
-    formGroup = $(this).closest(".form-group")
+    formGroup = link.closest(".form-group")
+    form = formGroup.closest("form")
     area = formGroup.find("textarea:visible")
     formGroup.removeClass("form-edit")
 
     if area.length
       formGroup.find(".form-value p").text(area.val())
-      $(formGroup).closest("form").submit()
+      updatedSection = link.data("updated-section")
+      if updatedSection
+        input = form.find("input[name='updated_section']")
+        if input.length
+          input.val(updatedSection)
+      form.submit()
   $("#new_review_audit_certificate input[type='radio']").on "change", ->
     area = $(".audit-cert-description")
     if $(this).val() == "confirmed_changes"

--- a/app/models/assessor_assignment_service.rb
+++ b/app/models/assessor_assignment_service.rb
@@ -1,5 +1,6 @@
 class AssessorAssignmentService
   attr_reader :params, :current_subject, :resource
+  DESC_REGEX = /_desc$/
 
   def initialize(params, current_subject)
     @params = params
@@ -32,7 +33,20 @@ class AssessorAssignmentService
   end
 
   def normalize_params
-    params[:assessor_assignment].delete_if { |k, v| v.blank? && k != "assessor_id" }
+    p = params[:assessor_assignment]
+    p.delete_if { |k, v| v.blank? && k != "assessor_id" }
+    if updated_section.present?
+      # Because every text field has separated submit form button
+      # but there is only single huge form for all of the descriptions
+      # it's needed to updated only description marked explicitly by the admin
+      # to achieve data other description fields should be removed from params
+      p.delete_if { |k, _| k =~ DESC_REGEX && k != updated_section }
+    end
+  end
+
+  def updated_section
+    out = params[:updated_section]
+    out if out =~ DESC_REGEX
   end
 
   def assignment_request?

--- a/app/models/assessor_assignment_service.rb
+++ b/app/models/assessor_assignment_service.rb
@@ -1,6 +1,7 @@
 class AssessorAssignmentService
   attr_reader :params, :current_subject, :resource
   DESC_REGEX = /_desc$/
+  RATE_REGEX = /_rate$/
 
   def initialize(params, current_subject)
     @params = params
@@ -40,13 +41,16 @@ class AssessorAssignmentService
       # but there is only single huge form for all of the descriptions
       # it's needed to updated only description marked explicitly by the admin
       # to achieve data other description fields should be removed from params
-      p.delete_if { |k, _| k =~ DESC_REGEX && k != updated_section }
+      if updated_section =~ DESC_REGEX
+        p.delete_if { |k, _| k =~ DESC_REGEX && k != updated_section }
+      elsif updated_section =~ RATE_REGEX
+        p.delete_if { |k, _| k != updated_section && (k =~ DESC_REGEX || k =~ RATE_REGEX) }
+      end
     end
   end
 
   def updated_section
-    out = params[:updated_section]
-    out if out =~ DESC_REGEX
+    params[:updated_section]
   end
 
   def assignment_request?

--- a/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
@@ -12,5 +12,5 @@
       = simple_form_for([namespace_name, moderated_assessment], remote: true, authenticity_token: true, html: { "data-type" => "json"}) do |f|
         = render_section(resource, f)
         = hidden_field_tag :updated_section
-        = f.submit :add, class: "if-js-hide"
+        = f.submit "Save changes", class: "if-js-hide btn btn-primary"
     = render("admin/form_answers/appraisal_form_components/submit_appraisal_form", assessment: moderated_assessment)

--- a/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
@@ -11,5 +11,6 @@
     .panel-body
       = simple_form_for([namespace_name, moderated_assessment], remote: true, authenticity_token: true, html: { "data-type" => "json"}) do |f|
         = render_section(resource, f)
+        = hidden_field_tag :updated_section
         = f.submit :add, class: "if-js-hide"
     = render("admin/form_answers/appraisal_form_components/submit_appraisal_form", assessment: moderated_assessment)

--- a/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
@@ -12,7 +12,7 @@
       = simple_form_for([namespace_name, primary_assessment], remote: true, authenticity_token: true, html: { "data-type" => "json"}) do |f|
         = hidden_field_tag :updated_section
         = render_section(resource, f)
-        = f.submit :add, class: "if-js-hide"
+        = f.submit "Save changes", class: "if-js-hide btn btn-primary"
       .clear
       br
       = render("admin/form_answers/appraisal_form_components/submit_appraisal_form", assessment: primary_assessment)

--- a/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
@@ -10,7 +10,7 @@
     .panel-body
 
       = simple_form_for([namespace_name, primary_assessment], remote: true, authenticity_token: true, html: { "data-type" => "json"}) do |f|
-        = f.hidden_field :form_answer_id
+        = hidden_field_tag :updated_section
         = render_section(resource, f)
         = f.submit :add, class: "if-js-hide"
       .clear

--- a/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
@@ -9,7 +9,7 @@
   #section-appraisal-form-secondary.section-appraisal-form.section-appraisal-form-secondary.panel-collapse.collapse role="tabpanel" aria-labelledby="appraisal-form-secondary-heading"
     .panel-body
       = simple_form_for([namespace_name, secondary_assessment], remote: true, html: { "data-type" => "json"}) do |f|
-        = f.hidden_field :form_answer_id
+        = hidden_field_tag :updated_section
         = render_section(resource, f)
         = f.submit :add, class: "if-js-hide"
       .clear

--- a/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
@@ -11,7 +11,7 @@
       = simple_form_for([namespace_name, secondary_assessment], remote: true, html: { "data-type" => "json"}) do |f|
         = hidden_field_tag :updated_section
         = render_section(resource, f)
-        = f.submit :add, class: "if-js-hide"
+        = f.submit "Save changes", class: "if-js-hide btn btn-primary"
       .clear
       br
       = render("admin/form_answers/appraisal_form_components/submit_appraisal_form", assessment: secondary_assessment)

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -22,6 +22,7 @@
         = render partial: "admin/form_answers/appraisal_form_components/application_background_section",
           locals: { f: f}
         = render_section(resource, f)
+        = hidden_field_tag :updated_section
         = f.submit "Save changes", class: "if-js-hide btn btn-primary"
 
       .clear

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -22,7 +22,7 @@
         = render partial: "admin/form_answers/appraisal_form_components/application_background_section",
           locals: { f: f}
         = render_section(resource, f)
-        = f.submit :add, class: "if-js-hide"
+        = f.submit "Save changes", class: "if-js-hide btn btn-primary"
 
       .clear
       br

--- a/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
@@ -11,5 +11,5 @@
   = link_to "#", class: "form-edit-link pull-right"
     span.glyphicon.glyphicon-pencil
     ' Edit
-  = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
+  = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide"
   .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -43,5 +43,5 @@
     = link_to "#", class: "form-edit-link pull-right"
       span.glyphicon.glyphicon-pencil
       ' Edit
-    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
+    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right", "data-updated-section" => section.desc
     .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -8,7 +8,7 @@
             as: :select,
             label: false,
             collection: options,
-            input_html: { class: "if-js-hide" }
+            input_html: { class: "if-js-hide", "data-updated-section" => section.rate }
 
   label.form-label
     = section.label

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -43,5 +43,5 @@
     = link_to "#", class: "form-edit-link pull-right"
       span.glyphicon.glyphicon-pencil
       ' Edit
-    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right", "data-updated-section" => section.desc
+    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", "data-updated-section" => section.desc
     .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_strengths_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_strengths_section.html.slim
@@ -7,7 +7,7 @@
     as: :select,
     label: false,
     collection: options,
-    input_html: { class: "if-js-hide" }
+    input_html: { class: "if-js-hide", "data-updated-section" => section.rate }
 
   label.form-label
     = section.label

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -42,5 +42,5 @@
     = link_to "#", class: "form-edit-link pull-right"
       span.glyphicon.glyphicon-pencil
       ' Edit
-    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right", "data-updated-section" => section.desc
+    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", "data-updated-section" => section.desc
     .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -42,5 +42,5 @@
     = link_to "#", class: "form-edit-link pull-right"
       span.glyphicon.glyphicon-pencil
       ' Edit
-    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
+    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right", "data-updated-section" => section.desc
     .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -7,7 +7,7 @@
             as: :select,
             label: false,
             collection: options,
-            input_html: { class: "if-js-hide" }
+            input_html: { class: "if-js-hide", "data-updated-section"  => section.desc}
 
   label.form-label
     = section.label

--- a/spec/models/assessor_assignment_service_spec.rb
+++ b/spec/models/assessor_assignment_service_spec.rb
@@ -95,6 +95,27 @@ describe AssessorAssignmentService do
       end
     end
 
+    context "updated section is commercial_rate" do
+      let(:params) do
+        {
+          assessor_assignment: {
+            commercial_success_rate: "negative",
+            another_rate: "negative",
+            strategy_desc: "asd",
+            created_at: "text"
+          },
+          updated_section: "commercial_success_rate",
+          id: primary.id
+        }.with_indifferent_access
+      end
+
+      it "removes the not relevant _rate and _desc" do
+        subject.save
+        expect(subject.update_params).to eq(
+          "commercial_success_rate" => "negative", "created_at" => "text")
+      end
+    end
+
     context "updated section is in invalid attr" do
       let(:params) do
         {

--- a/spec/models/assessor_assignment_service_spec.rb
+++ b/spec/models/assessor_assignment_service_spec.rb
@@ -75,5 +75,44 @@ describe AssessorAssignmentService do
       subject.save
       expect(subject.resource.reload.verdict_desc).to eq("this is a verdict")
     end
+
+    context "updated section is commercial_success_desc" do
+      let(:params) do
+        {
+          assessor_assignment: {
+            commercial_success_desc: "I am description",
+            strategy_desc: "should not be saved",
+            whatever_desc: "asd"
+          },
+          updated_section: "commercial_success_desc",
+          id: primary.id
+        }.with_indifferent_access
+      end
+
+      it "removes the strategy_desc/whatever_desc from relevant attrs" do
+        subject.save
+        expect(subject.update_params).to eq("commercial_success_desc" => "I am description")
+      end
+    end
+
+    context "updated section is in invalid attr" do
+      let(:params) do
+        {
+          assessor_assignment: {
+            commercial_success_desc: "I am description",
+            strategy_desc: "should be saved"
+          },
+          updated_section: "asd",
+          id: primary.id
+        }.with_indifferent_access
+      end
+
+      it "ignores the updated section attr" do
+        subject.save
+        expect(subject.update_params).to eq(
+          "commercial_success_desc" => "I am description",
+          "strategy_desc" => "should be saved")
+      end
+    end
   end
 end

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -28,6 +28,14 @@ shared_context "successful appraisal form edition" do
       assert_description_change(secondary, secondary_header)
       assert_description_change(moderated, moderated_header)
     end
+
+    context "multiple descriptions change" do
+      it "updates the form in separation" do
+        assert_multiple_description_change(primary, primary_header)
+        assert_multiple_description_change(secondary, secondary_header)
+        assert_multiple_description_change(moderated, moderated_header)
+      end
+    end
   end
 
   describe "Overall verdict change" do
@@ -109,6 +117,31 @@ def assert_description_change(section_id, header_id)
     expect(page).to have_selector("textarea", text: text)
   end
   visit show_path
+end
+
+def assert_multiple_description_change(section_id, header_id)
+  text = "should NOT be saved"
+  text2 = "should be saved"
+
+  find("#{header_id} .panel-title a").click
+  within section_id do
+    first(".form-edit-link").click
+    fill_in("assessor_assignment_level_of_innovation_desc", with: text)
+    all(".form-edit-link").last.click
+    fill_in("assessor_assignment_verdict_desc", with: text2)
+    all(".form-save-link").last.click
+  end
+
+  sleep(0.5)
+  visit show_path
+  find("#{header_id} .panel-title a").click
+
+  within section_id do
+    expect(page).to have_selector(".form-value p", text: text2, count: 1)
+    expect(page).to have_selector(".form-value p", text: text, count: 0)
+    all(".form-edit-link").last.click
+    expect(page).to have_selector("textarea", text: text2)
+  end
 end
 
 def assert_verdict_change(section_id, header_id)


### PR DESCRIPTION
+      # Because every text field has separated submit form button
+      # but there is only single huge form for all of the descriptions
+      # it's needed to updated only description marked explicitly by the admin
+      # to achieve data other description fields should be removed from params

https://podio.com/bitzesty/app-qae/apps/stories/items/175 (last comment with pics)