### PR TITLE
Remove the reset expiration time for imported users.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,6 +98,15 @@ class User < ActiveRecord::Base
     "#{first_name} #{last_name}".strip
   end
 
+  def reset_password_period_valid?
+    release_date = Date.new(2015, 4, 21)
+    if imported? && reset_password_sent_at.present? && reset_password_sent_at.to_date == release_date
+      true
+    else
+      super
+    end
+  end
+
   private
 
   def first_step?


### PR DESCRIPTION
Users migrated from another app shouldn't have expiration of their reset
password tokens. Assumed that all tokens sent on release date are these sent with import.