### PR TITLE
Fix review functionality.

### DIFF
--- a/app/controllers/account/collaborators_controller.rb
+++ b/app/controllers/account/collaborators_controller.rb
@@ -1,6 +1,7 @@
 class Account::CollaboratorsController < Account::BaseController
-  
+
   before_action :require_to_be_not_current_user!, only: [:destroy]
+  before_action :restrict_access_if_admin_in_read_only_mode!
 
   before_action :set_form_answer
 
@@ -15,8 +16,8 @@ class Account::CollaboratorsController < Account::BaseController
   end
   expose(:add_collaborator_interactor) do
     AddCollaborator.new(
-        current_user, 
-        account, 
+        current_user,
+        account,
         {})
   end
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,13 +1,6 @@
 class AccountsController < ApplicationController
   before_action :authenticate_user!
-  before_action :restrict_access_if_admin_in_read_only_mode!, only: [
-    :new, :create, :update, :destroy,
-    :update_correspondent_details,
-    :update_company_details,
-    :update_contact_settings,
-    :update_password_settings,
-    :complete_registration
-  ]
+  before_action :restrict_access_if_admin_in_read_only_mode!
 
   def correspondent_details
     @active_step = 1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_in_read_only_mode?
-    @admin_in_read_only_mode ||= admin_signed_in? &&
+    @admin_in_read_only_mode ||= (admin_signed_in? || assessor_signed_in?) &&
                                  session["warden.user.user.key"] &&
                                  session[:admin_in_read_only_mode]
   end
@@ -39,8 +39,26 @@ class ApplicationController < ActionController::Base
 
   def restrict_access_if_admin_in_read_only_mode!
     if admin_in_read_only_mode?
-      redirect_to root_url, alert: "You have no permissions!"
+      redirect_to :back, alert: "You have no permissions!"
       return
+    end
+  end
+
+  def allow_assessor_access!(fa)
+    if admin_in_read_only_mode?
+      if assessor_signed_in? && !admin_signed_in?
+        if fa.present?
+          if current_assessor.lead_or_assigned?(fa)
+            return true
+          end
+        end
+        if request.referer
+          redirect_to :back, alert: "You have no permissions!"
+        else
+          render text: "You have no permissions!"
+        end
+        return false
+      end
     end
   end
 

--- a/app/controllers/content_only_controller.rb
+++ b/app/controllers/content_only_controller.rb
@@ -44,6 +44,8 @@ class ContentOnlyController < ApplicationController
                   :privacy,
                   :cookies
                 ]
+  before_action :restrict_access_if_admin_in_read_only_mode!,
+                only: [:dashboard]
 
   expose(:form_answer) {
     current_user.form_answers.find(params[:id])

--- a/app/controllers/form_award_eligibilities_controller.rb
+++ b/app/controllers/form_award_eligibilities_controller.rb
@@ -7,6 +7,9 @@ class FormAwardEligibilitiesController < ApplicationController
   before_action :restrict_access_if_admin_in_read_only_mode!, only: [
     :new, :create, :update, :destroy
   ]
+  before_action do
+    allow_assessor_access!(@form_answer)
+  end
 
   def show
     #    if award eligibility is not passed

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -12,6 +12,9 @@ class FormController < ApplicationController
   ]
   before_action :require_to_be_account_admin!, only: :submit_confirm
   before_action :check_trade_count_limit, only: :new_international_trade_form
+  before_action do
+    allow_assessor_access!(@form_answer)
+  end
 
   expose(:support_letter_attachments) do
     @form_answer.support_letter_attachments.inject({}) do |r, attachment|

--- a/app/controllers/users/form_answers_controller.rb
+++ b/app/controllers/users/form_answers_controller.rb
@@ -4,6 +4,9 @@ class Users::FormAnswersController < Users::BaseController
                 form_answers.
                 find(params[:id])
   }
+  before_action do
+    allow_assessor_access!(form_answer)
+  end
 
   def show
     respond_to do |format|


### PR DESCRIPTION
Found that Assessor is able to review the all User forms even if is not
assigned to that case and is not a lead either. Added some restrictions to
reviewing the resources also as It was designed initially to use for the Admin,
but in case of Assessors we should be more suspicious.