### PR TITLE
BZSTAGING | No need to ask to reboot server on errors while deploy

### DIFF
--- a/config/deploy/bzstaging.rb
+++ b/config/deploy/bzstaging.rb
@@ -2,4 +2,4 @@ set :default_env, { 'RAILS_ENV' => 'bzstaging' }
 set :rails_env, 'bzstaging'
 set :branch, ENV["BRANCH"] || 'master'
 
-server '162.13.46.189', user: 'qae', roles: %w{web app db}
+server '162.13.46.189', user: 'qae', roles: %w{web app db bzstaging}


### PR DESCRIPTION
THIS applying only for BZSTAGING!
So we are often getting random "Allocate Memory" issues on deploy (a specially after number of deploys).
So solution is to reboot server after each deploy in order to reduce possible "Allocate memory" issues.
