### PR TITLE
QAE1137 feedbacks pdf add category year separation

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -2,7 +2,7 @@ class Admin::ReportsController < Admin::BaseController
   before_action :check_category, only: [:download_feedbacks_pdf]
 
   expose(:pdf_data) do
-    FeedbackPdfs::Base.new("all", {category: params[:category]})
+    FeedbackPdfs::Base.new("all", nil, {category: params[:category]})
   end
 
   def show

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -15,7 +15,7 @@ class FormAnswerDecorator < ApplicationDecorator
 
   def feedbacks_pdf_generator
     "FeedbackPdfs::Awards2016::#{object.award_type.capitalize}::Base".constantize
-                                                                     .new("singular", {}, object)
+                                                                     .new("singular", object, {})
   end
 
   def pdf_audit_certificate_generator

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -14,7 +14,8 @@ class FormAnswerDecorator < ApplicationDecorator
   end
 
   def feedbacks_pdf_generator
-    "FeedbackPdfs::Awards2016::#{object.award_type.capitalize}::Base".constantize.new("singular", object)
+    "FeedbackPdfs::Awards2016::#{object.award_type.capitalize}::Base".constantize
+                                                                     .new("singular", {}, object)
   end
 
   def pdf_audit_certificate_generator

--- a/app/forms/qae_2014_forms/innovation/innovation_step3.rb
+++ b/app/forms/qae_2014_forms/innovation/innovation_step3.rb
@@ -15,6 +15,7 @@ class QAE2014Forms
             "2 to 4" => "2",
             "5 plus" => "5"
           })
+          sub_category_question
         end
 
         innovation_financial_year_date :financial_year_date, "Please enter your financial year end date." do

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step3.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step3.rb
@@ -16,7 +16,7 @@ class QAE2014Forms
                                                                                      answer_key: "international_trade_6",
                                                                                      question_value: "6 plus",
                                                                                      placeholder_text: %{
-              As you currently hold a Queen's Award for Continuous Achievement in International Trade (3 years), you can only apply for the Outstanding Achievement Award (6 years).
+              As you currently hold a Queen's Award for Outstanding Achievement in International Trade (3 years), you can only apply for the Continuous Achievement Award (6 years).
             }
           placeholder_preselected_condition :queen_award_holder_details,             question_suffix: :category,
                                                                                      parent_question_answer_key: "international_trade_6",
@@ -29,6 +29,7 @@ class QAE2014Forms
             "3 to 5" => "3",
             "6 plus" => "6"
           })
+          sub_category_question
         end
 
         innovation_financial_year_date :financial_year_date, "Please enter your financial year end date." do
@@ -139,7 +140,7 @@ class QAE2014Forms
           }
           hint "See the full list of income to be included in 'direct overseas sales'.", %{
             <p>
-              Include figures for sales of goods/services to non-UK residents or their buying agents. Include royalties, license fees, provision of know-how and other related services to non-UK residents. Include sales to, and by, your overseas subsidiaries (though for what they buy from you to sell on, only include their markup). 
+              Include figures for sales of goods/services to non-UK residents or their buying agents. Include royalties, license fees, provision of know-how and other related services to non-UK residents. Include sales to, and by, your overseas subsidiaries (though for what they buy from you to sell on, only include their markup).
             </p>
             <p>
               Income from services in connection to imports into the UK (other than freight) should not be included. Ship-owners may include freight paid in the UK by a non-resident through an agent. Sales to UK branches/subsidiaries of foreign companies, or sales for use in the UK, should not be included. However, services performed in the UK but invoiced to a non-UK resident can be included eg. tourism.

--- a/app/forms/qae_2014_forms/sustainable_development/sustainable_development_step3.rb
+++ b/app/forms/qae_2014_forms/sustainable_development/sustainable_development_step3.rb
@@ -11,6 +11,7 @@ class QAE2014Forms
             "2 to 4" => "2",
             "5 plus" => "5"
           })
+          sub_category_question
         end
 
         innovation_financial_year_date :financial_year_date, "Please enter your financial year end date." do

--- a/app/pdf_generators/feedback_pdfs/base.rb
+++ b/app/pdf_generators/feedback_pdfs/base.rb
@@ -9,7 +9,7 @@ class FeedbackPdfs::Base < Prawn::Document
               :options,
               :pdf_doc
 
-  def initialize(mode, options={}, form_answer=nil)
+  def initialize(mode, form_answer=nil, options={})
     super(page_size: "A4", page_layout: :landscape)
 
     @pdf_doc = self

