### PR TITLE
Fixing autosave for upload questions

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -288,12 +288,12 @@ jQuery ->
   triggerAutosave = (e) ->
     window.autosave_timer ||= setTimeout( autosave, 500 )
 
-  $(".js-trigger-autosave").debounce "change", triggerAutosave, 50
-  $("input[type='text'].js-trigger-autosave").debounce "keyup", triggerAutosave, 50
-  $("input[type='number'].js-trigger-autosave").debounce "keyup", triggerAutosave, 50
-  $("input[type='url'].js-trigger-autosave").debounce "keyup", triggerAutosave, 50
-  $("input[type='tel'].js-trigger-autosave").debounce "keyup", triggerAutosave, 50
-  $("textarea.js-trigger-autosave").debounce "keyup", triggerAutosave, 50
+  $(document).debounce "change", ".js-trigger-autosave", triggerAutosave, 50
+  $(document).debounce "keyup", "input[type='text'].js-trigger-autosave", triggerAutosave, 50
+  $(document).debounce "keyup", "input[type='number'].js-trigger-autosave", triggerAutosave, 50
+  $(document).debounce "keyup", "input[type='url'].js-trigger-autosave", triggerAutosave, 50
+  $(document).debounce "keyup", "input[type='tel'].js-trigger-autosave", triggerAutosave, 50
+  $(document).debounce "keyup", "textarea.js-trigger-autosave", triggerAutosave, 50
 
   updateUploadListVisiblity = (list, button, max) ->
     list_elements = list.find("li")
@@ -398,7 +398,7 @@ jQuery ->
       if link
         div = $("<div>")
         label = $("<label>").text('Website address')
-        input = $("<input class=\"medium\" type=\"text\">").
+        input = $("<input class=\"medium js-trigger-autosave\" type=\"text\">").
           prop('name', "#{form_name}[#{name}][][link]")
         label.append(input)
         appendRemoveLinkForWebsiteLink(div)
@@ -426,7 +426,9 @@ jQuery ->
         desc_div = $("<div>")
         unique_name = "#{form_name}[#{name}][][description]"
         label = ($("<label>").text("Description").attr("for", unique_name))
-        label.append($("<textarea class='js-char-count' rows='2' maxlength='600' data-word-max='100'>").attr("name", unique_name).attr("id", unique_name))
+        label.append($("<textarea class='js-char-count js-trigger-autosave' rows='2' maxlength='600' data-word-max='100'>")
+             .attr("name", unique_name)
+             .attr("id", unique_name))
         desc_div.append(label)
         new_el.append(desc_div)
 
@@ -480,6 +482,7 @@ jQuery ->
       li.remove()
       updateUploadListVisiblity(list, button, max)
       reindexUploadListInputs(list)
+      triggerAutosave()
       false
 
   # Show current holder info when they are a current holder on basic eligibility current holder question

--- a/app/assets/javascripts/vendor/jquery-debounce.js
+++ b/app/assets/javascripts/vendor/jquery-debounce.js
@@ -14,8 +14,13 @@
   }
 
   $.extend($.fn, {
-    debounce: function(event, callback, delay) {
-      this.bind(event, debounce.apply(this, [callback, delay]));
+    debounce: function(event, selector, callback, delay) {
+      // where we use only three params
+      if (delay === undefined) {
+        this.bind(event, debounce.apply(this, [selector, callback]));
+      } else {
+        this.on(event, selector, debounce.apply(this, [callback, delay]));
+      }
     }
   });
 })(jQuery);

--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -30,14 +30,14 @@
                 | Remove
               label
                 ' Website address
-                input.large type="text" name=question.input_name(suffix: 'link', index: idx) value=question.input_value(suffix: 'link', index: idx)
+                input.large.js-trigger-autosave type="text" name=question.input_name(suffix: 'link', index: idx) value=question.input_value(suffix: 'link', index: idx)
           - if question.description
             div
               label for=question.input_name(suffix: 'description', index: idx)
                 span.label-char-count-reposition
                   ' Description
                 / (optional)
-              textarea.js-char-count rows="2" maxlength="600" data-word-max="100" name=question.input_name(suffix: 'description', index: idx) id=question.input_name(suffix: 'description', index: idx)
+              textarea.js-char-count.js-trigger-autosave rows="2" maxlength="600" data-word-max="100" name=question.input_name(suffix: 'description', index: idx) id=question.input_name(suffix: 'description', index: idx)
                 = question.input_value(suffix: 'description', index: idx)
 
   ul.errors-container


### PR DESCRIPTION
This PR fixes issue on Innovation Award and International Trade, where on upload questions texts were no saving (website address and descriptions).

To fix, the `debounce` function was modified to be overloaded, and pass a selector. This allows to listen for event on elements that are created after the page load (like on upload questions).

This is tested on Chrome, Firefox and on IE8.