### PR TITLE
Stats

### DIFF
--- a/app/controllers/form_award_eligibilities_controller.rb
+++ b/app/controllers/form_award_eligibilities_controller.rb
@@ -57,6 +57,7 @@ class FormAwardEligibilitiesController < ApplicationController
         if @eligibility.eligible_on_step?(step)
           redirect_to next_wizard_path(form_id: @form_answer.id, skipped: false)
         else
+          @form_answer.state_machine.perform_transition("not_eligible", nil, false) unless @form_answer.not_eligible?
           redirect_to action: :show, form_id: @form_answer.id
         end
       else

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -1,5 +1,12 @@
 namespace :form_answers do
 
+  desc "fixes eligibility inconsistencies"
+  task fix_eligibility: :environment do
+    FormAnswer.find_each do |f|
+      f.state_machine.perform_transition("not_eligible", nil, false) unless f.eligible?
+    end
+  end
+
   desc "fixes attachment arrays"
   task fix_attachments: :environment do
     FormAnswer.find_each do |f|


### PR DESCRIPTION
Modified eligibility process to transitionate to "not_eligible".
Created a rake task to take all the non-eligible (calculated in the moment) form_answers and transitionates to "not_eligible"

This PR could be wrong IF:
- There were some rules about what was eligible and what was not. And those rules have changed.
- The logic we use in the model diverge from what the controller actually does.

This could be possible since the model uses 
```
  def eligible?
    eligibility && eligibility.eligible? && (promotion? || (form_basic_eligibility && form_basic_eligibility.eligible?))
  end
```
While the controller uses
```
    builder = FormAnswer::AwardEligibilityBuilder.new(@form_answer)
    @award_eligibility = builder.eligibility
    @basic_eligibility =  builder.basic_eligibility
```