--- a/app/pdf_generators/feedback_pdfs/base.rb
+++ b/app/pdf_generators/feedback_pdfs/base.rb
@@ -1,14 +1,22 @@
+require "prawn/measurement_extensions"
+
 class FeedbackPdfs::Base < Prawn::Document
+  include FeedbackPdfs::General::DrawElements
+
   attr_reader :mode,
               :form_answer,
-              :feedbacks
+              :feedbacks,
+              :options,
+              :pdf_doc
 
-  def initialize(mode, form_answer=nil)
+  def initialize(mode, options={}, form_answer=nil)
     super(page_size: "A4", page_layout: :landscape)
 
+    @pdf_doc = self
     @mode = mode
     @form_answer = form_answer
-    @feedbacks = Feedback.submitted if mode == "all"
+    @options = options
+    set_feedbacks if mode == "all"
 
     generate!
   end
@@ -17,11 +25,26 @@ class FeedbackPdfs::Base < Prawn::Document
     if mode == "singular"
       render_item(form_answer)
     else
+      all_mode
+    end
+  end
+
+  def all_mode
+    if feedbacks.present?
       feedbacks.each_with_index do |feedback, index|
         start_new_page if index.to_i != 0
         render_item(feedback.form_answer)
       end
+    else
+      render_not_found_block
     end
+  end
+
+  def set_feedbacks
+    @feedbacks = Feedback.submitted
+                         .includes(:form_answer)
+                         .where("form_answers.award_type = ?", options[:category])
+                         .order("form_answers.award_year")
   end
 
   def render_item(form_answer)

--- a/app/pdf_generators/feedback_pdfs/general/data_pointer.rb
+++ b/app/pdf_generators/feedback_pdfs/general/data_pointer.rb
@@ -1,7 +1,29 @@
 module FeedbackPdfs::General::DataPointer
   def sub_category
-    # TODO
-    "Outstanding" # hardcoded for now
+    if sub_category_question.present?
+      answer = filled_answers[sub_category_question.key]
+
+      if answer.present?
+        options = sub_category_question.ops_values
+
+        selected_option = options.detect do |k, v|
+          k == answer
+        end[1]
+
+        if selected_option == options.values.max
+          "Continious"
+        else
+          "Outstanding"
+        end
+      end
+    end
+  end
+
+  def sub_category_question
+    all_questions.detect do |q|
+      q.delegate_obj.is_a?(QAEFormBuilder::OptionsQuestion) &&
+      q.sub_category_question.present?
+    end
   end
 
   def feedback_table_headers

--- a/app/pdf_generators/feedback_pdfs/general/draw_elements.rb
+++ b/app/pdf_generators/feedback_pdfs/general/draw_elements.rb
@@ -8,7 +8,7 @@ module FeedbackPdfs::General::DrawElements
     render_logo
     render_urn
     render_applicant
-    render_sub_category
+    render_sub_category unless form_answer.promotion?
     render_award_general_information
     render_award_title
   end

--- a/app/pdf_generators/feedback_pdfs/general/draw_elements.rb
+++ b/app/pdf_generators/feedback_pdfs/general/draw_elements.rb
@@ -65,6 +65,16 @@ module FeedbackPdfs::General::DrawElements
                                }
   end
 
+  def render_not_found_block
+    render_logo
+    render_not_found_message
+  end
+
+  def render_not_found_message
+    pdf_doc.text_box "No feedbacks found by selected category!",
+                     header_text_properties.merge(at: [32.mm, 137.mm + DEFAULT_OFFSET])
+  end
+
   def default_bottom_margin
     pdf_doc.move_down 5.mm
   end

--- a/app/pdf_generators/feedback_pdfs/pointer.rb
+++ b/app/pdf_generators/feedback_pdfs/pointer.rb
@@ -3,12 +3,16 @@ require "prawn/measurement_extensions"
 class FeedbackPdfs::Pointer
   include FeedbackPdfs::General::DrawElements
   include FeedbackPdfs::General::DataPointer
+  include FormAnswersBasePointer
 
   UNDEFINED_VALUE = "Not filled yet..."
 
   attr_reader :user,
               :form_answer,
               :award_form,
+              :all_questions,
+              :answers,
+              :filled_answers,
               :feedback_data,
               :pdf_doc
 
@@ -16,7 +20,14 @@ class FeedbackPdfs::Pointer
     @pdf_doc = pdf_doc
     @form_answer = form_answer
     @user = form_answer.user
