### PR TITLE
Make all questions that add rows of data to trigger autosave

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -588,6 +588,8 @@ jQuery ->
           # remove the default reached class to allow removing again
           questionAddDefaultReached(question.find(".list-add"))
 
+          triggerAutosave()
+
   # Removing these added fields
   $(document).on "click", ".question-group .list-add .js-remove-link", (e) ->
     e.preventDefault()
@@ -611,7 +613,7 @@ jQuery ->
         $(this).closest("li").remove()
 
       questionAddDefaultReached(parent_ul)
-      autosave()
+      triggerAutosave()
 
   questionAddDefaultReached = (ul) ->
     if ul.size() > 0

--- a/app/views/qae_form/_award_fields.html.slim
+++ b/app/views/qae_form/_award_fields.html.slim
@@ -19,7 +19,7 @@ li.js-add-example class=(award.blank? ? "if-no-js-hide" : '') non-js-attribute=a
       label
         span.if-no-js-hide
           ' Award/personal honour title
-          input autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][title]" type="text" value=award['title'] data-dependable-option-siffix="title"
+          input.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][title]" type="text" value=award['title'] data-dependable-option-siffix="title"
 
         span.if-js-hide
           strong
@@ -35,7 +35,7 @@ li.js-add-example class=(award.blank? ? "if-no-js-hide" : '') non-js-attribute=a
         label
           span.if-no-js-hide
             ' Year
-            input autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][year]" type="text" value=award['year'] data-dependable-option-siffix="year"
+            input.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][year]" type="text" value=award['year'] data-dependable-option-siffix="year"
 
           span.if-js-hide
             strong
@@ -51,7 +51,7 @@ li.js-add-example class=(award.blank? ? "if-no-js-hide" : '') non-js-attribute=a
     label for="form[#{question.key}][#{index}][details]"
       span.label-char-count-reposition
         ' Details
-    textarea.award-textarea.js-char-count rows="2" name="form[#{question.key}][#{index}][details]" id="form[#{question.key}][#{index}][details]" data-word-max=question.details_words_max data-dependable-option-siffix="details" *possible_read_only_ops
+    textarea.award-textarea.js-char-count.js-trigger-autosave rows="2" name="form[#{question.key}][#{index}][details]" id="form[#{question.key}][#{index}][details]" data-word-max=question.details_words_max data-dependable-option-siffix="details" *possible_read_only_ops
       = award['details']
   span.if-js-hide
     br

--- a/app/views/qae_form/_position_fields.html.slim
+++ b/app/views/qae_form/_position_fields.html.slim
@@ -3,7 +3,7 @@ li.js-add-example
   = link_to "Remove", "#", class: "remove-link js-remove-link #{'read_only' if admin_in_read_only_mode?}"
   label
     ' Position/Role
-    input.medium name="form[position_details][#{index}][name]" value=position['name'] type="text" *possible_read_only_ops
+    input.medium.js-trigger-autosave name="form[position_details][#{index}][name]" value=position['name'] type="text" *possible_read_only_ops
   .validate-date-start-end
     span.row
       span.span-3
@@ -39,5 +39,5 @@ li.js-add-example
   label for="form[position_details][#{index}][details]"
     span.label-char-count-reposition
       ' Details
-  textarea.position-textarea.js-char-count rows="2" name="form[position_details][#{index}][details]" id="form[position_details][#{index}][details]" data-word-max=question.details_words_max
+  textarea.position-textarea.js-char-count.js-trigger-autosave rows="2" name="form[position_details][#{index}][details]" id="form[position_details][#{index}][details]" data-word-max=question.details_words_max
     = position['details']

--- a/app/views/qae_form/_queen_award_holder_question.html.slim
+++ b/app/views/qae_form/_queen_award_holder_question.html.slim
@@ -26,7 +26,7 @@ ul.list-add data-add-limit="10" data-need-to-clear-example=true data-default=1 i
       label
         span.visuallyhidden Category
         span.if-no-js-hide
