### PR TITLE
display country name rather than ISO code in CSV reports

### DIFF
--- a/app/models/reports/all_entries.rb
+++ b/app/models/reports/all_entries.rb
@@ -116,6 +116,10 @@ class Reports::AllEntries
       method: :unit_website
     },
     {
+      label: "ImmediateParentName",
+      method: :immediate_parent_name
+    },
+    {
       label: "ImmediateParentCountry",
       method: :immediate_parent_country
     },

--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -124,7 +124,12 @@ module Reports::DataPickers::FormDocumentPicker
   end
 
   def immediate_parent_country
-    doc("parent_company_country")
+    country_code = doc("parent_company_country")
+
+    if country_code
+      country = ISO3166::Country[country_code]
+      country.name
+    end
   end
 
   def organisation_with_ultimate_control_country
@@ -235,8 +240,8 @@ module Reports::DataPickers::FormDocumentPicker
     bool(obj.document["corp_responsibility_form"].to_s == "declare_now")
   end
 
-  def immediate_parent
-    doc("parent_group_entry")
+  def immediate_parent_name
+    doc("parent_company")
   end
 
   def doc(key)

--- a/app/models/reports/press_book_list.rb
+++ b/app/models/reports/press_book_list.rb
@@ -79,8 +79,8 @@ class Reports::PressBookList
       method: :unit_website
     },
     {
-      label: "ImmediateParent",
-      method: :immediate_parent
+      label: "ImmediateParentName",
+      method: :immediate_parent_name
     },
     {
       label: "ImmediateParentCountry",

--- a/spec/features/admin/form_answers/generation_of_csv_reports_spec.rb
+++ b/spec/features/admin/form_answers/generation_of_csv_reports_spec.rb
@@ -45,7 +45,7 @@ describe "Admin generates the CSV reports" do
     let(:id) { "press-book-list" }
     it "produces proper output" do
       expect(output.size).to eq(2)
-      expect(output[1][-2]).to eq("GB")
+      expect(output[1][-2]).to eq("United Kingdom")
       expect(output[1][-4]).to eq("example.com")
     end
   end


### PR DESCRIPTION
add missing immediat parent company name to the Entries report