### PR TITLE
Remove links from audit certificate email

### DIFF
--- a/app/views/users/audit_certificate_request_mailer/notify.html.slim
+++ b/app/views/users/audit_certificate_request_mailer/notify.html.slim
@@ -6,15 +6,10 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' We're emailing to remind you that you have until
   => @deadline
-  ' to
-  = link_to "upload your completed Audit Certificate here.", users_form_answer_audit_certificate_url(@form_answer)
+  ' to upload your completed Audit Certificate.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' If you don't submit your Audit Certificate before the deadline, we will not have sufficient information to assess your application and it will most likely be withdrawn.
-
-p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' You can
-  = link_to "download a blank copy of the Audit Certificate here.", users_form_answer_audit_certificate_url(@form_answer)
 
 p style="font-weight: 700; font-size: 19px; line-height: 1.315789474; margin: 38px 0 38px 0;"
   ' Thank you,

--- a/app/views/users/audit_certificate_request_mailer/notify.text.slim
+++ b/app/views/users/audit_certificate_request_mailer/notify.text.slim
@@ -4,13 +4,9 @@
 
 ' We're emailing to remind you that you have until
 => @deadline
-' to
-= link_to "upload your completed Audit Certificate here.", users_form_answer_audit_certificate_url(@form_answer)
+' to upload your completed Audit Certificate.
 
 ' If you don't submit your Audit Certificate before the deadline, we will not have sufficient information to assess your application and it will most likely be withdrawn.
-
-' You can
-= link_to "download a blank copy of the Audit Certificate here.", users_form_answer_audit_certificate_url(@form_answer)
 
 ' Thank you,
 


### PR DESCRIPTION
I've removed the links from the audit certificate email and changed the copy.

I couldn't test because I couldn't get the emails to trigger. Otherwise it would've been better to fix the links.