### PR TITLE
[PDF generation brakes when table not complete] fix

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/custom_questions/lists.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/lists.rb
@@ -24,6 +24,7 @@ module QaePdfForms::CustomQuestions::Lists
     "Good/Service",
     "% of your total overseas trade"
   ]
+  UNDEFINED_CELL_VALUE = "Undefined"
 
   def render_list
     if q_visible? && humanized_answer.present?
@@ -113,10 +114,10 @@ module QaePdfForms::CustomQuestions::Lists
   end
 
   def trade_goods_conditions(prepared_item)
-    if prepared_item["desc_short"].present?
+    if prepared_item["desc_short"].present? || prepared_item["total_overseas_trade"].present?
       [
-        prepared_item["desc_short"],
-        prepared_item["total_overseas_trade"].present? ? prepared_item["total_overseas_trade"] : FormPdf::UNDEFINED_TITLE
+        form_pdf.render_value_or_undefined(prepared_item["desc_short"], UNDEFINED_CELL_VALUE),
+        form_pdf.render_value_or_undefined(prepared_item["total_overseas_trade"], UNDEFINED_CELL_VALUE)
       ]
     end
   end

--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -216,4 +216,8 @@ module QaePdfForms::General::DrawElements
       valign: :top
     }
   end
+
+  def render_value_or_undefined(val, undefined_text)
+    val.present? ? val : undefined_text
+  end
 end


### PR DESCRIPTION
```
Prawn::Errors::InvalidTableData: data must be a two dimensional array of cellable objects:
https://app.getsentry.com/bit-zesty-client-apps/qae/group/88387436/

https://app.getsentry.com/bit-zesty-client-apps/qae/group/89287283/

https://staging.queens-awards-enterprise.service.gov.uk/form/70
```