-    @award_form = form_answer.award_form.decorate
+
+    unless form_answer.promotion?
+      @answers = fetch_answers
+      @award_form = form_answer.award_form.decorate(answers: answers)
+      @all_questions = award_form.steps.map(&:questions).flatten
+      @filled_answers = fetch_filled_answers
+    end
+
     @feedback_data = form_answer.feedback.document
 
     generate!

--- a/app/views/admin/dashboard/index.html.slim
+++ b/app/views/admin/dashboard/index.html.slim
@@ -18,17 +18,9 @@
                   span.visible-lg.visible-md
                     ' Download
 
-          - if policy(:report).show?
-            li
-              = link_to "#"
-                span.action-title
-                  span.glyphicon.glyphicon-file
-                  | Application Feedbacks
-              .pull-right
-                =link_to download_feedbacks_pdf_admin_reports_path(format: :pdf)
-                  span.glyphicon.glyphicon-download-alt
-                  span.visible-lg.visible-md
-                    ' Download
+      - if policy(:report).show?
+        = render "admin/feedbacks/pdf_reports"
+
       / TODO resources
       .well
         h2

--- a/app/views/admin/feedbacks/_pdf_reports.html.slim
+++ b/app/views/admin/feedbacks/_pdf_reports.html.slim
@@ -1,0 +1,15 @@
+.well
+  h2
+    ' Feedbacks
+  ul.list-unstyled.list-actions
+    - FormAnswer::AWARD_TYPE_FULL_NAMES.each do |key, value|
+      li
+        = link_to "#"
+          span.action-title
+            span.glyphicon.glyphicon-file
+            = value
+        .pull-right
+          = link_to download_feedbacks_pdf_admin_reports_path(category: key, format: :pdf)
+            span.glyphicon.glyphicon-download-alt
+            span.visible-lg.visible-md
+              ' Download

--- a/lib/qae_form_builder/options_question.rb
+++ b/lib/qae_form_builder/options_question.rb
@@ -18,11 +18,15 @@ class QAEFormBuilder
       @q.ops_values = ops
     end
 
+    def sub_category_question
+      @q.sub_category_question = true
+    end
+
   end
 
   class OptionsQuestion < Question
     attr_reader :options
-    attr_accessor :financial_date_selector, :ops_values
+    attr_accessor :financial_date_selector, :sub_category_question, :ops_values
 
     def after_create
       @options = []

--- a/spec/features/admin/form_answers/admin_download_all_feedbacks_spec.rb
+++ b/spec/features/admin/form_answers/admin_download_all_feedbacks_spec.rb
@@ -9,45 +9,43 @@ So that I can print and review application feedbacks
 
   let!(:admin) { create(:admin) }
 
-  let!(:form_answer) do
-    create :form_answer, :innovation,
-                         :submitted
-  end
-
-  let(:feedback_content) do
-    res = {}
-
-    FeedbackForm.fields_for_award_type(form_answer.award_type).each do |key, value|
-      res["#{key}_strength"] = "#{key} strength"
-      res["#{key}_weakness"] = "#{key} weakness"
-    end
-
-    res
-  end
-
-  let!(:feedback) do
-    create :feedback, form_answer: form_answer,
-                      document: feedback_content,
-                      submitted: true
-  end
-
-  let(:pdf_filename) do
-    "application_feedbacks"
-  end
-
   before do
     login_admin(admin)
   end
 
-  describe "Download PDF" do
+  describe "Dashboard / Feedbacks section displaying" do
     before do
-      visit download_feedbacks_pdf_admin_reports_path(format: :pdf)
+      visit admin_dashboard_index_path
     end
 
-    it "should generate pdf" do
-      expect(page.status_code).to eq(200)
-      expect(page.response_headers["Content-Disposition"]).to be_eql "attachment; filename=\"#{pdf_filename}\""
-      expect(page.response_headers["Content-Type"]).to be_eql "application/pdf"
+    it "should be links to download feedbacks" do
+      FormAnswer::AWARD_TYPE_FULL_NAMES.each do |award_type, value|
+        expect(page).to have_link('Download',
+          href: download_feedbacks_pdf_admin_reports_path(
+            category: award_type, format: :pdf
+          )
+        )
+      end
     end
+  end
+
+  describe "International Trade Award" do
+    let(:award_type) { :trade }
+    include_context "admin all feedbacks pdf generation"
+  end
+
+  describe "Innovation Award" do
+    let(:award_type) { :innovation }
+    include_context "admin all feedbacks pdf generation"
+  end
+
+  describe "Sustainable Development Award" do
+    let(:award_type) { :development }
+    include_context "admin all feedbacks pdf generation"
+  end
+
+  describe "Enterprise Promotion Award" do
+    let(:award_type) { :promotion }
+    include_context "admin all feedbacks pdf generation"
   end
 end