-          select.inline name="form[queen_award_holder_details][#{index}][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+          select.inline.js-trigger-autosave name="form[queen_award_holder_details][#{index}][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
             option value=""
               ' Category
             - question.categories.each do |category|
@@ -39,7 +39,7 @@ ul.list-add data-add-limit="10" data-need-to-clear-example=true data-default=1 i
       label
         span.visuallyhidden Year Awarded
         span.if-no-js-hide
-          select.inline name="form[queen_award_holder_details][#{index}][year]" data-dependable-option-siffix="year" data-parent-option-dependable-key=question.key class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+          select.inline.js-trigger-autosave name="form[queen_award_holder_details][#{index}][year]" data-dependable-option-siffix="year" data-parent-option-dependable-key=question.key class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
             option value=""
               ' Year Awarded
             - question.years.each do |year|
@@ -57,7 +57,7 @@ ul.list-add data-add-limit="10" data-need-to-clear-example=true data-default=1 i
 
       label
         span.visuallyhidden Category
-        select.inline name="form[queen_award_holder_details][0][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+        select.inline.js-trigger-autosave name="form[queen_award_holder_details][0][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
           option value=""
             ' Category
           - question.categories.each do |category|
@@ -66,7 +66,7 @@ ul.list-add data-add-limit="10" data-need-to-clear-example=true data-default=1 i
 
       label
         span.visuallyhidden Year Awarded
-        select.inline name="form[queen_award_holder_details][0][year]" data-dependable-option-siffix="year" data-parent-option-dependable-key=question.key class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+        select.inline.js-trigger-autosave name="form[queen_award_holder_details][0][year]" data-dependable-option-siffix="year" data-parent-option-dependable-key=question.key class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
           option value=""
             ' Year Awarded
           - question.years.each do |year|

--- a/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
+++ b/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
@@ -23,7 +23,7 @@ ul.list-add data-add-limit="10" data-need-to-clear-example="true" data-default=1
           label.small
             .if-no-js-hide
               ' Name
-              input.medium type="text" name="#{question.input_name}[#{index}][name]" value=subsidiary["name"] autocomplete="off" *possible_read_only_ops
+              input.medium.js-trigger-autosave type="text" name="#{question.input_name}[#{index}][name]" value=subsidiary["name"] autocomplete="off" *possible_read_only_ops
             .if-js-hide
               strong Name
               br
@@ -35,7 +35,7 @@ ul.list-add data-add-limit="10" data-need-to-clear-example="true" data-default=1
           label.small
             .if-no-js-hide
               ' Location
-              input.medium type="text" name="#{question.input_name}[#{index}][location]" value=subsidiary["location"]  autocomplete="off" *possible_read_only_ops
+              input.medium.js-trigger-autosave type="text" name="#{question.input_name}[#{index}][location]" value=subsidiary["location"]  autocomplete="off" *possible_read_only_ops
             .if-js-hide
               strong Location
               br
@@ -47,7 +47,7 @@ ul.list-add data-add-limit="10" data-need-to-clear-example="true" data-default=1
           label.small
             .if-no-js-hide
               ' Number of UK Employees
-              input.small type="text" name="#{question.input_name}[#{index}][employees]" value=subsidiary["employees"]  autocomplete="off" *possible_read_only_ops
+              input.small.js-trigger-autosave type="text" name="#{question.input_name}[#{index}][employees]" value=subsidiary["employees"]  autocomplete="off" *possible_read_only_ops
             .if-js-hide
               strong Number of UK Employees
               br
@@ -64,15 +64,15 @@ ul.list-add data-add-limit="10" data-need-to-clear-example="true" data-default=1
         span.span-4
           label.small
             ' Name
-            input.medium type="text" name="#{question.input_name}[0][name]" autocomplete="off" *possible_read_only_ops
+            input.medium.js-trigger-autosave type="text" name="#{question.input_name}[0][name]" autocomplete="off" *possible_read_only_ops
         span.span-4
           label.small
             ' Location
-            input.medium type="text" name="#{question.input_name}[0][location]" autocomplete="off" *possible_read_only_ops
+            input.medium.js-trigger-autosave type="text" name="#{question.input_name}[0][location]" autocomplete="off" *possible_read_only_ops
         span.span-4
           label.small
             ' Number of UK Employees
-            input.small type="text" name="#{question.input_name}[0][employees]" autocomplete="off" *possible_read_only_ops
+            input.small.js-trigger-autosave type="text" name="#{question.input_name}[0][employees]" autocomplete="off" *possible_read_only_ops
       span.clear
 
 a.button.button-add.js-button-add.if-no-js-hide href="#"

--- a/app/views/qae_form/_supporter_fields.html.slim
+++ b/app/views/qae_form/_supporter_fields.html.slim
@@ -17,7 +17,7 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
         ' First Name
         ul.errors-container
         .clear
-        input.js-support-letter-first-name autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][first_name]" type="text" value=supporter["first_name"]
+        input.js-support-letter-first-name.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][first_name]" type="text" value=supporter["first_name"]
         span.visible-read-only = supporter["first_name"]
   span.clear
   span.row
