### PR TITLE
[Admin | Entries Report] Financial Summary fixes

### DIFF
--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -237,7 +237,10 @@ module Reports::DataPickers::FormDocumentPicker
   def collect_final_value_from_doc(meth)
     if meth
       b = doc meth.keys.first
-      doc meth.values.first[b]
+      target_key = meth.values.first[b]
+
+      amended_value = financial_data[target_key]
+      amended_value.present? ? amended_value : doc(target_key)
     end
   end
 

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -5,12 +5,14 @@ class Reports::FormAnswer
 
   attr_reader :obj,
               :answers,
-              :award_form
+              :award_form,
+              :financial_data
 
   def initialize(form_answer)
     @obj = form_answer
     @answers = ActiveSupport::HashWithIndifferentAccess.new(obj.document)
     @award_form = form_answer.award_form.decorate(answers: answers)
+    @financial_data = form_answer.financial_data || {}
 
     @moderated = pick_assignment("moderated")
     @primary = pick_assignment("primary")


### PR DESCRIPTION
Related to [TrelloStory](https://trello.com/c/kCbS6i2Y/224-issue-with-entries-report-not-picking-up-the-latest-data)

"Employees", "FinalYearOverseasSales" and "FinalYearTotalSales"
are not reflecting any amendments to this figure if it is edited
in the “Financial Summary” section of the Assessment site.