--- a/spec/support/shared_contexts/admin_all_feedbacks_pdf_generation.rb
+++ b/spec/support/shared_contexts/admin_all_feedbacks_pdf_generation.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+shared_context "admin all feedbacks pdf generation" do
+  let!(:form_answer) do
+    create :form_answer, award_type,
+                         :submitted
+  end
+
+  let!(:feedback) do
+    create :feedback, form_answer: form_answer,
+                      document: feedback_document(award_type),
+                      submitted: true
+  end
+
+  let(:pdf_filename) do
+    "#{FormAnswer::AWARD_TYPE_FULL_NAMES[award_type]}_award_feedbacks"
+  end
+
+  describe "Download PDF" do
+    before do
+      visit download_feedbacks_pdf_admin_reports_path(category: award_type, format: :pdf)
+    end
+
+    it "should generate pdf" do
+      expect(page.status_code).to eq(200)
+      expect(page.response_headers["Content-Disposition"]).to include pdf_filename
+      expect(page.response_headers["Content-Type"]).to be_eql "application/pdf"
+    end
+  end
+
+  def feedback_document(award_type)
+    res = {}
+
+    FeedbackForm.fields_for_award_type(award_type).each do |key, value|
+      res["#{key}_strength"] = "#{key} strength"
+      res["#{key}_weakness"] = "#{key} weakness"
+    end
+
+    res
+  end
+end

--- a/spec/unit/pdf_generators/feedback_pdfs/base_spec.rb
+++ b/spec/unit/pdf_generators/feedback_pdfs/base_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe "FeedbackPdfs::Base" do
+  let!(:form_answer_2014_innovation) do
+    FactoryGirl.create :form_answer, :submitted, :innovation,
+                        award_year: 2014
+  end
+
+  let!(:form_answer_2015_innovation) do
+    FactoryGirl.create :form_answer, :submitted, :innovation,
+                        award_year: 2015
+  end
+
+  let!(:form_answer_2014_trade) do
+    FactoryGirl.create :form_answer, :submitted, :trade,
+                        award_year: 2014
+  end
+
+  let!(:form_answer_2015_trade) do
+    FactoryGirl.create :form_answer, :submitted, :trade,
+                        award_year: 2015
+  end
+
+  before do
+    create :feedback, submitted: true,
+                      form_answer: form_answer_2014_trade,
+                      document: set_feedback_content(:trade)
+
+    create :feedback, submitted: true,
+                      form_answer: form_answer_2015_trade,
+                      document: set_feedback_content(:trade)
+
+    create :feedback, submitted: true,
+                      form_answer: form_answer_2015_innovation,
+                      document: set_feedback_content(:innovation)
+
+    create :feedback, submitted: true,
+                      form_answer: form_answer_2014_innovation,
+                      document: set_feedback_content(:innovation)
+  end
+
+  describe "#set_feedbacks" do
+    it "should be ordered in year and filtered by category" do
+      innovation_feedbacks = FeedbackPdfs::Base.new("all", {category: "innovation"})
+                                               .set_feedbacks
+                                               .map(&:id)
+
+      expect(innovation_feedbacks).to match_array([
+        form_answer_2014_innovation.feedback.id,
+        form_answer_2015_innovation.feedback.id
+      ])
+
+      trade_feedbacks = FeedbackPdfs::Base.new("all", {category: "trade"})
+                                          .set_feedbacks
+                                          .map(&:id)
+
+      expect(trade_feedbacks).to match_array([
+        form_answer_2014_trade.feedback.id,
+        form_answer_2015_trade.feedback.id
+      ])
+    end
+  end
+
+  private
+
+  def set_feedback_content(award_type)
+    res = {}
+
+    FeedbackForm.fields_for_award_type(award_type).each_with_index do |block, index|
+      key = block[0]
+      res["#{key}_strength"] = "#{index}_strength"
+      res["#{key}_weakness"] = "#{index}_weakness"
+    end
+
+    res
+  end
+end


### PR DESCRIPTION
Mostly related to [QAE1137](https://podio.com/bitzesty/app-qae/apps/stories/items/137)
```
As an Admin I want to download all Feedbacks as one pdf (all feedbacks) from Dashboard
```

 * Admin Feedback PDF:
    - added separation per Award category and ordering by year
    - added displaying of Sub-Category (Outstanding / Continious)
    - added some Rspec tests for it
*  Internation Trade Form: C1 placeholder_preselected_condition: Fixed typo error