### PR TITLE
Tweaking layout on sic code and previous winning sections

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -261,8 +261,9 @@ handleCompanyDetailsForm = ->
 
       $(newNestedForm).find('label').each ->
         oldLabel = $(this).attr 'for'
-        newLabel = oldLabel.replace(new RegExp(/_[0-9]+_/), "_#{formsOnPage}_")
-        $(this).attr 'for', newLabel
+        if oldLabel
+          newLabel = oldLabel.replace(new RegExp(/_[0-9]+_/), "_#{formsOnPage}_")
+          $(this).attr 'for', newLabel
 
       $(newNestedForm).find('select, input').each ->
         oldId = $(this).attr 'id'

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -462,3 +462,21 @@
     clear:both;
   }
 }
+
+.form-group.previous-wins-form.form-edit {
+  .form-fields {
+    display: block !important;
+  }
+}
+
+.form-group.sic-code.form-edit {
+  .form-fields {
+    margin-left: 10px;
+  }
+
+  .form-save-link {
+    position: relative;
+    top: -5px;
+    margin-top: 0;
+  }
+}

--- a/app/views/admin/form_answers/company_details/_previous_wins_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_previous_wins_form.html.slim
@@ -40,7 +40,6 @@
                             collection: AwardYear::AVAILABLE_YEARS
 
         = link_to "+ Add another winnings", "#", class: "btn btn-default if-no-js-hide add-previous-winning"
-        .clear
         = f.submit "Save", class: "btn btn-primary pull-right"
 
 

--- a/app/views/admin/form_answers/company_details/_sic_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_sic_form.html.slim
@@ -17,7 +17,6 @@
                   collection: SICCode.collection,
                   include_blank: false,
                   label: false
-      .clear
       = f.submit "Save", class: "btn btn-primary form-save-link pull-right"
 
       = link_to "#", class: "form-edit-link pull-right"


### PR DESCRIPTION
This PR fixes position of save button on sic code editing form and also fixes the layout of the previous winning section, also editing form.

It also checks for a variable on the `handleCompanyDetailsForm`, which was causing error by being undefined and trying to perform a `replace`.