### PR TITLE
[Assessor] should have ability to update financials

### DIFF
--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -14,22 +14,6 @@ class Admin::FormAnswersController < Admin::BaseController
                                    .includes(:comments)
   end
 
-  def update_financials
-    authorize @form_answer, :update_financials?
-    @form_answer.financial_data = financial_data_ops
-    @form_answer.save
-
-    if request.xhr?
-      head :ok, content_type: "text/html"
-
-      return
-    else
-      flash.notice = "Financial data updated"
-      redirect_to action: :show
-      return
-    end
-  end
-
   private
 
   helper_method :resource,
@@ -40,17 +24,5 @@ class Admin::FormAnswersController < Admin::BaseController
 
   def resource
     @form_answer ||= load_resource
-  end
-
-  def load_resource
-    @form_answer = FormAnswer.find(params[:id]).decorate
-  end
-
-  def financial_data_ops
-    {
-      updated_at: Time.zone.now,
-      updated_by_id: current_admin.id,
-      updated_by_type: current_admin.class
-    }.merge(params[:financial_data])
   end
 end

--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -1,6 +1,8 @@
 class Assessor::FormAnswersController < Assessor::BaseController
   include FormAnswerMixin
 
+  before_filter :load_resource, only: [:update_financials]
+
   helper_method :resource,
                 :primary_assessment,
                 :secondary_assessment,

--- a/app/controllers/concerns/form_answer_mixin.rb
+++ b/app/controllers/concerns/form_answer_mixin.rb
@@ -29,6 +29,22 @@ module FormAnswerMixin
     end
   end
 
+  def update_financials
+    authorize @form_answer, :update_financials?
+    @form_answer.financial_data = financial_data_ops
+    @form_answer.save
+
+    if request.xhr?
+      head :ok, content_type: "text/html"
+
+      return
+    else
+      flash.notice = "Financial data updated"
+      redirect_to action: :show
+      return
+    end
+  end
+
   def show
     authorize resource, :show?
   end
@@ -84,5 +100,17 @@ module FormAnswerMixin
     else
       authorize resource, :update?
     end
+  end
+
+  def load_resource
+    @form_answer = FormAnswer.find(params[:id]).decorate
+  end
+
+  def financial_data_ops
+    {
+      updated_at: Time.zone.now,
+      updated_by_id: pundit_user.id,
+      updated_by_type: pundit_user.class
+    }.merge(params[:financial_data])
   end
 end

--- a/app/views/admin/form_answers/financial_summary/_list.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_list.html.slim
@@ -1,5 +1,7 @@
+- url = pundit_user.is_a?(Admin) ? update_financials_admin_form_answer_path(@form_answer) : update_financials_assessor_form_answer_path(@form_answer)
+
 .form-group
-  = form_for @form_answer, url: update_financials_admin_form_answer_path(@form_answer) do |f|
+  = form_for @form_answer, url: url do |f|
     .table-overflow-container
       table.table.table-striped#financial-table
         colgroup

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,7 +160,10 @@ Rails.application.routes.draw do
         end
       end
 
-      member { get(:review) }
+      member do
+        patch :update_financials
+        get :review
+      end
       resources :draft_notes, only: [:create, :update]
     end
     resources :assessor_assignments, only: [:update]


### PR DESCRIPTION
[Trello Story](https://trello.com/c/pJB5aig7/188-assessor-view-form-answer-details-page-update-financials-unauthorized-error-on-attempt-to-update-financials)

If you are logged as Assessor and try to update financials - changes doesn't apply to "FInancial Table".
In log I see:

```
Started PATCH "/admin/form_answers/14/update_financials" for 127.0.0.1 at 2015-09-28 19:38:24 +0300
Processing by Admin::FormAnswersController#update_financials as */*
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"HWNp6pC87s4tZ6NIGLxNBGMEpeJp22YADWbn5hnxx3DRNMeF0PK6JK0RmNo68kp2HeHGDaVyGOgsUyWNhifcgQ==", "financial_data"=>{"employees_1of2"=>"12", "employees_2of2"=>"22", "total_turnover_1of2"=>"1000000", "total_turnover_2of2"=>"1000000", "exports_1of2"=>"500000", "exports_2of2"=>"500000", "net_profit_1of2"=>"1000000", "net_profit_2of2"=>"1000000", "total_net_assets_1of2"=>"1000000", "total_net_assets_2of2"=>"1000000"}, "id"=>"14"}
Completed 401 Unauthorized in 1ms (ActiveRecord: 0.0ms)
```