### PR TITLE
replace old chart if the unique attachment condition is not achieved

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -219,6 +219,10 @@ class FormController < ApplicationController
     @attachment.attachable = current_user
     @attachment.question_key = params[:question_key] if params[:question_key].present?
 
+    if @attachment.question_key == "org_chart"
+      @form_answer.form_answer_attachments.where(question_key: "org_chart").destroy_all
+    end
+
     if @attachment.save
       # text/plain content type is needed for jquery.fileupload
       render json: @attachment, status: :created, content_type: "text/plain"


### PR DESCRIPTION
this is to avoid the issue where the attachment has been saved but the form_answer document hasn't. 
With this modification, you can upload the attachment again.