### PR TITLE
Adding advisory_lock to prevent scheduled tasks running on both machines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,8 @@ gem 'active_hash'
 gem 'whenever'
 gem "virtus"
 gem "nilify_blanks"
+# DB locking
+gem "with_advisory_lock"
 
 # Monitoring
 gem "skylight"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,6 +553,9 @@ GEM
       chronic (>= 0.6.3)
     wicked (1.1.0)
       rails (>= 3.0.7)
+    with_advisory_lock (3.0.0)
+      activerecord (>= 3.2)
+      thread_safe
     xpath (2.0.0)
       nokogiri (~> 1.3)
     zxcvbn-ruby (0.0.3)
@@ -639,3 +642,4 @@ DEPENDENCIES
   webmock
   whenever
   wicked (~> 1.1)
+  with_advisory_lock

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,8 +1,11 @@
+# All scheduled tasks need to run with a advisory_lock
+# To prevent two processes running them concurrently
+# User.with_advisory_lock('name', 0) { block }
+
 every 5.minutes do
-  runner "Notifiers::EmailNotificationService.run"
+  runner "User.with_advisory_lock('email_notification', 0) { Notifiers::EmailNotificationService.run }"
 end
 
 every 5.minutes do
-  runner "FormAnswerStateMachine.trigger_deadlines"
+  runner "User.with_advisory_lock('deadlines', 0) { FormAnswerStateMachine.trigger_deadlines }"
 end
-


### PR DESCRIPTION
All tasks need to have a lock