### PR TITLE
Financial data fixes

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -220,6 +220,13 @@ jQuery ->
 
   updateTurnoverExportCalculation()
 
+  replaceCommasInFinancialData = ->
+    $(document).on "change", "input.js-form-financial-data", ->
+      formatted_value = $(this).val().replace(/,/g, '')
+      $(this).val(formatted_value)
+
+  replaceCommasInFinancialData()
+
   # Show/hide the correct step/page for the award form
   showAwardStep = (step) ->
     $("body").removeClass("show-error-page")

--- a/app/helpers/financials_helper.rb
+++ b/app/helpers/financials_helper.rb
@@ -1,0 +1,6 @@
+module FinancialsHelper
+  def formatted_uk_sales_value(field)
+    val = field.to_s.split(".").last == "0" ? field.to_f.round(0) : field
+    number_with_delimiter(val)
+  end
+end

--- a/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
@@ -260,13 +260,13 @@ module CaseSummaryPdfs::General::DataPointer
   def render_base_growth_table
     rows = if @form_answer.trade?
       [
-        financial_pointer.growth_overseas_earnings_list.unshift("% Growth overseas earnings"),
-        financial_pointer.sales_exported_list.unshift("% Sales exported"),
-        financial_pointer.average_growth_for_list.unshift("% Sector average growth")
+        @growth_overseas_earnings_list.unshift("% Growth overseas earnings"),
+        @sales_exported_list.unshift("% Sales exported"),
+        @average_growth_for_list.unshift("% Sector average growth")
       ]
     else
       [
-        financial_pointer.growth_in_total_turnover_list.unshift("% Growth in total turnover")
+        @growth_in_total_turnover_list.unshift("% Growth in total turnover")
       ]
     end
 
@@ -280,11 +280,11 @@ module CaseSummaryPdfs::General::DataPointer
     rows = [
       [
         "Overall growth £[year 1 - #{financial_pointer.period_length}]",
-        financial_pointer.overall_growth
+        @overall_growth
       ],
       [
         "Overall growth %[year 1 - #{financial_pointer.period_length}]",
-        financial_pointer.overall_growth_in_percents
+        @overall_growth_in_percents
       ]
     ]
 

--- a/app/pdf_generators/case_summary_pdfs/pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/pointer.rb
@@ -50,24 +50,36 @@ class CaseSummaryPdfs::Pointer < ReportPdfFormAnswerPointerBase
 
       data_rows << if row[:uk_sales]
         row.values.flatten
-           .map { |field| field.to_i.to_s }
-           .unshift(I18n.t("#{LOCALE_PREFIX}.uk_sales_row.#{row.keys.first}"))
+           .map do |field|
+             formatted_uk_sales_value(field)
+           end.unshift(I18n.t("#{LOCALE_PREFIX}.uk_sales_row.#{row.keys.first}"))
       else
         row.values.flatten
-           .map { |field| field[:value] }
-           .unshift(I18n.t("#{LOCALE_PREFIX}.row.#{row.keys.first}"))
+           .map do |field|
+             ApplicationController.helpers.number_with_delimiter(field[:value])
+           end.unshift(I18n.t("#{LOCALE_PREFIX}.row.#{row.keys.first}"))
       end
     end
 
     data_rows
   end
 
+  def formatted_uk_sales_value(item)
+    ApplicationController.helpers.formatted_uk_sales_value(item)
+  end
+
+  def formatter_metrics(list)
+    list.map do |item|
+      formatted_uk_sales_value(item)
+    end
+  end
+
   def set_financial_benchmarks
-    @growth_overseas_earnings_list = financial_pointer.growth_overseas_earnings_list
-    @sales_exported_list = financial_pointer.sales_exported_list
-    @average_growth_for_list = financial_pointer.average_growth_for_list
-    @growth_in_total_turnover_list = financial_pointer.growth_in_total_turnover_list
-    @overall_growth = financial_pointer.overall_growth
-    @overall_growth_in_percents = financial_pointer.overall_growth_in_percents
+    @growth_overseas_earnings_list = formatter_metrics financial_pointer.growth_overseas_earnings_list
+    @sales_exported_list = formatter_metrics financial_pointer.sales_exported_list
+    @average_growth_for_list = formatter_metrics financial_pointer.average_growth_for_list
+    @growth_in_total_turnover_list = formatter_metrics financial_pointer.growth_in_total_turnover_list
+    @overall_growth = formatted_uk_sales_value financial_pointer.overall_growth
+    @overall_growth_in_percents = formatted_uk_sales_value financial_pointer.overall_growth_in_percents
   end
 end

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -54,6 +54,10 @@ module PdfAuditCertificates::General::SharedElements
     end
   end
 
+  def number_with_delimiter(val)
+    ApplicationController.helpers.number_with_delimiter(val)
+  end
+
   def financial_data(question_key, question_data)
     question_data.map do |entry|
       if entry.is_a?(Array)
@@ -61,7 +65,7 @@ module PdfAuditCertificates::General::SharedElements
       elsif entry.is_a?(Hash)
         data_by_type(question_key, entry)
       else # CALCULATED_DATA
