### PR TITLE
Fixing leave popup issue on submitting form

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -262,6 +262,14 @@ jQuery ->
 
   changesUnsaved = false
 
+  $(".qae-form").on "submit", (e) ->
+    if changesUnsaved
+      e.preventDefault()
+      e.stopPropagation()
+
+      autosave ->
+        $(".qae-form").trigger("submit")
+
   $(document).on "click", ".js-step-link", (e) ->
     e.preventDefault()
     if !$(this).hasClass("step-current")


### PR DESCRIPTION
Title pretty much says it all.

This PR fixes issue when submitting form, which is a special case, similar to "save and come back later".
Tested on IE8+, Chrome, firefox, Opera and safari