### PR TITLE
Allow collaborators to submit the application form

### DIFF
--- a/app/controllers/account/base_controller.rb
+++ b/app/controllers/account/base_controller.rb
@@ -4,13 +4,4 @@ class Account::BaseController < ApplicationController
   before_action :restrict_access_if_admin_in_read_only_mode!, only: [
     :new, :create, :update, :destroy
   ]
-
-  private
-
-  def require_to_be_account_admin!
-    unless current_user.account_admin?
-      redirect_to root_path,
-                  notice: "Access denied!"
-    end
-  end
 end

--- a/app/controllers/account/base_controller.rb
+++ b/app/controllers/account/base_controller.rb
@@ -4,4 +4,13 @@ class Account::BaseController < ApplicationController
   before_action :restrict_access_if_admin_in_read_only_mode!, only: [
     :new, :create, :update, :destroy
   ]
+
+  private
+
+  def require_to_be_account_admin!
+    unless current_user.account_admin?
+      redirect_to root_path,
+                  notice: "Access denied!"
+    end
+  end
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,8 +1,8 @@
 module FormHelper
-  def possible_read_only_ops(submission=nil)
+  def possible_read_only_ops
     ops = {}
 
-    if admin_in_read_only_mode? || (submission && !current_user.account_admin?) || submission_ended?
+    if admin_in_read_only_mode? || submission_ended?
       ops[:disabled] = "disabled"
       ops[:class] = "read-only"
     end

--- a/app/views/qae_form/_form_footer.html.slim
+++ b/app/views/qae_form/_form_footer.html.slim
@@ -25,7 +25,7 @@ footer
       - else
         - if step.submit
           li.submit.qae-form
-            button type="submit" name="submit" value="true" class="button #{step.submit.style.presence}" *possible_read_only_ops(true)
+            button type="submit" name="submit" value="true" class="button #{step.submit.style.presence}"
               = step.submit.text
 
       - if !admin_in_read_only_mode? && !submission_ended?


### PR DESCRIPTION
We have a number of support requests due to the fact that collaborators cannot submit the form, only an admin can.

This reverts the work done to restrict the submission to admins, so that collaborators can submit. We will need to have a wider review of the collaborator role after the submission deadline (today).