### PR TITLE
Primary assessor permissions

### DIFF
--- a/app/helpers/partials_visibility_helper.rb
+++ b/app/helpers/partials_visibility_helper.rb
@@ -5,7 +5,7 @@ module PartialsVisibilityHelper
   end
 
   def show_section_appraisal_moderated?
-    current_subject.lead?(@form_answer)
+    policy(@form_answer).show_section_appraisal_moderated?
   end
 
   def show_winners_section?

--- a/app/models/assessor_assignment.rb
+++ b/app/models/assessor_assignment.rb
@@ -92,6 +92,7 @@ class AssessorAssignment < ActiveRecord::Base
   def owner_or_administrative?(subject)
     subject.is_a?(Admin) ||
       subject.try(:lead?, form_answer) ||
+      (case_summary? && subject.try(:primary?, form_answer)) ||
       (!moderated? && !case_summary? && assessor_id == subject.id)
   end
 

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -3,6 +3,11 @@ class FormAnswerPolicy < ApplicationPolicy
     admin? || assessor?
   end
 
+  def show_section_appraisal_moderated?
+    subject.lead?(record) ||
+      (record.assessor_assignments.moderated.submitted? && subject.primary?(record))
+  end
+
   def review?
     return true if admin?
     subject.lead_or_assigned?(record)


### PR DESCRIPTION
Allow primary assessors:
- see the moderated appraisal after moderated appraisal submission
- edit the case summary