### PR TITLE
Nominee name data migration task for FormAnswers

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -233,7 +233,8 @@ class FormAnswer < ActiveRecord::Base
   def assign_searching_attributes
     unless submitted_and_after_the_deadline?
       self.company_or_nominee_name = company_or_nominee_from_document
-     end
+    end
+
     self.nominee_full_name = nominee_full_name_from_document
     self.nominator_full_name = nominator_full_name_from_document
     self.nominator_email = nominator_email_from_document

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -80,24 +80,6 @@ namespace :form_answers do
     end
   end
 
-  desc "Populate the form progresses"
-  # Remove after use - it assumes that progress set up before save
-  task populate_form_answer_progresses: :environment do
-    output = {
-      saved: [],
-      not_saved: []
-    }
-    FormAnswer.find_each do |f|
-      if f.save
-        output[:saved] << f.id
-      else
-        output[:not_saved] << f.id
-      end
-    end
-
-    p "Saved: #{output[:saved].size}; not saved: #{output[:not_saved].inspect}"
-  end
-
   desc "Resaves company_or_nominee_name field"
   task resave_company_or_nominee_name: :environment do
     FormAnswer.find_each do |f|

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -83,7 +83,14 @@ namespace :form_answers do
   desc "Resaves company_or_nominee_name field"
   task resave_company_or_nominee_name: :environment do
     FormAnswer.find_each do |f|
-      f.update_column(:company_or_nominee_name, f.company_or_nominee_from_document)
+      args = {
+        company_or_nominee_name: f.company_or_nominee_from_document,
+        nominee_full_name: f.nominee_full_name_from_document,
+        nominator_full_name: f.send(:nominator_full_name_from_document),
+        nominator_email: f.send(:nominator_email_from_document)
+      }
+
+      f.update_columns(args)
     end
   end
 end

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -97,4 +97,11 @@ namespace :form_answers do
 
     p "Saved: #{output[:saved].size}; not saved: #{output[:not_saved].inspect}"
   end
+
+  desc "Resaves company_or_nominee_name field"
+  task resave_company_or_nominee_name: :environment do
+    FormAnswer.find_each do |f|
+      f.update_column(:company_or_nominee_name, f.company_or_nominee_from_document)
+    end
+  end
 end


### PR DESCRIPTION
Also removed legacy rake task that said "Remove after use" 