### PR TITLE
now the document is saved when an attachment is uploaded

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -487,7 +487,6 @@ jQuery ->
       list.removeClass('visuallyhidden')
       updateUploadListVisiblity(list, button, max)
       reindexUploadListInputs(list)
-      triggerAutosave()
 
     updateUploadListVisiblity(list, button, max)
 

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -227,7 +227,7 @@ class FormController < ApplicationController
 
       if @attachment.save
         attachments_hash = @form_answer.document[@attachment.question_key]
-        index = last_key(attachments_hash)
+        index = next_index(attachments_hash)
         attachments_hash[index] = { file: @attachment.id }
         @form_answer.save!
 
@@ -245,7 +245,7 @@ class FormController < ApplicationController
 
   private
 
-  def last_key(hash)
+  def next_index(hash)
     return 0 if hash.empty?
     return hash.keys.sort.last.to_i + 1
   end

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -1,5 +1,13 @@
 namespace :form_answers do
 
+  desc 'fixes missing org_chart from document'
+  task fix_missing_org_chart: :environment do
+    FormAnswerAttachment.where(question_key: "org_chart").find_each do |attachment|
+      attachment.form_answer.document["org_chart"] = { "0" => { "file" => attachment.id } }
+      attachment.form_answer.save!
+    end
+  end
+
   desc 'Adds search indexed data'
   task refresh_search_indexes: :environment do
     FormAnswer.find_each do |f|


### PR DESCRIPTION
ok, this is not what I said I would do. 
But removing every trace of the attachment from the document proved to be very hard and I don't think it's the best solution anymore. 

This are some examples of why I no longer think what I've said is the best idea:

* The max number of attachments + links validation, proves that in some cases it's better to have links and attachment tied together.
* Some attachments need a "description". If I moved it to the FormAttachment, it would be empty when it's not needed, and the document content would be scattered between different objects. But If I kept it in the document, then the lifecycle of the attachment and its description could diverge (the same issue we have now, but only for the description)

So In short, I think it's OK to have the attachment as a simple list that is pointed by the document inside its specific structure.

So, what I've done is to move the saving process of the attachment info to the same method of the controller that uploads the attachment: Wrapped inside a transaction, it's impossible for a FormAttachment to be uploaded without updating its FormAnswer.
