### PR TITLE
[Primary Assessor] should be able to edit 'Previous Wins' and 'Sic Code'

### DIFF
--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -17,7 +17,7 @@ class FormAnswerPolicy < ApplicationPolicy
   end
 
   def update_item?(item)
-    admin? || (subject.lead?(record) && [:previous_wins, :sic_code].include?(item))
+    admin? || ((subject.lead?(record) || subject.primary?(record)) && [:previous_wins, :sic_code].include?(item))
   end
 
   def can_update_by_admin_lead_and_primary_assessors?


### PR DESCRIPTION
Related to stories:

1) [Previous Winnings - Assessor Screen (for the three Corporate categories)in](https://trello.com/c/djCvnxvN/120-previous-winnings-assessor-screen-for-the-three-corporate-categories)

2) [SIC - Assessor Screen (for the three Corporate categories)](https://trello.com/c/1grk7WUb/121-sic-assessor-screen-for-the-three-corporate-categories)