### PR TITLE
Admin entries report fixes

### DIFF
--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -250,7 +250,7 @@ module Reports::DataPickers::FormDocumentPicker
   end
 
   def doc(key)
-    obj.document[key]
+    obj.document[key] if key.present? && question_visible?(key)
   end
 
   def country_name(code)

--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -254,7 +254,7 @@ module Reports::DataPickers::FormDocumentPicker
   end
 
   def country_name(code)
-    if code
+    if code.present?
       country = ISO3166::Country[code]
       country.name
     end

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -1,11 +1,18 @@
 class Reports::FormAnswer
   include Reports::DataPickers::UserPicker
   include Reports::DataPickers::FormDocumentPicker
+  include FormAnswersBasePointer
 
-  attr_reader :obj, :award_form
+  attr_reader :obj,
+              :form_answer,
+              :award_form
 
   def initialize(form_answer)
     @obj = form_answer
+
+    # FormAnswersBasePointer#fetch_answers mixin uses form_answer, instead of obj
+    @form_answer = form_answer
+    @award_form = form_answer.award_form.decorate(answers: fetch_answers)
 
     @moderated = pick_assignment("moderated")
     @primary = pick_assignment("primary")
@@ -14,6 +21,11 @@ class Reports::FormAnswer
 
     @secondary_assessor = @obj.secondary_assessor
     @press_summary = @obj.press_summary if @obj.awarded?
+  end
+
+  def question_visible?(question_key)
+    question = award_form[question_key.to_sym]
+    question.present? && question.visible?
   end
 
   def call_method(methodname)

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -25,7 +25,7 @@ class Reports::FormAnswer
 
   def question_visible?(question_key)
     question = award_form[question_key.to_sym]
-    question.present? && question.visible?
+    question.blank? || question.visible?
   end
 
   def call_method(methodname)

--- a/spec/features/admin/form_answers/generation_of_csv_reports_spec.rb
+++ b/spec/features/admin/form_answers/generation_of_csv_reports_spec.rb
@@ -45,7 +45,7 @@ describe "Admin generates the CSV reports" do
     let(:id) { "press-book-list" }
     it "produces proper output" do
       expect(output.size).to eq(2)
-      expect(output[1][-2]).to eq("United Kingdom")
+      expect(output[1][1]).to eq("Sustainable Development")
       expect(output[1][-4]).to eq("example.com")
     end
   end


### PR DESCRIPTION
[Issue with Entries report not picking up the latest data]
[Trello Story](https://trello.com/c/DAcukVYf/390-issue-with-entries-report-not-picking-up-the-latest-data)

Entries report should not display non displayed conditional questions, also check that the product description is being displayed properly.