### PR TITLE
Admin docs section

### DIFF
--- a/app/controllers/admin/audit_certificates_controller.rb
+++ b/app/controllers/admin/audit_certificates_controller.rb
@@ -1,0 +1,3 @@
+class Admin::AuditCertificatesController < Admin::BaseController
+  include AuditCertificateContext
+end

--- a/app/controllers/admin/support_letters_controller.rb
+++ b/app/controllers/admin/support_letters_controller.rb
@@ -1,0 +1,3 @@
+class Admin::SupportLettersController < Admin::BaseController
+  include ::SupportLettersContext
+end

--- a/app/controllers/assessor/audit_certificates_controller.rb
+++ b/app/controllers/assessor/audit_certificates_controller.rb
@@ -1,0 +1,3 @@
+class Assessor::AuditCertificatesController < Assessor::BaseController
+  include AuditCertificateContext
+end

--- a/app/controllers/assessor/support_letters_controller.rb
+++ b/app/controllers/assessor/support_letters_controller.rb
@@ -1,0 +1,3 @@
+class Assessor::SupportLettersController < Assessor::BaseController
+  include ::SupportLettersContext
+end

--- a/app/controllers/concerns/audit_certificate_context.rb
+++ b/app/controllers/concerns/audit_certificate_context.rb
@@ -1,0 +1,18 @@
+module AuditCertificateContext
+  def show
+    authorize form_answer, :download_audit_certificate_pdf?
+    send_data resource.attachment.read,
+              filename: resource.attachment.filename,
+              disposition: "inline"
+  end
+
+  private
+
+  def resource
+    @audit_certificate ||= form_answer.audit_certificate
+  end
+
+  def form_answer
+    @form_answer ||= FormAnswer.find(params[:form_answer_id])
+  end
+end

--- a/app/controllers/concerns/support_letters_context.rb
+++ b/app/controllers/concerns/support_letters_context.rb
@@ -1,0 +1,22 @@
+module SupportLettersContext
+  def show
+    authorize resource, :show?
+    send_data support_letter_attachment.attachment.read,
+              filename: support_letter_attachment.original_filename,
+              disposition: "inline"
+  end
+
+  private
+
+  def resource
+    @support_letter ||= form_answer.support_letters.find(params[:id])
+  end
+
+  def form_answer
+    @form_answer ||= FormAnswer.find(params[:form_answer_id])
+  end
+
+  def support_letter_attachment
+    resource.support_letter_attachment
+  end
+end

--- a/app/models/form_answer_attachment.rb
+++ b/app/models/form_answer_attachment.rb
@@ -4,6 +4,9 @@ class FormAnswerAttachment < ActiveRecord::Base
 
   mount_uploader :file, FormAnswerAttachmentUploader
 
+  scope :uploaded_by_user, -> { where attachable_type: "User" }
+  scope :uploaded_not_by_user, -> { where.not(attachable_type: "User") }
+
   def filename
     read_attribute(:file)
   end
@@ -16,5 +19,9 @@ class FormAnswerAttachment < ActiveRecord::Base
     out = all
     out = all.where(restricted_to_admin: false) unless subject.is_a?(Admin)
     out
+  end
+
+  def uploaded_not_by_user?
+    attachable_type != "User"
   end
 end

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -35,4 +35,20 @@ class FormAnswerPolicy < ApplicationPolicy
   def download_feedback_pdf?
     admin? && record.submitted? && record.feedback.present?
   end
+
+  def download_case_summary_pdf?
+    admin? # TODO: need to confirm
+  end
+
+  def download_audit_certificate_pdf?
+    (admin? || subject.lead_or_assigned?(record)) &&
+    record.audit_certificate.present? &&
+    record.audit_certificate.attachment.present?
+  end
+
+  def has_access_to_post_shortlisting_docs?
+    download_feedback_pdf? ||
+    download_case_summary_pdf? ||
+    download_audit_certificate_pdf?
+  end
 end

