### PR TITLE
PDF FIXES

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
@@ -77,8 +77,14 @@ module QaePdfForms::CustomQuestions::ByYear
       financial_year_changed_dates_value.present? ? YEAR_ENDING_IN_PREFIX : ""
     end
 
-    financial_table_headers.map do |i|
-      "#{prefix} #{i}"
+    if form_pdf.pdf_blank_mode.present? # BLANK FOR MODE
+      financial_table_default_headers.map.with_index do |item, index|
+        financial_table_default_headers.size == (index + 1) ? "#{item} (Current)" : item
+      end
+    else
+      financial_table_headers.map do |i|
+        "#{prefix} #{i}"
+      end
     end
   end
 

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/supporter_lists.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/supporter_lists.rb
@@ -6,7 +6,7 @@ module QaePdfForms::CustomQuestions::SupporterLists
       form_answer.supporters
     end
 
-    if entries.present?
+    if entries.present? && form_pdf.pdf_blank_mode.blank?
       render_supporters_list(entries)
     else
       form_pdf.render_nothing_uploaded_message

--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -90,7 +90,7 @@ module QaePdfForms::General::DrawElements
     indent 32.mm do
       render_urn if form_answer.urn.present?
       render_award_information
-      render_company_name
+      render_company_name unless pdf_blank_mode.present?
     end
 
     move_down 15.mm

--- a/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
@@ -276,10 +276,13 @@ class QaePdfForms::General::QuestionPointer
 
   def render_option_branching_info(child_condition)
     text = question.conditional_hint(child_condition, questions_with_references)
-    form_pdf.render_text text,
-                         color: "999999",
-                         style: :italic,
-                         size: 10
+
+    if text.present?
+      form_pdf.render_text text,
+                           color: "999999",
+                           style: :italic,
+                           size: 10
+    end
   end
 
   def question_block_type(question)

--- a/lib/qae_form_builder/question.rb
+++ b/lib/qae_form_builder/question.rb
@@ -242,15 +242,24 @@ class QAEFormBuilder
 
     def generate_hint(option_name, dependencies)
       if delegate_obj.form.title == "Sustainable Development Award Application" && delegate_obj.ref.to_s == "A 8"
-        # Yeah, it's hardcoded by client request:
+        # Hardcoded condition by client request:
         #
         # "Please change Sustainable Development note in question A8 'If Yes, please answer the questions A8.1 and B7'
         # to 'If Yes, please answer both parts of question A8.1 and B7' from the print out."
-        # If it would be more cases like this - then need to try code that on conditions
         #
-        # For now, hardcoding
         "If #{option_name}, please answer both parts of question A8.1 and B7"
+
+      elsif delegate_obj.form.title == "International Trade Award Application" &&
+            delegate_obj.ref.to_s == "A 1" &&
+            option_name.to_s == "Organisation"
+        # Hardcoded condition by client request:
+        #
+        # On International Trade, Question A1 please can you remove note 'if organisation,
+        # please answer the questions C4' from the print out.
+        #
+        # Nothing
       else
+        # Normal behavior
         "If #{option_name}, please answer the questions #{dependencies.to_sentence}"
       end
     end

--- a/lib/qae_form_builder/question.rb
+++ b/lib/qae_form_builder/question.rb
@@ -237,7 +237,22 @@ class QAEFormBuilder
         res.delete(' ')
       end
 
-      "If #{option_name}, please answer the questions #{dependencies.to_sentence}"
+      generate_hint(option_name, dependencies)
+    end
+
+    def generate_hint(option_name, dependencies)
+      if delegate_obj.form.title == "Sustainable Development Award Application" && delegate_obj.ref.to_s == "A 8"
+        # Yeah, it's hardcoded by client request:
+        #
+        # "Please change Sustainable Development note in question A8 'If Yes, please answer the questions A8.1 and B7'
+        # to 'If Yes, please answer both parts of question A8.1 and B7' from the print out."
+        # If it would be more cases like this - then need to try code that on conditions
+        #
+        # For now, hardcoding
+        "If #{option_name}, please answer both parts of question A8.1 and B7"
+      else
+        "If #{option_name}, please answer the questions #{dependencies.to_sentence}"
+      end
     end
   end
 


### PR DESCRIPTION
Bunch of PDF fixes related to:

1) (Blank PDF Version story)[https://trello.com/c/e4Eny0s3/267-blank-form-not-blank]
```
I have tested the blank form download and found that with all categories both with submitted entries and those still in progress the application/nomination name still appears in the download at the top of page one. Additionally for the corporate ones although the figures do not show, the dates do.

With the QAEP it is support request details that show as well as the nominee name on the front page.
```

and 

(Form print outs not showing all questions when printed story)[https://trello.com/c/wDMxGuiA/232-form-print-outs-not-showing-all-questions-when-printed]
```
On International Trade, Question A1 please can you remove note 'if organisation, please answer the questions C4' from the print out.

Please change Sustainable Development note in question A8 'If Yes, please answer the questions A8.1 and B7' to 'If Yes, please answer both parts of question A8.1 and B7' from the print out.

```