@@ -26,7 +26,7 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
         ' Surname
         ul.errors-container
         .clear
-        input.js-support-letter-last-name autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][last_name]" type="text" value=supporter["last_name"]
+        input.js-support-letter-last-name.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][last_name]" type="text" value=supporter["last_name"]
         span.visible-read-only = supporter["last_name"]
   span.clear
   span.row
@@ -35,7 +35,7 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
         ' Relationship to Nominee
         ul.errors-container
         .clear
-        input.js-support-letter-relationship-to-nominee autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][relationship_to_nominee]" type="text" value=supporter["relationship_to_nominee"]
+        input.js-support-letter-relationship-to-nominee.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][relationship_to_nominee]" type="text" value=supporter["relationship_to_nominee"]
         span.visible-read-only = supporter["relationship_to_nominee"]
   span.clear
   span.row
@@ -56,7 +56,7 @@ li.js-add-example class="#{'read-only js-support-letter-received' if persisted}"
           ' Email address
           ul.errors-container
           .clear
-          input.js-support-letter-email autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][email]" type="text" value=supporter['email']
+          input.js-support-letter-email.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][#{index}][email]" type="text" value=supporter['email']
           span.visible-read-only = supporter['email']
   span.clear
   span.row

--- a/app/views/qae_form/_supporter_fields_placeholder.html.slim
+++ b/app/views/qae_form/_supporter_fields_placeholder.html.slim
@@ -9,7 +9,7 @@ li.js-add-example.hidden
         ' First Name
         ul.errors-container
         .clear
-        input.js-support-letter-first-name autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][{index}][first_name]" type="text" disabled=true
+        input.js-support-letter-first-name.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][{index}][first_name]" type="text" disabled=true
         span.visible-read-only
   span.clear
   span.row
@@ -18,7 +18,7 @@ li.js-add-example.hidden
         ' Surname
         ul.errors-container
         .clear
-        input.js-support-letter-last-name autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][{index}][last_name]" type="text" disabled=true
+        input.js-support-letter-last-name.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][{index}][last_name]" type="text" disabled=true
         span.visible-read-only
   span.clear
   span.row
@@ -27,7 +27,7 @@ li.js-add-example.hidden
         ' Relationship to Nominee
         ul.errors-container
         .clear
-        input.js-support-letter-relationship-to-nominee autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][{index}][relationship_to_nominee]" type="text" disabled=true
+        input.js-support-letter-relationship-to-nominee.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][{index}][relationship_to_nominee]" type="text" disabled=true
         span.visible-read-only
   span.clear
   span.row
@@ -44,7 +44,7 @@ li.js-add-example.hidden
           ' Email address
           ul.errors-container
           .clear
-          input.js-support-letter-email autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][{index}][email]" type="text" disabled=true
+          input.js-support-letter-email.js-trigger-autosave autocomplete="off" class="js-trigger-autosave medium" name="form[#{question.key}][{index}][email]" type="text" disabled=true
           span.visible-read-only
   span.clear
   span.row


### PR DESCRIPTION
This PR adds class to trigger autosave on all inputs on questions that add rows, like subsidiaries, award holders, etc.

The fix was tested on Chrome, Firefox and IE8