--- a/app/policies/support_letter_policy.rb
+++ b/app/policies/support_letter_policy.rb
@@ -1,0 +1,7 @@
+class SupportLetterPolicy < ApplicationPolicy
+  # TODO: needs clarification
+
+  def show?
+    true
+  end
+end

--- a/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
+++ b/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
@@ -5,7 +5,7 @@ li.form_answer_attachment
     span.action-title
       span.glyphicon.glyphicon-file
       = form_answer_attachment.decorate.display_name
-  - if policy(form_answer_attachment).destroy?
+  - if form_answer_attachment.uploaded_not_by_user? && policy(form_answer_attachment).destroy?
     small.pull-right
       = form_for(form_answer_attachment, url: admin_form_answer_form_answer_attachment_path(form_answer_attachment.form_answer, form_answer_attachment), html: {method: :delete, style: 'display:inline-block;'}) do |f|
         = f.submit 'Remove', class: 'if-js-hide'

--- a/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
+++ b/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
@@ -1,5 +1,6 @@
+- url_namespace = admin_signed_in? ? :admin : :assessor
 li.form_answer_attachment
-  = link_to [:admin, form_answer_attachment.form_answer, form_answer_attachment],
+  = link_to [url_namespace, form_answer_attachment.form_answer, form_answer_attachment],
             target: "_blank",
             class: "ellipsis"
     span.action-title

--- a/app/views/admin/form_answer_attachments/_support_letter.html.slim
+++ b/app/views/admin/form_answer_attachments/_support_letter.html.slim
@@ -1,0 +1,7 @@
+li.form_answer_attachment
+  = link_to [:admin, support_letter.form_answer, support_letter],
+            target: "_blank",
+            class: "ellipsis"
+    span.action-title
+      span.glyphicon.glyphicon-file
+      = support_letter.support_letter_attachment.original_filename

--- a/app/views/admin/form_answer_attachments/_support_letter.html.slim
+++ b/app/views/admin/form_answer_attachments/_support_letter.html.slim
@@ -1,5 +1,6 @@
+- url_namespace = admin_signed_in? ? :admin : :assessor
 li.form_answer_attachment
-  = link_to [:admin, support_letter.form_answer, support_letter],
+  = link_to [url_namespace, support_letter.form_answer, support_letter],
             target: "_blank",
             class: "ellipsis"
     span.action-title

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -4,18 +4,11 @@
       ' Application & Supporting Docs
     = render "admin/form_answers/docs/application_and_supporting_docs"
 
-  .sidebar-section
-    / TODO Auto generated Docs
-    h2
-      ' Post Shortlisting Docs
-    ul.list-unstyled.list-actions.todo-placeholder
-      li
-        = link_to "View/print Audit Certificate"
-      li
-        = link_to "View/print Case Summary"
-      - if policy(resource).download_feedback_pdf?
-        li
-          = link_to "View/print an application's feedbacks", download_pdf_admin_form_answer_feedbacks_path(@form_answer, format: :pdf)
+  - if policy(resource).has_access_to_post_shortlisting_docs?
+    .sidebar-section
+      h2
+        ' Post Shortlisting Docs
+      = render "admin/form_answers/docs/post_shortlisting_docs"
 
   / TODO Only appears for EP but for now we need to think more on it
   /.sidebar-section

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -2,16 +2,7 @@
   .sidebar-section
     h2
       ' Application & Supporting Docs
