### PR TITLE
Form Improvements related to avoiding possible "erasing' of form data

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -230,6 +230,8 @@ jQuery ->
       if this_index < current_index
         $(this).addClass("step-past")
 
+    $("#current_step_id").val(step.replace("step-", ""))
+
   if window.location.hash
     step = window.location.hash.substr(1)
     if $(".js-step-condition[data-step='step-#{step}']").size() > 0
@@ -238,6 +240,7 @@ jQuery ->
       resetResizeTextarea()
     else
       window.location.hash = $(".js-step-condition.step-current").attr("data-step").substr(5)
+      $("#current_step_id").val(step.replace("step-", ""))
 
   $(document).on "click", ".js-step-link", (e) ->
     e.preventDefault()

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -232,82 +232,14 @@ class FormController < ApplicationController
 
   private
 
-  def prepare_doc
-    form_data = params[:form]
-
-    allowed_questions = @form_answer.award_form.steps.detect do |s|
+  def updating_step
+    @form_answer.award_form.steps.detect do |s|
       s.title.parameterize == params[:current_step_id]
-    end.questions
+    end.decorate
+  end
 
-    Rails.logger.info "[allowed_questions] #{allowed_questions.map(&:key)}"
-
-    allowed_params = {}
-
-    allowed_questions.each do |q|
-      Rails.logger.info "[q] #{q.key}"
-      question = q.decorate
-      allowed_params[question.key] = form_data[question.key]
-
-      sub_question_keys = []
-      sub_fields = question.sub_fields rescue nil
-      required_sub_fields = question.required_sub_fields rescue nil
-      by_year_conditions = question.by_year_conditions rescue nil
-
-      Rails.logger.info "[sub_fields] #{sub_fields}"
-      Rails.logger.info "[required_sub_fields] #{required_sub_fields}"
-      Rails.logger.info "[by_year_conditions] #{by_year_conditions}"
-
-      if sub_fields.present?
-        res = sub_fields.map { |f| f.keys.first }
-        Rails.logger.info "[sub_fields] res #{res}"
-        sub_question_keys += res
-      end
-
-      if required_sub_fields.present?
-        res = required_sub_fields.map { |f| f.keys.first }
-        Rails.logger.info "[required_sub_fields] res #{res}"
-        sub_question_keys += res
-      end
-
-      if by_year_conditions.present?
-        res = question.by_year_conditions.map do |c|
-          (1..c.years).map do |y|
-            if q.is_a?(QAEFormBuilder::ByYearsLabelQuestion)
-              [:day, :month, :year].map do |i|
-                "#{y}of#{c.years}#{i}"
-              end
-            else
-              "#{y}of#{c.years}"
-            end
-          end
-        end.flatten
-        Rails.logger.info "[by_year_conditions] res #{res}"
-
-        sub_question_keys += res
-      end
-
-      sub_question_keys = sub_question_keys.flatten
-                                            .uniq
-                                            .map { |s| "#{question.key}_#{s}" }
-
-      Rails.logger.info "[sub_question_keys] #{sub_question_keys}"
-
-      sub_question_keys.each do |sub_question_key|
-        allowed_params[sub_question_key] = form_data[sub_question_key]
-      end
-    end
-
-    Rails.logger.info "[allowed_params before] #{allowed_params}"
-
-    allowed_params = allowed_params.select do |k, v|
-      v.present?
-    end
-
-    Rails.logger.info "[allowed_params after] #{allowed_params}"
-
-    Rails.logger.info "[form_data] #{form_data.keys.count}"
-    Rails.logger.info "[allowed_params] #{allowed_params.keys.count} #{allowed_params}"
-
+  def prepare_doc
+    allowed_params = updating_step.allowed_questions_params_list(params[:form])
     @form_answer.document.merge(serialize_doc(allowed_params))
   end
 

--- a/app/forms/qae_2014_forms/innovation/innovation_step6.rb
+++ b/app/forms/qae_2014_forms/innovation/innovation_step6.rb
@@ -13,6 +13,11 @@ class QAE2014Forms
         end
 
         head_of_business :head_of_business, "" do
+          sub_fields([
+            { first_name: "First name" },
+            { last_name: "Last name" },
+            { honours: "Personal Honours" }
+          ])
         end
 
         text :head_job_title, "Job title / Role in the organisation" do

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step6.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step6.rb
@@ -13,6 +13,11 @@ class QAE2014Forms
         end
 
         head_of_business :head_of_business, "" do
+          sub_fields([
+            { first_name: "First name" },
+            { last_name: "Last name" },
+            { honours: "Personal Honours" }
+          ])
         end
 
         text :head_job_title, "Job title / Role in the organisation" do

--- a/app/forms/qae_2014_forms/sustainable_development/sustainable_development_step6.rb
+++ b/app/forms/qae_2014_forms/sustainable_development/sustainable_development_step6.rb
@@ -13,6 +13,11 @@ class QAE2014Forms
         end
 
         head_of_business :head_of_business, "" do
