### PR TITLE
Clarify the deadlines stuff

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -103,7 +103,7 @@ class FormController < ApplicationController
 
     submitted_was_changed = @form_answer.submitted_changed?
 
-    if @form_answer.save
+    if @form_answer.eligible? && @form_answer.save
       if submitted_was_changed
         @form_answer.state_machine.submit(current_user)
         Notifiers::Submission::SuccessNotifier.new(@form_answer).run

--- a/app/models/deadline.rb
+++ b/app/models/deadline.rb
@@ -13,6 +13,10 @@ class Deadline < ActiveRecord::Base
     where(kind: "submission_end", states_triggered_at: nil).where("trigger_at < ?", time)
   end
 
+  def self.submission_end
+    where(kind: "submission_end")
+  end
+
   def passed?
     trigger_at && trigger_at < Time.zone.now
   end

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -96,8 +96,6 @@ class FormAnswer < ActiveRecord::Base
   end
 
   begin :callbacks
-    before_validation :check_eligibility, if: :submitted?
-
     before_save :set_award_year, unless: :award_year?
     before_save :set_urn
     before_save :set_progress
@@ -173,10 +171,6 @@ class FormAnswer < ActiveRecord::Base
 
   def nominee_full_name_from_document
     "#{document['nominee_info_first_name']} #{document['nominee_info_last_name']}".strip
-  end
-
-  def check_eligibility
-    errors.add(:base, "Sorry, you are not eligible") unless eligible?
   end
 
   def set_urn

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -166,8 +166,7 @@ class FormAnswer < ActiveRecord::Base
   end
 
   def submitted_and_after_the_deadline?
-    # TODO: clarify how it should work !
-    true
+    submitted? && Settings.after_current_submission_deadline?
   end
 
   private

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -16,6 +16,10 @@ class Settings < ActiveRecord::Base
     for_year(Date.current.year)
   end
 
+  def self.after_current_submission_deadline?
+    DateTime.now > current.deadlines.submission_end.first.trigger_at
+  end
+
   private
 
   def create_deadlines

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -16,8 +16,13 @@ class Settings < ActiveRecord::Base
     for_year(Date.current.year)
   end
 
+  def self.current_submission_deadline
+    current.deadlines.submission_end.first
+  end
+
   def self.after_current_submission_deadline?
-    DateTime.now > current.deadlines.submission_end.first.trigger_at
+    deadline = current_submission_deadline.trigger_at
+    DateTime.now >= deadline if deadline.present?
   end
 
   private

--- a/app/views/admin/form_answers/company_details/_company_name_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_company_name_form.html.slim
@@ -10,10 +10,9 @@
 
       .clear
       = f.submit "Save", class: "btn btn-primary form-save-link pull-right"
-      - unless @form_answer.submitted_and_after_the_deadline?
-        = link_to "#", class: "form-edit-link pull-right"
-          span.glyphicon.glyphicon-pencil
-          ' Edit
+      = link_to "#", class: "form-edit-link pull-right"
+        span.glyphicon.glyphicon-pencil
+        ' Edit
       .clear
 - else
   .form-group

--- a/spec/features/admin/form_answers/admin_fulfills_company_details_spec.rb
+++ b/spec/features/admin/form_answers/admin_fulfills_company_details_spec.rb
@@ -7,32 +7,33 @@ describe "Admin fulfills the company details" do
 
   before do
     login_admin(admin)
+    form_answer.update_column(:submitted, true)
+    Settings.current_submission_deadline.update(trigger_at: DateTime.now - 1.day)
     visit admin_form_answer_path(form_answer)
   end
 
-  context "after the deadline" do
-    it "fulfills the address information" do
-      building = "buildingbuildingbuilding"
-      within ".company-address-form" do
-        find(".company_detail_address_building input").set(building)
-        click_button "Save"
-      end
-      expect(form_answer.reload.company_detail.address_building).to eq(building)
+  it "fulfills the address information" do
+    building = "buildingbuildingbuilding"
+    within ".company-address-form" do
+      find(".company_detail_address_building input").set(building)
+      click_button "Save"
     end
+    expect(form_answer.reload.company_detail.address_building).to eq(building)
+  end
 
-    it "fulfills the company name" do
-      name = "namenana123"
-      within ".company-name-form" do
-        find(".form_answer_company_or_nominee_name input").set(name)
-        click_button "Save"
-      end
-      expect(form_answer.reload.company_or_nominee_name).to eq(name)
+  it "fulfills the company name" do
+    pending "fix eligibility validation"
+    name = "namenana123"
+    within ".company-name-form" do
+      find(".form_answer_company_or_nominee_name input").set(name)
+      click_button "Save"
     end
+    expect(form_answer.reload.company_or_nominee_name).to eq(name)
+  end
 
-    it "can see the edit buttons" do
-      within ".company-details-forms" do
-        expect(page).to have_selector("input[type='submit']", count: 4)
-      end
+  it "can see the edit buttons" do
+    within ".company-details-forms" do
+      expect(page).to have_selector("input[type='submit']", count: 4)
     end
   end
 end

--- a/spec/features/admin/form_answers/admin_fulfills_company_details_spec.rb
+++ b/spec/features/admin/form_answers/admin_fulfills_company_details_spec.rb
@@ -22,7 +22,6 @@ describe "Admin fulfills the company details" do
   end
 
   it "fulfills the company name" do
-    pending "fix eligibility validation"
     name = "namenana123"
     within ".company-name-form" do
       find(".form_answer_company_or_nominee_name input").set(name)

--- a/spec/features/admin/form_answers/previous_winnings_spec.rb
+++ b/spec/features/admin/form_answers/previous_winnings_spec.rb
@@ -5,6 +5,9 @@ describe "Admin sets up previous winnings" do
   let!(:admin) { create(:admin) }
 
   before do
+    Settings.current_submission_deadline.update(trigger_at: DateTime.now - 1.day)
+    form_answer.update(submitted: true)
+
     login_admin(admin)
     visit admin_form_answer_path(form_answer)
   end
@@ -26,6 +29,7 @@ describe "Admin sets up previous winnings" do
 
   context "deletion" do
     let!(:form_answer) { create(:previous_win).form_answer }
+
     it "deletes previous winning" do
       within ".previous-wins-form" do
         expect(page).to have_selector(".list-add", count: 2)

--- a/spec/features/admin/form_answers/sic_code_select_spec.rb
+++ b/spec/features/admin/form_answers/sic_code_select_spec.rb
@@ -6,9 +6,10 @@ describe "SIC Code selection", "
   I want to set up the SIC Code per application." do
 
   let!(:admin) { create(:admin) }
-  let!(:form_answer) { create(:form_answer) }
+  let!(:form_answer) { create(:form_answer, submitted: true) }
   let(:selected) { "1623 - Manufacture of other builders' carpentry and joinery" }
   before do
+    Settings.current_submission_deadline.update(trigger_at: DateTime.now - 1.day)
     login_admin admin
     visit admin_form_answer_path(form_answer)
   end


### PR DESCRIPTION
- Deadlines clarification, - triggering the automatic states transitions, displaying the hidden sections of admin panel after the deadline.
- Removed the validation from the form_answer, as there can be a 2 sources of the eligibility changes: eligibility form and changes made by the admin (only admin). 