### PR TITLE
Attachment error fix

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -226,6 +226,7 @@ class FormController < ApplicationController
       end
 
       if @attachment.save
+        @form_answer.document[@attachment.question_key]  ||= []
         attachments_hash = @form_answer.document[@attachment.question_key]
         index = next_index(attachments_hash)
         attachments_hash[index] = { file: @attachment.id }


### PR DESCRIPTION
fixed scenario: Attachments not being added when the related document hash is empty.

It caused an additional issue with the VirusScanner service.
It was rollbacking the FormAnswerAttachment, but the scan request was already sent, so it was being executed.
During the virus scanner callback, it produced another issue because the Scan related to the attachment was never commited to the db.
