### PR TITLE
Security headers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,9 +6,13 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   # TODO: remove back once go live
-  # unless (Rails.env.test? || Rails.env.development?)
-  #   ensure_security_headers
-  # end
+  unless (Rails.env.test? || Rails.env.development?)
+    # Checking on ENV["AWS_ACCESS_KEY_ID"] exists
+    # In order to avoid exceptions on dev and demo servers too
+    # as they also use production env
+
+    ensure_security_headers if ENV["AWS_ACCESS_KEY_ID"]
+  end
 
   before_filter :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  ensure_security_headers if ENV['ENSURE_SECURITY_HEADERS']
+  ensure_security_headers if ENV["ENSURE_SECURITY_HEADERS"]
 
   before_filter :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,14 +5,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  # TODO: remove back once go live
-  unless (Rails.env.test? || Rails.env.development?)
-    # Checking on ENV["AWS_ACCESS_KEY_ID"] exists
-    # In order to avoid exceptions on dev and demo servers too
-    # as they also use production env
-
-    ensure_security_headers if ENV["AWS_ACCESS_KEY_ID"]
-  end
+  ensure_security_headers if ENV['ENSURE_SECURITY_HEADERS']
 
   before_filter :configure_permitted_parameters, if: :devise_controller?
 

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -8,6 +8,14 @@
   config.x_permitted_cross_domain_policies = "none"
   config.csp = {
     default_src: "https: inline eval",
-    img_src: "https:"
+    img_src: "https:",
+
+    # font_src - defines valid sources of fonts. (http://content-security-policy.com/)
+    # This is fix for "[Report Only] Refused to load the font ..."
+    # error message on Chrome/FF console
+    # By default, we do not specify a font-src which means the value
+    # should have taken the value of default-src ('none' in this case)
+    # Below we add "font-src data:;" to whitelist the font being loaded.
+    font_src: "'self' data:"
   }
 end


### PR DESCRIPTION
This is fix for "[Report Only] Refused to load the font ..." error message on Chrome/FF console
By default, we do not specify a font-src which means the value should have taken the value of default-src ('none' in this case)

Below we add "font-src data:;" to whitelist the font being loaded.
```
  config.csp = {
    default_src: "https: inline eval",
    img_src: "https:",
    font_src: "'self' data:" # font_src - defines valid sources of fonts. (http://content-security-policy.com/)
  }
```