### PR TITLE
[ADMIN/ASSESSOR FINANCIAL SUMMARY]

### DIFF
--- a/app/views/admin/form_answers/_section_financial_summary.html.slim
+++ b/app/views/admin/form_answers/_section_financial_summary.html.slim
@@ -1,4 +1,4 @@
-- financial_pointer = FormFinancialPointer.new(@form_answer)
+- financial_pointer = FormFinancialPointer.new(@form_answer, {exclude_ignored_questions: true})
 - if !financial_pointer.period_length.zero? && @form_answer.submitted?
   .panel.panel-default
     .panel-heading#financial-summary-heading role="tab"


### PR DESCRIPTION
Exclude "overseas_sales_indirect" line in financial table in accordance with note:

```
On International trade for assessors and admins (and applicants in the audit cert they download)
remove the line for indirect sales from the table and audit certs
```

Guys, please do not merge with PR. 
I need to confirm it with Michael Wallace!