### PR TITLE
Fixing login issue on some versions of IE

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -313,11 +313,11 @@ jQuery ->
   loseChangesMessage = "You have unsaved changes! If you leave the page now, some answers will be lost. Stay on the page for a minute in order for everything to be saved or use the buttons at the bottom of the page."
 
   window.onbeforeunload = ->
-    if changesUnsaved then loseChangesMessage else null
+    if changesUnsaved then loseChangesMessage else undefined
 
   if window.addEventListener isnt undefined
     window.addEventListener "beforeunload", (e) ->
-      return null unless changesUnsaved
+      return undefined unless changesUnsaved
 
       e.returnValue = loseChangesMessage
       loseChangesMessage


### PR DESCRIPTION
Issue was in the return of the event handler which warns the user when leaving page with changes unsaved.

When no message was supposed to be displayed, it was returning false, which was causing some issues with some versions of IE. Changed to undefined and tested everything again.