-    / TODO uploaded docs by applicant (Can't delete)
-    ul.list-unstyled.list-actions.todo-placeholder
-      li
-        = link_to "#"
-          span.glyphicon.glyphicon-file
-          ' company-application.pdf
-      li
-        = link_to "#"
-          span.glyphicon.glyphicon-file
-          ' company-compliance-outline.pdf
+    = render "admin/form_answers/docs/application_and_supporting_docs"
 
   .sidebar-section
     / TODO Auto generated Docs
@@ -38,8 +29,8 @@
       p.p-empty class="#{'visuallyhidden' if @form_answer.form_answer_attachments.any?}"
         ' No documents have been attached to this case.
       ul.list-unstyled.list-actions
-        - if @form_answer.form_answer_attachments.any?
-          = render(partial: "admin/form_answer_attachments/form_answer_attachment", collection: @form_answer.form_answer_attachments.visible_for(current_subject))
+        - if @form_answer.form_answer_attachments.uploaded_not_by_user.any?
+          = render(partial: "admin/form_answer_attachments/form_answer_attachment", collection: @form_answer.form_answer_attachments.uploaded_not_by_user.visible_for(current_subject))
       br
 
     = form_for [namespace_name, @form_answer, @form_answer.form_answer_attachments.build], html: { multipart: true} do |form|

--- a/app/views/admin/form_answers/docs/_application_and_supporting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_application_and_supporting_docs.html.slim
@@ -1,0 +1,10 @@
+.document-list
+  p.p-empty class="#{'visuallyhidden' if @form_answer.form_answer_attachments.any?}"
+    ' No documents have been attached to this case.
+  ul.list-unstyled.list-actions
+    - if @form_answer.form_answer_attachments.uploaded_by_user.any?
+      = render(partial: "admin/form_answer_attachments/form_answer_attachment", collection: @form_answer.form_answer_attachments.uploaded_by_user.visible_for(current_subject))
+
+    - if @form_answer.support_letters.any?
+      - @form_answer.support_letters.each do |support_letter|
+        = render "admin/form_answer_attachments/support_letter", support_letter: support_letter

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -1,0 +1,12 @@
+- url_namespace = admin_signed_in? ? :admin : :assessor
+ul.list-unstyled.list-actions
+  - if policy(resource).download_audit_certificate_pdf?
+    li
+      = link_to "View/print Audit Certificate", [url_namespace, @form_answer, @form_answer.audit_certificate], target: "_blank"
+
+  - if policy(resource).download_case_summary_pdf?
+    li
+      = link_to "View/print Case Summary", "#"
+  - if policy(resource).download_feedback_pdf?
+    li
+      = link_to "View/print an application's feedbacks", download_pdf_admin_form_answer_feedbacks_path(@form_answer, format: :pdf)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
       resources :comments
       resources :form_answer_attachments, only: [:create, :show, :destroy]
       resources :support_letters, only: [:show]
+      resources :audit_certificates, only: [:show]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit
@@ -153,6 +154,7 @@ Rails.application.routes.draw do
       resources :comments
       resources :form_answer_attachments, only: [:create, :show, :destroy]
       resources :support_letters, only: [:show]
+      resources :audit_certificates, only: [:show]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
       resources :form_answer_state_transitions, only: [:create]
       resources :comments
       resources :form_answer_attachments, only: [:create, :show, :destroy]
+      resources :support_letters, only: [:show]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit
@@ -151,6 +152,7 @@ Rails.application.routes.draw do
       resources :form_answer_state_transitions, only: [:create]
       resources :comments
       resources :form_answer_attachments, only: [:create, :show, :destroy]
+      resources :support_letters, only: [:show]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit

--- a/spec/features/admin/form_answers/attachments_management_spec.rb
+++ b/spec/features/admin/form_answers/attachments_management_spec.rb
@@ -24,7 +24,7 @@ describe 'Form answer attachments management', %q{
 
   context "with existing attachment" do
     before do
-      form_answer.form_answer_attachments.create
+      form_answer.form_answer_attachments.create(attachable: admin)
       visit admin_form_answer_path(form_answer)
     end
 


### PR DESCRIPTION
Docs section corrects:
1) APPLICATION & SUPPORTING DOCS
```
should have any supporting docs attached to application form (i.e. organisation chart etc. etc.)
```
2) POST SHORTLISTING DOCS
```
This should have audit cert uploaded by user and place to download case summary
```
TODO: Pdf generation for Case Summary

3) OTHER_DOCS
```
"Other Docs" should have anything uploaded by an assessor and admin
```
