### PR TITLE
[QAE1178 | CRON STUFF]

### DIFF
--- a/app/models/cron_job.rb
+++ b/app/models/cron_job.rb
@@ -1,0 +1,8 @@
+class CronJobRun
+  def self.run(lock_name, timeout_seconds=0, sleep_before_run=3, &block)
+    User.with_advisory_lock(lock_name, timeout_seconds) do
+      sleep(sleep_before_run) if sleep_before_run.to_i > 0
+      block.call
+    end
+  end
+end

--- a/app/models/cron_job.rb
+++ b/app/models/cron_job.rb
@@ -1,5 +1,5 @@
 class CronJobRun
-  def self.run(lock_name, timeout_seconds=0, sleep_before_run=3, &block)
+  def self.run(lock_name, timeout_seconds=0, sleep_before_run=5, &block)
     User.with_advisory_lock(lock_name, timeout_seconds) do
       sleep(sleep_before_run) if sleep_before_run.to_i > 0
       block.call

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,7 +32,7 @@ set :rbenv_ruby, '2.1.5'
 set :rbenv_roles, :all
 
 set :linked_files, %w(config/database.yml config/secrets.yml .env)
-set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads}
+set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads}
 
 set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,9 +10,9 @@ set :output, File.expand_path("#{File.dirname __FILE__}/../log/cron_log.log")
 # Do not run jobs with the same offset
 
 every :day, at: "12:30am" do
-  runner "CronJobRun.run('deadlines', 0, 5) { FormAnswerStateMachine.trigger_deadlines }"
+  runner "CronJobRun.run('deadlines') { FormAnswerStateMachine.trigger_deadlines }"
 end
 
 every :hour do
-  runner "CronJobRun.run('email_notification', 0, 5) { Notifiers::EmailNotificationService.run }"
+  runner "CronJobRun.run('email_notification') { Notifiers::EmailNotificationService.run }"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,6 @@
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+
+set :job_template, "env PATH=$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH /bin/bash -l -c ':job'"
 set :output, File.expand_path("#{File.dirname __FILE__}/../log/cron_log.log")
 
 # All scheduled tasks need to run with a advisory_lock
@@ -6,10 +9,10 @@ set :output, File.expand_path("#{File.dirname __FILE__}/../log/cron_log.log")
 
 # Do not run jobs with the same offset
 
-every 7.minutes do
-  runner "User.with_advisory_lock('email_notification', 0) { Notifiers::EmailNotificationService.run }"
+every :day, at: "12:30am" do
+  runner "CronJobRun.run('deadlines', 0, 5) { FormAnswerStateMachine.trigger_deadlines }"
 end
 
-every 5.minutes do
-  runner "User.with_advisory_lock('deadlines', 0) { FormAnswerStateMachine.trigger_deadlines }"
+every :hour do
+  runner "CronJobRun.run('email_notification', 0, 5) { Notifiers::EmailNotificationService.run }"
 end

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -4,3 +4,5 @@ authentication: <%= ENV['SKYLIGHT_AUTHENTICATION'] %>
 
 ignored_endpoints:
   - HealthchecksController#show
+
+alert_log_file: "log/skylight.log"


### PR DESCRIPTION
* Implemented CronJob class that does the locking stuff and adds a small sleep say 3 secs before the work
* Skylight: disabled alert messages on dev / staging envs
* Cron / Capistrano: fixed issue with binstubs messages

Changed the schedule for some tasks:

`FormAnswerStateMachine.trigger_deadlines` only needs to be run the day after the deadline to move form states, so run at 12:30am.

`Notifiers::EmailNotificationService.run` is not time sensitive so just run once an hour.