-        "£#{entry.to_s}"
+        "£#{ApplicationController.helpers.formatted_uk_sales_value(entry)}"
       end
     end
   end
@@ -69,9 +73,9 @@ module PdfAuditCertificates::General::SharedElements
   def data_by_type(question_key, entry)
     if entry[:value].present?
       if NOT_CURRENCY_QUESTION_KEYS.include?(question_key)
-        entry[:value]
+        number_with_delimiter(entry[:value])
       else
-        "£#{entry[:value]}" if entry[:value] != "-"
+        "£#{number_with_delimiter(entry[:value])}" if entry[:value] != "-"
       end
     end
   end

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
@@ -33,11 +33,13 @@ module QaePdfForms::CustomQuestions::ByYear
 
   def render_years_table
     rows = if CALCULATED_FINANCIAL_DATA.include?(question.key)
-      get_audit_data(question.key).map(&:to_i).map(&:to_s)
+      get_audit_data(question.key).map do |field|
+        ApplicationController.helpers.formatted_uk_sales_value(field)
+      end
     else
       active_fields.map do |field|
-        entry = year_entry(field)
-        entry.present? ? entry.to_s.gsub(",", "") : IN_PROGRESS
+        entry = year_entry(field).to_s.gsub(",", "")
+        entry.present? ? ApplicationController.helpers.number_with_delimiter(entry) : IN_PROGRESS
       end
     end
 

--- a/app/views/admin/form_answers/financial_summary/_benchmarks.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_benchmarks.html.slim
@@ -20,23 +20,23 @@
           th % Growth overseas earnings
 
           - financial_pointer.growth_overseas_earnings_list.each do |entry|
-            td.value = entry
+            td.value = formatted_uk_sales_value(entry)
         tr.exports-percentage
           th % Sales exported
 
           - financial_pointer.sales_exported_list.each do |entry|
-            td.value = entry
+            td.value = formatted_uk_sales_value(entry)
         tr.sector-average-growth
           th % Sector average growth
 
           - financial_pointer.average_growth_for_list.each do |entry|
-            td = entry
+            td = formatted_uk_sales_value(entry)
       - else
         tr.turnover-growth
           th % Growth in total turnover
 
           - financial_pointer.growth_in_total_turnover_list.each do |entry|
-            td.value = entry
+            td.value = formatted_uk_sales_value(entry)
 
   label.avg-growth-legend = @form_answer.average_growth_legend([1,2,3])
 
@@ -48,8 +48,8 @@
       tr.overall-growth
         th
           'Overall growth £[year 1 - #{financial_pointer.period_length}]
-        td.value = financial_pointer.overall_growth
+        td.value = formatted_uk_sales_value(financial_pointer.overall_growth)
       tr.overall-growth-in-percents
         th
           ' Overall growth %[year 1 - #{financial_pointer.period_length}]
-        td.value = financial_pointer.overall_growth_in_percents
+        td.value = formatted_uk_sales_value(financial_pointer.overall_growth_in_percents)

--- a/app/views/admin/form_answers/financial_summary/_row.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_row.html.slim
@@ -3,5 +3,5 @@ tr class=(row.keys.first == 'overseas_sales' ? 'exports' : row.keys.first)
 
   - row.values.flatten.each do |field|
     td.value
-      span.form-value = field[:value]
+      span.form-value = number_with_delimiter(field[:value])
       = text_field_tag "financial_data[#{field[:name]}]", field[:value], class: 'form-control'

--- a/app/views/admin/form_answers/financial_summary/_uk_sales_row.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_uk_sales_row.html.slim
@@ -3,4 +3,4 @@ tr.uk-sales
 
   - row.values.flatten.each do |field|
     td.value
-      = field
+      = formatted_uk_sales_value(field)

--- a/app/views/qae_form/_by_years_question.html.slim
+++ b/app/views/qae_form/_by_years_question.html.slim
@@ -21,5 +21,5 @@
             span class="#{'currency-input' if question.type == :money}"
               - if question.type == :money
                 span.currency-unit £
-              input.small.js-trigger-autosave type="text" name=question.input_name(suffix: "#{y}of#{c.years}") value=question.input_value(suffix: "#{y}of#{c.years}").to_s.gsub(",", "") id=question.input_name(suffix: "#{y}of#{c.years}") autocomplete="off" *possible_read_only_ops
+              input.small.js-trigger-autosave.js-form-financial-data type="text" name=question.input_name(suffix: "#{y}of#{c.years}") value=question.input_value(suffix: "#{y}of#{c.years}").to_s.gsub(",", "") id=question.input_name(suffix: "#{y}of#{c.years}") autocomplete="off" *possible_read_only_ops
       .clear


### PR DESCRIPTION
Related to (Trello story)[https://trello.com/c/vxyIDS5X/84-financials-auto-calculation-a-problem-has-been-raised-on-the-live-application-site-that-affects-the-innovation-and-sustainable-d]

Updates:
1) Add commas separation to Admin Financial view
2) Check  I have found that if the “Save & continue” button is used to save the figures entered the commas remain. 
3) Remove decimal points from "UK Sales" on Admin Financial table