### PR TITLE
Fixes for org chart uploads

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: passenger start
+web: passenger start -p 3001

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -487,7 +487,7 @@ jQuery ->
       list.removeClass('visuallyhidden')
       updateUploadListVisiblity(list, button, max)
       reindexUploadListInputs(list)
-      triggerAutosave()
+      autosave()
 
     updateUploadListVisiblity(list, button, max)
 

--- a/app/models/form_answer_attachment.rb
+++ b/app/models/form_answer_attachment.rb
@@ -62,10 +62,10 @@ class FormAnswerAttachment < ActiveRecord::Base
     # possible improvements:
     # - validating all upload questions in this way
     # - smart collecting max-attachments information from the form structure
-    if question_key == "org_chart" && new_record?
-      if self.class.where(question_key: question_key, form_answer_id: form_answer_id).count > 0
-        errors.add(:base, "Maximum amount of these kind of files reached.")
-      end
-    end
+    # if question_key == "org_chart" && new_record?
+    #   if self.class.where(question_key: question_key, form_answer_id: form_answer_id).count > 0
+    #     errors.add(:base, "Maximum amount of these kind of files reached.")
+    #   end
+    # end
   end
 end

--- a/app/models/form_answer_attachment.rb
+++ b/app/models/form_answer_attachment.rb
@@ -62,10 +62,10 @@ class FormAnswerAttachment < ActiveRecord::Base
     # possible improvements:
     # - validating all upload questions in this way
     # - smart collecting max-attachments information from the form structure
-    # if question_key == "org_chart" && new_record?
-    #   if self.class.where(question_key: question_key, form_answer_id: form_answer_id).count > 0
-    #     errors.add(:base, "Maximum amount of these kind of files reached.")
-    #   end
-    # end
+    if question_key == "org_chart" && new_record?
+      if self.class.where(question_key: question_key, form_answer_id: form_answer_id).count > 0
+        errors.add(:base, "Maximum amount of these kind of files reached.")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds code to help on the org chart upload issue.
The issue is a race condition that happens between saving the file and the form with the reference to the file.
So in this scenario, the file is there, but lost, no one referenciing it.

This branch insted of triggering the autosave function, actually autosaves immediately after getting success response from backend, making browsers wait till saved before the user try to navigate out of the form.

This branch also removes the validation on org chart to allow multiple files to exist (the frontend doesn't allow more uploads though).