### PR TITLE
Clean up orphaned files which are removed from form

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -310,8 +310,20 @@ jQuery ->
       $(li).find("textarea").each process_input
       idx++
 
-  appendLinkDocumentRemoveLink = (div) ->
+  appendRemoveLinkForWebsiteLink = (div) ->
     remove_link = $("<a>").addClass("remove-link").prop("href", "#").text("Remove")
+    div.append(remove_link)
+
+  appendRemoveLinkForAttachment = (div, data) ->
+    attachment_id = data.result['id']
+    form_answer_id = data.result['form_answer_id']
+    destroy_url = "/form/form_answers/" + form_answer_id + "/form_attachments/" + attachment_id
+
+    remove_link = $("<a>").addClass("remove-link")
+                          .prop("href", destroy_url)
+                          .attr("data-method", "delete")
+                          .attr("data-remote", "true")
+                          .text("Remove")
     div.append(remove_link)
 
   $('.js-file-upload').each (idx, el) ->
@@ -377,7 +389,7 @@ jQuery ->
         input = $("<input class=\"medium\" type=\"text\">").
           prop('name', "#{form_name}[#{name}][][link]")
         label.append(input)
-        appendLinkDocumentRemoveLink(div)
+        appendRemoveLinkForWebsiteLink(div)
         div.append(label)
         new_el.append(div)
       else
@@ -395,7 +407,7 @@ jQuery ->
         hidden_input = $("<input type='hidden' name='#{form_name}[#{name}][][file]' value='#{data.result['id']}' />")
 
         div.append(hidden_input)
-        appendLinkDocumentRemoveLink(div)
+        appendRemoveLinkForAttachment(div, data)
         new_el.append(div)
 
       if needs_description

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -314,10 +314,15 @@ jQuery ->
     remove_link = $("<a>").addClass("remove-link").prop("href", "#").text("Remove")
     div.append(remove_link)
 
-  appendRemoveLinkForAttachment = (div, data) ->
+  appendRemoveLinkForAttachment = (div, name, data) ->
     attachment_id = data.result['id']
     form_answer_id = data.result['form_answer_id']
-    destroy_url = "/form/form_answers/" + form_answer_id + "/form_attachments/" + attachment_id
+
+    destroy_url = if name == "org_chart"
+      "/form/form_answers/" + form_answer_id + "/organisational_charts/" + attachment_id
+    else
+      "/form/form_answers/" + form_answer_id + "/form_attachments/" + attachment_id
+
 
     remove_link = $("<a>").addClass("remove-link")
                           .prop("href", destroy_url)
@@ -407,7 +412,7 @@ jQuery ->
         hidden_input = $("<input type='hidden' name='#{form_name}[#{name}][][file]' value='#{data.result['id']}' />")
 
         div.append(hidden_input)
-        appendRemoveLinkForAttachment(div, data)
+        appendRemoveLinkForAttachment(div, name, data)
         new_el.append(div)
 
       if needs_description

--- a/app/controllers/form/form_attachments_controller.rb
+++ b/app/controllers/form/form_attachments_controller.rb
@@ -1,7 +1,7 @@
 class Form::FormAttachmentsController < Form::MaterialsBaseController
 
   # This controller handles saving of attachments
-  # This section is used in case if JS disabled
+  # This section is used in case if JS disabled (destroy action used for both JS and NON JS)
 
   expose(:form_answer_attachments) do
     @form_answer.form_answer_attachments
@@ -78,7 +78,15 @@ class Form::FormAttachmentsController < Form::MaterialsBaseController
       form_answer_attachment.destroy
     end
 
-    redirect_to form_form_answer_form_attachments_url(@form_answer)
+    respond_to do |format|
+      format.html do
+        if request.xhr?
+          render nothing: true
+        else
+          redirect_to form_form_answer_form_attachments_url(@form_answer)
+        end
+      end
+    end
   end
 
   private

--- a/app/controllers/form/organisational_charts_controller.rb
+++ b/app/controllers/form/organisational_charts_controller.rb
@@ -83,7 +83,15 @@ class Form::OrganisationalChartsController < Form::MaterialsBaseController
       form_answer_attachment.destroy
     end
 
-    redirect_to edit_form_url(id: @form_answer.id, step: "company-information")
+    respond_to do |format|
+      format.html do
+        if request.xhr?
+          render nothing: true
+        else
+          redirect_to edit_form_url(id: @form_answer.id, step: "company-information")
+        end
+      end
+    end
   end
 
   private

--- a/app/forms/qae_2014_forms/international_trade/international_trade_step1.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step1.rb
@@ -265,6 +265,7 @@ class QAE2014Forms
               chm, csv, diff, doc, docx, dot, dxf, eps, gif, gml, ics, jpg, kml, odp, ods, odt, pdf, png, ppt, pptx, ps, rdf, rtf, sch, txt, wsdl, xls, xlsm, xlsx, xlt, xml, xsd, xslt, zip
             </p>
           )
+          max_attachments 1
         end
       end
     end

--- a/app/forms/qae_2014_forms/sustainable_development/sustainable_development_step1.rb
+++ b/app/forms/qae_2014_forms/sustainable_development/sustainable_development_step1.rb
@@ -296,6 +296,7 @@ class QAE2014Forms
               chm, csv, diff, doc, docx, dot, dxf, eps, gif, gml, ics, jpg, kml, odp, ods, odt, pdf, png, ppt, pptx, ps, rdf, rtf, sch, txt, wsdl, xls, xlsm, xlsx, xlt, xml, xsd, xslt, zip
             </p>
           )
+          max_attachments 1
         end
       end
     end

--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -18,8 +18,10 @@
                 a.remove-link.if-no-js-hide href="#" *possible_read_only_ops
                   | Remove
               - else
-                a.remove-link href="#" *possible_read_only_ops
-                  | Remove
+                = link_to "Remove", form_form_answer_form_attachment_url(@form_answer.id, el['file'].to_i),
+                                    possible_read_only_ops.merge({class: "remove-link",
+                                                                  remote: true,
+                                                                  method: :delete})
 
             - elsif el['link'].present?
               a.remove-link href="#" *possible_read_only_ops

--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -15,8 +15,10 @@
               - if question.key == :org_chart
                 = link_to "Remove", form_form_answer_organisational_chart_confirm_deletion_url(@form_answer.id, el['file'].to_i), class: "remove-link if-js-hide"
 
-                a.remove-link.if-no-js-hide href="#" *possible_read_only_ops
-                  | Remove
+                = link_to "Remove", form_form_answer_organisational_chart_url(@form_answer.id, el['file'].to_i),
+                                    possible_read_only_ops.merge({class: "remove-link if-no-js-hide",
+                                                                  remote: true,
+                                                                  method: :delete})
               - else
                 = link_to "Remove", form_form_answer_form_attachment_url(@form_answer.id, el['file'].to_i),
                                     possible_read_only_ops.merge({class: "remove-link",


### PR DESCRIPTION
Fixes https://github.com/bitzesty/qae/issues/358
1) Form Attachments: AJAX removing of attachment record 
2) Form | Organisational Chart Upload | Remove: implemented AJAX removing of file
3) Form | Organisational Chart Upload:  added missing max attachments validations for Trade and Dev forms