### PR TITLE
PDF questionnaire change request

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/general/step_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/step_pointer.rb
@@ -14,6 +14,15 @@ class QaePdfForms::General::StepPointer
       FormPdf::HIDDEN_QUESTIONS.include?(question.key.to_s)
     end
 
+    # When we are displaying only visible questions (in accordance with conditions) use:
+    #
+    # @filtered_questions = step_questions.select do |question|
+    #   award_form[question.key].visible?
+    # end
+    #
+    # If need to show all questions use:
+    # @filtered_questions = step_questions
+
     @filtered_questions = step_questions.select do |question|
        award_form[question.key].visible?
     end


### PR DESCRIPTION
PDF questionnaire change request
[Trello Story](https://trello.com/c/ybhKQDNv/163-issue-with-conditional-questions-pdf)

```
On the Live site an error has been identified by an applicant (Environmental Crop Management Ltd – a Sustainable Development category).

He originally answered Question A8 as ‘Yes’ and then as per the correct system instructions he answered question A8.1 and B7. However, he then changed his answer to QA8 to “No”, and therefore the online screen entry does not show his Questions A8.1 and B7 original answers, which is why he cannot delete the his original answer to Question B7 (which is what he wanted to do). But when the pdf of the entry is downloaded, Question A8 reflects the amended answer of “No” but it also displays the original answers to QA8.1 & B7.

This is very confusing as the pdf should be a match of the online screen answers. It is also going to be confusing for the assessors.

I also then looked at one of my test applications in staging (QA0019/16S) and this was one where I filled in Question C4 originally as “A single product or service” and the system correctly asked me to answer Questions C6.1 to C6.7. However, I then changed my mind and changed the answer to QC4 to ‘The entire business’. The on screen correctly does not show questions C6.1 to C6.7 but when the pdf is downloaded it shows the answers to C6.1 to C6.7.

This issue with the pdf needs to be addressed urgently please.
```