+          sub_fields([
+            { first_name: "First name" },
+            { last_name: "Last name" },
+            { honours: "Personal Honours" }
+          ])
         end
 
         text :head_job_title, "Job title / Role in the organisation" do

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/lists.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/lists.rb
@@ -6,6 +6,11 @@ module QaePdfForms::CustomQuestions::Lists
   ]
   AWARD_HOLDER_LIST_HEADERS = [
     "Award/personal honour title",
+    "Year",
+    "Details"
+  ]
+  NOMINATION_AWARD_LIST_HEADERS = [
+    "Award/personal honour title",
     "Details"
   ]
   POSITION_LIST_HEADERS = [
@@ -35,7 +40,11 @@ module QaePdfForms::CustomQuestions::Lists
   def list_headers
     case question.delegate_obj
     when QAEFormBuilder::AwardHolderQuestion
-      AWARD_HOLDER_LIST_HEADERS
+      if question.award_years_present
+        AWARD_HOLDER_LIST_HEADERS
+      else
+        NOMINATION_AWARD_LIST_HEADERS
+      end
     when QAEFormBuilder::PositionDetailsQuestion
       POSITION_LIST_HEADERS
     when QAEFormBuilder::ByTradeGoodsAndServicesLabelQuestion
@@ -56,10 +65,18 @@ module QaePdfForms::CustomQuestions::Lists
 
   def award_holder_query_conditions(prepared_item)
     if prepared_item["title"].present?
-      [
-        prepared_item["title"],
-        prepared_item["details"]
-      ]
+      if question.award_years_present
+        [
+          prepared_item["title"],
+          prepared_item["year"],
+          prepared_item["details"]
+        ]
+      else
+        [
+          prepared_item["title"],
+          prepared_item["details"]
+        ]
+      end
     end
   end
 

--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -151,11 +151,7 @@ module QaePdfForms::General::DrawElements
   end
 
   def render_answer_by_display(title, display)
-    if display == "block"
-      render_standart_answer_block(title)
-    else
-      title
-    end
+    render_standart_answer_block(title)
   end
 
   def render_standart_answer_block(title)

--- a/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
@@ -100,7 +100,11 @@ class QaePdfForms::General::QuestionPointer
   def fetch_sub_answers
     res = []
 
-    question.required_sub_fields.each do |sub_field|
+    required_sub_fields = question.required_sub_fields rescue []
+    sub_fields = question.sub_fields rescue []
+    merged_sub_fields = (required_sub_fields + sub_fields).flatten.uniq
+
+    merged_sub_fields.each do |sub_field|
       sub_field_key = sub_field.keys.first
       sub_answer = form_pdf.fetch_answer_by_key("#{key}_#{sub_field_key}")
 

--- a/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
@@ -143,6 +143,8 @@ class QaePdfForms::General::QuestionPointer
          question_block_type(question) == "block" ||
          humanized_answer.blank?
         question_answer(question, "block")
+      else
+        question_answer(question, "inline")
       end
     end
   end

--- a/app/views/qae_form/show.html.slim
+++ b/app/views/qae_form/show.html.slim
@@ -3,6 +3,8 @@
 form.qae-form.award-form data-autosave-url=save_form_url(@form_answer) action=save_form_url(@form_answer, next_step: next_step(@form, params[:step]), current_step: params[:step]) method="POST" data-attachments-url=attachments_url(@form_answer) novalidate=true
   input name="authenticity_token" type="hidden" value=form_authenticity_token
 
+  = hidden_field_tag :current_step_id, (params[:step].present? ? params[:step] : @form.steps.first.title.parameterize)
+
   header.page-header.group.page-header-over-sidebar
     div
       h1

--- a/lib/qae_form_builder/head_of_business_question.rb
+++ b/lib/qae_form_builder/head_of_business_question.rb
@@ -12,9 +12,13 @@ class QAEFormBuilder
   end
 
   class HeadOfBusinessQuestionBuilder < QuestionBuilder
+    def sub_fields fields
+      @q.sub_fields = fields
+    end
   end
 
   class HeadOfBusinessQuestion < Question
+    attr_accessor :sub_fields
   end
 
 end

--- a/lib/qae_form_builder/step.rb
+++ b/lib/qae_form_builder/step.rb
@@ -34,12 +34,9 @@ class QAEFormBuilder
     end
 
     def allowed_questions_params_list(form_data)
-      Rails.logger.info "[questions] #{questions.map(&:key)}"
-
       allowed_params = {}
 
       questions.each do |question|
-        Rails.logger.info "^^^^^^^^^^^[q.class] #{question.class}"
         allowed_params[question.key] = form_data[question.key]
 
         question_possible_sub_keys(question).each do |sub_question_key|
@@ -47,50 +44,31 @@ class QAEFormBuilder
         end
       end
 
-      Rails.logger.info "[allowed_params before] #{allowed_params}"
-
       allowed_params = allowed_params.select do |k, v|
         v.present?
       end
-
-      Rails.logger.info "[allowed_params after] #{allowed_params}"
-
-      Rails.logger.info "[form_data] #{form_data.keys.count}"
-      Rails.logger.info "[allowed_params] #{allowed_params.keys.count} #{allowed_params}"
 
       allowed_params
     end
 
     def question_possible_sub_keys(question)
-      Rails.logger.info "[question] #{question.key}"
-
       sub_question_keys = []
+
       sub_fields = question.sub_fields rescue nil
       required_sub_fields = question.required_sub_fields rescue nil
       by_year_conditions = question.by_year_conditions rescue nil
 
-      Rails.logger.info "[sub_fields] #{sub_fields}"
-      Rails.logger.info "[required_sub_fields] #{required_sub_fields}"
-      Rails.logger.info "[by_year_conditions] #{by_year_conditions}"
-
       if sub_fields.present?
-        res = sub_fields.map { |f| f.keys.first }
-        Rails.logger.info "[sub_fields] res #{res}"
-        sub_question_keys += res
+        sub_question_keys += sub_fields.map { |f| f.keys.first }
       end
 
       if required_sub_fields.present?
-        res = required_sub_fields.map { |f| f.keys.first }
-        Rails.logger.info "[required_sub_fields] res #{res}"
-        sub_question_keys += res
+        sub_question_keys += required_sub_fields.map { |f| f.keys.first }
       end
 
       if by_year_conditions.present?
-        res = question.by_year_conditions.map do |c|
+        sub_question_keys += question.by_year_conditions.map do |c|
           (1..c.years).map do |y|
-            if question.key == :financial_year_changed_dates
-              Rails.logger.info "---------------[q.class] #{question.delegate_obj.class}"
-            end
             if question.delegate_obj.is_a?(QAEFormBuilder::ByYearsLabelQuestion)
               [:day, :month, :year].map do |i|
                 "#{y}of#{c.years}#{i}"
@@ -100,17 +78,11 @@ class QAEFormBuilder
             end
           end
         end.flatten
-        Rails.logger.info "[by_year_conditions] res #{res}"
-
-        sub_question_keys += res
       end
 
-      sub_question_keys = sub_question_keys.flatten
-                                            .uniq
-                                            .map { |s| "#{question.key}_#{s}" }
-
-      Rails.logger.info "[sub_question_keys] #{sub_question_keys}"
-      sub_question_keys
+      sub_question_keys.flatten
+                       .uniq
+                       .map { |s| "#{question.key}_#{s}" }
     end
 
     private

--- a/lib/qae_form_builder/step.rb
+++ b/lib/qae_form_builder/step.rb
@@ -38,10 +38,11 @@ class QAEFormBuilder
 
       allowed_params = {}
 
-      questions.each do |q|
-        allowed_params[q.key] = form_data[q.key]
+      questions.each do |question|
+        Rails.logger.info "^^^^^^^^^^^[q.class] #{question.class}"
+        allowed_params[question.key] = form_data[question.key]
 
-        question_possible_sub_keys(q).each do |sub_question_key|
+        question_possible_sub_keys(question).each do |sub_question_key|
           allowed_params[sub_question_key] = form_data[sub_question_key]
         end
       end
@@ -60,10 +61,8 @@ class QAEFormBuilder
       allowed_params
     end
 
-    def question_possible_sub_keys(q)
-      Rails.logger.info "[q] #{q.key}"
-
-      question = q.decorate
+    def question_possible_sub_keys(question)
+      Rails.logger.info "[question] #{question.key}"
 
       sub_question_keys = []
       sub_fields = question.sub_fields rescue nil
@@ -89,7 +88,10 @@ class QAEFormBuilder
       if by_year_conditions.present?
         res = question.by_year_conditions.map do |c|
           (1..c.years).map do |y|
-            if q.is_a?(QAEFormBuilder::ByYearsLabelQuestion)
+            if question.key == :financial_year_changed_dates
+              Rails.logger.info "---------------[q.class] #{question.delegate_obj.class}"
+            end
+            if question.delegate_obj.is_a?(QAEFormBuilder::ByYearsLabelQuestion)
               [:day, :month, :year].map do |i|
                 "#{y}of#{c.years}#{i}"
               end


### PR DESCRIPTION
1) Form Improvements related to avoiding possible "erasing' of form data:
- saving only current section (not all form data)
- reject blank data

2) Bunch of PDF fixes:
- Step F: Authorize and Submit, question F1: Head of your organisation
  Personal Honours not displaying at all
- Step A: Copmany Info, question A13:
   "Country of immediate parent company" and "Country and organisation with ultimate control" are not displaying answers in PDF
- EP Form | A2: Does the nominee currently hold any awards/personal honours? 
  do not display years
