### PR TITLE
Previous wins fixes

### DIFF
--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -79,14 +79,13 @@ class FormAnswerDecorator < ApplicationDecorator
         new_array = attributes[key]
         old_array = object.document[key]
 
-        if new_array.length < old_array.length
-          old_array.slice!(new_array.length, old_array.length)
-        else
-          old_array.push *Array.new(new_array.length - old_array.length, {})
+        new_array.each do |index, value|
+          if index.to_i < old_array.length
+            old_array[index.to_i].merge! value
+          else
+            old_array << value
+          end
         end
-
-        new_array.each{ |index, value| old_array[index.to_i].merge! value }
-
         old_array.reject!{|i| i.include? "_destroy" }
       end
     end

--- a/app/helpers/form_answer_helper.rb
+++ b/app/helpers/form_answer_helper.rb
@@ -45,6 +45,14 @@ module FormAnswerHelper
     FormAnswerDecorator::SELECT_BOX_LABELS.invert.to_a
   end
 
+  def each_index_or_empty(collection, attrs, &block)
+    if collection.any?
+      collection.each_with_index &block
+    else
+      block.(attrs, 0)
+    end
+  end
+
   def sic_code(form_answer)
     code = form_answer.sic_code
     code || "-"

--- a/app/views/admin/form_answers/company_details/previous_wins/_form.html.slim
+++ b/app/views/admin/form_answers/company_details/previous_wins/_form.html.slim
@@ -9,7 +9,7 @@
 
     .input.form-group.form-fields.form-block
       ul.list-add
-        - @form_answer.document["queen_award_holder_details"].each_with_index do |win, index|
+        - each_index_or_empty(@form_answer.document["queen_award_holder_details"], {"category" => nil, "year" => nil }) do |win, index|
           li.well.duplicatable-nested-form
             .pull-right
               = link_to "Remove", "#", class: "if-no-js-hide remove-link"


### PR DESCRIPTION
It solves 2 issues related to the previous year award administration.
1. it is the one detected by the client: when you have no previous award but you try to create a new one.
2. when you create more than 1 award at a time, the data wasn't being stored properly