### PR TITLE
[Forms] set authenticity_token: true for remote forms

### DIFF
--- a/app/views/admin/form_answers/_section_admin_comments.html.slim
+++ b/app/views/admin/form_answers/_section_admin_comments.html.slim
@@ -6,7 +6,7 @@
   #section-admin-comments.section-admin-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="admin-comments-heading"
     .panel-body
       .comments-container data-comment-form=new_admin_form_answer_comment_path(@form_answer)
-        = form_tag [:toggle, namespace_name, @form_answer, :flags], remote: true, class: "critical-flag" do
+        = form_tag [:toggle, namespace_name, @form_answer, :flags], remote: true, authenticity_token: true, class: "critical-flag" do
           - checked = "checked" if @form_answer.admin_importance_flag?
           = check_box nil, :admin_importance_flag, { class: "flag-comment-checkbox if-js-hide", checked: checked}, 1, 0
 

--- a/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
@@ -8,7 +8,7 @@
             = secondary_assessment.last_editor_info
   #section-appraisal-form-secondary.section-appraisal-form.section-appraisal-form-secondary.panel-collapse.collapse role="tabpanel" aria-labelledby="appraisal-form-secondary-heading"
     .panel-body
-      = simple_form_for([namespace_name, secondary_assessment], remote: true, html: { "data-type" => "json"}) do |f|
+      = simple_form_for([namespace_name, secondary_assessment], remote: true, authenticity_token: true, html: { "data-type" => "json"}) do |f|
         = hidden_field_tag :updated_section
         = render_section(resource, f)
         = f.submit "Save changes", class: "if-js-hide btn btn-primary"

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -29,7 +29,7 @@
       br
 
       - unless assessment.submitted?
-        = form_tag(url_for([namespace_name, :assessment_submissions]), remote: true, class: "submit-assessment", "data-type" => "json")
+        = form_tag(url_for([namespace_name, :assessment_submissions]), remote: true, authenticity_token: true, class: "submit-assessment", "data-type" => "json")
           = hidden_field_tag :assessment_id, assessment.id
           = submit_tag "Confirm Case Summary", class: "btn btn-default btn-block"
           .feedbackHolder

--- a/app/views/admin/form_answers/_section_critical_comments.html.slim
+++ b/app/views/admin/form_answers/_section_critical_comments.html.slim
@@ -6,7 +6,7 @@
   #section-critical-comments.section-critical-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="critical-comments-heading"
     .panel-body
       .comments-container.comment-assessor
-        = form_tag [:toggle, namespace_name, @form_answer, :flags], remote: true, class: "critical-flag" do
+        = form_tag [:toggle, namespace_name, @form_answer, :flags], remote: true, authenticity_token: true, class: "critical-flag" do
           - checked = "checked" if @form_answer.assessor_importance_flag?
           = check_box nil, :assessor_importance_flag, { class: "flag-comment-checkbox if-js-hide", checked: checked}, 1, 0
 

--- a/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
@@ -1,5 +1,5 @@
 - unless assessment.submitted?
-  = form_tag(url_for([namespace_name, :assessment_submissions]), remote: true, class: "submit-assessment", "data-type" => "json")
+  = form_tag(url_for([namespace_name, :assessment_submissions]), remote: true, authenticity_token: true, class: "submit-assessment", "data-type" => "json")
     = hidden_field_tag :assessment_id, assessment.id
     = submit_tag "Submit Appraisal", class: "btn btn-default btn-block"
     .feedbackHolder

--- a/app/views/admin/settings/_deadline_form.html.slim
+++ b/app/views/admin/settings/_deadline_form.html.slim
@@ -6,7 +6,7 @@
     span.trigger-at
       = deadline.formatted_trigger_time
   .deadline-form.well
-    = simple_form_for deadline, url: admin_settings_deadline_path(deadline), remote: true do |f|
+    = simple_form_for deadline, url: admin_settings_deadline_path(deadline), remote: true, authenticity_token: true do |f|
       .control-date
         label.control-label Set period
         = f.input :trigger_at,

--- a/app/views/admin/settings/_notification.html.slim
+++ b/app/views/admin/settings/_notification.html.slim
@@ -15,7 +15,7 @@ li id="notification-#{notification.id}"
         '  |
       = button_to "Delete", admin_settings_email_notification_path(notification), { onclick: "return confirm('Are you sure?')", method: :delete, remote: true }
   .notification-edit-form.well
-    = simple_form_for notification, url: admin_settings_email_notification_path(notification), remote: true do |f|
+    = simple_form_for notification, url: admin_settings_email_notification_path(notification), remote: true, authenticity_token: true do |f|
       .control-date
         label.control-label Edit schedule
         = f.input :trigger_at,

--- a/app/views/admin/settings/_schedule_new.html.slim
+++ b/app/views/admin/settings/_schedule_new.html.slim
@@ -3,7 +3,7 @@
 
 .well.question-group.notification-new-form
   h3 Schedule new email
-  = simple_form_for notification, url: admin_settings_email_notifications_path(year: params[:year]), remote: true do |f|
+  = simple_form_for notification, url: admin_settings_email_notifications_path(year: params[:year]), remote: true, authenticity_token: true do |f|
     = f.input :kind, as: :hidden
     .control-date
       .form-group

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 20150406130916) do
   add_index "assessors", ["reset_password_token"], name: "index_assessors_on_reset_password_token", unique: true, using: :btree
 
   create_table "audit_certificates", force: :cascade do |t|
-    t.integer  "form_answer_id"
+    t.integer  "form_answer_id",      null: false
     t.string   "attachment"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false


### PR DESCRIPTION
Some of the remote forms don't have the authenticity_token: true config, just to remind that it won't work without js