### PR TITLE
Audit certificate template changes

### DIFF
--- a/app/pdf_generators/audit_certificate_pdf.rb
+++ b/app/pdf_generators/audit_certificate_pdf.rb
@@ -8,6 +8,8 @@ class AuditCertificatePdf < Prawn::Document
   attr_reader :audit_data,
               :form_answer,
               :award_type,
+              :award_type_full_name,
+              :company_name,
               :financial_pointer,
               :step_questions,
               :filled_answers
@@ -17,6 +19,8 @@ class AuditCertificatePdf < Prawn::Document
 
     @form_answer = form_answer.decorate
     @award_type = form_answer.award_type_full_name.downcase
+    @award_type_full_name = "#{@form_answer.award_type_full_name} #{form_answer.award_year.year}"
+    @company_name = @form_answer.company_name
     @financial_pointer = FormFinancialPointer.new(@form_answer, {exclude_ignored_questions: true})
     @audit_data = financial_pointer.data
     @step_questions = financial_pointer.financial_step.questions

--- a/app/pdf_generators/audit_certificate_pdf.rb
+++ b/app/pdf_generators/audit_certificate_pdf.rb
@@ -17,7 +17,7 @@ class AuditCertificatePdf < Prawn::Document
 
     @form_answer = form_answer.decorate
     @award_type = form_answer.award_type_full_name.downcase
-    @financial_pointer = FormFinancialPointer.new(@form_answer)
+    @financial_pointer = FormFinancialPointer.new(@form_answer, {exclude_ignored_questions: true})
     @audit_data = financial_pointer.data
     @step_questions = financial_pointer.financial_step.questions
     @filled_answers = financial_pointer.filled_answers
@@ -50,5 +50,17 @@ class AuditCertificatePdf < Prawn::Document
     render_financial_table
     render_explanation_of_the_changes
     render_additional_comments
+  end
+
+  def formatted_uk_sales_value(item)
+    ApplicationController.helpers.formatted_uk_sales_value(item)
+  end
+
+  def number_with_delimiter(item)
+    ApplicationController.helpers.number_with_delimiter(item)
+  end
+
+  def financials_i18_prefix
+    "admin.form_answers.financial_summary"
   end
 end

--- a/app/pdf_generators/pdf_audit_certificates/awards2016/development/base.rb
+++ b/app/pdf_generators/pdf_audit_certificates/awards2016/development/base.rb
@@ -3,8 +3,8 @@ module PdfAuditCertificates::Awards2016::Development
     # HERE YOU CAN OVERRIDE STANDART METHODS
     def render_options_list
       render_options(
-        "Option 1 - In accordance with instructions received from our client, Highland Happy Hens Ltd, we have examined the above figures for the entry for The Queen's Awards for Enterprise: Sustainable Development 2015. We confirm that, in our opinion, the entry correctly states the information required and that the applicable accounting standards have been complied with.",
-        "Option 2 - In accordance with instructions received from our client, Highland Happy Hens Ltd, we have examined the above figures for the entry for The Queen's Awards for Enterprise: Sustainable Development 2015. We confirm that, in our opinion, the entry, as revised by the included Schedule and explanation of the changes, correctly states the information required and that the applicable accounting standards have been complied with."
+        "Option 1 - In accordance with instructions received from our client, #{company_name}, we have examined the above figures for the entry for The Queen's Awards for Enterprise: #{award_type_full_name}. We confirm that, in our opinion, the entry correctly states the information required and that the applicable accounting standards have been complied with.",
+        "Option 2 - In accordance with instructions received from our client, #{company_name}, we have examined the above figures for the entry for The Queen's Awards for Enterprise: #{award_type_full_name}. We confirm that, in our opinion, the entry, as revised by the included Schedule and explanation of the changes, correctly states the information required and that the applicable accounting standards have been complied with."
       )
     end
   end

--- a/app/pdf_generators/pdf_audit_certificates/awards2016/innovation/base.rb
+++ b/app/pdf_generators/pdf_audit_certificates/awards2016/innovation/base.rb
@@ -3,8 +3,8 @@ module PdfAuditCertificates::Awards2016::Innovation
     # HERE YOU CAN OVERRIDE STANDART METHODS
     def render_options_list
       render_options(
-        "Option 1 - In accordance with instructions received from our client, Inventing the Wheel PLC, we have examined the above figures for the entry for The Queen's Awards for Enterprise: Innovation 2015. We confirm that, in our opinion, the entry correctly states the information required and that the applicable accounting standards have been complied with.",
-        "Option 2 - In accordance with instructions received from our client, Inventing the Wheel PLC, we have examined the above figures for the entry for The Queen's Awards for Enterprise: Innovation 2015. We confirm that, in our opinion, the entry, as revised by the included Schedule and explanation of the changes, correctly states the information required and that the applicable accounting standards have been complied with."
+        "Option 1 - In accordance with instructions received from our client, #{company_name}, we have examined the above figures for the entry for The Queen's Awards for Enterprise: #{award_type_full_name}. We confirm that, in our opinion, the entry correctly states the information required and that the applicable accounting standards have been complied with.",
+        "Option 2 - In accordance with instructions received from our client, #{company_name}, we have examined the above figures for the entry for The Queen's Awards for Enterprise: #{award_type_full_name}. We confirm that, in our opinion, the entry, as revised by the included Schedule and explanation of the changes, correctly states the information required and that the applicable accounting standards have been complied with."
       )
     end
   end

--- a/app/pdf_generators/pdf_audit_certificates/awards2016/trade/base.rb
+++ b/app/pdf_generators/pdf_audit_certificates/awards2016/trade/base.rb
@@ -3,8 +3,8 @@ module PdfAuditCertificates::Awards2016::Trade
     # HERE YOU CAN OVERRIDE STANDART METHODS
     def render_options_list
       render_options(
-        "Option 1 - In accordance with instructions received from our client, International Rescue UK Ltd, we have examined the above figures for the entry for The Queen's Awards for Enterprise: International Trade 2015. We confirm that, in our opinion, the entry correctly states the information required and that the applicable accounting standards have been complied with.",
-        "Option 2 - In accordance with instructions received from our client, International Rescue UK Ltd, we have examined the above figures for the entry for The Queen's Awards for Enterprise: International Trade 2015. We confirm that, in our opinion, the entry, as revised by the included Schedule and explanation of the changes, correctly states the information required and that the applicable accounting standards have been complied with."
+        "Option 1 - In accordance with instructions received from our client, #{company_name}, we have examined the above figures for the entry for The Queen's Awards for Enterprise: #{award_type_full_name}. We confirm that, in our opinion, the entry correctly states the information required and that the applicable accounting standards have been complied with.",
+        "Option 2 - In accordance with instructions received from our client, #{company_name}, we have examined the above figures for the entry for The Queen's Awards for Enterprise: #{award_type_full_name}. We confirm that, in our opinion, the entry, as revised by the included Schedule and explanation of the changes, correctly states the information required and that the applicable accounting standards have been complied with."
       )
     end
   end

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -157,13 +157,13 @@ module PdfAuditCertificates::General::SharedElements
   end
 
   def benchmark_by_years_table_headers
-    res = [""]
+    benchmark_year_headers = []
 
-    res += financial_pointer.period_length.times do |i|
-      "Year #{i + 1}"
+    financial_pointer.period_length.times do |i|
+      benchmark_year_headers << "Year #{i + 1}"
     end
 
-    res
+    benchmark_year_headers.unshift("")
   end
 
   def benchmarks_row(metric)
@@ -177,7 +177,18 @@ module PdfAuditCertificates::General::SharedElements
   end
 
   def render_financial_overall_benchmarks
+    rows = [
+      [
+        "Overall growth in £ (year 1 - #{financial_pointer.period_length})",
+        formatted_uk_sales_value(financial_pointer.overall_growth)
+      ],
+      [
+        "Overall growth in % (year 1 - #{financial_pointer.period_length})",
+        formatted_uk_sales_value(financial_pointer.overall_growth_in_percents)
+      ]
+    ]
 
+    table rows, table_default_ops
   end
 
   ###################################

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -144,15 +144,20 @@ module PdfAuditCertificates::General::SharedElements
   end
 
   def render_financial_benchmarks_by_years
-    rows = [
-      benchmark_by_years_table_headers
-    ]
+    # Uncomment me if you need to display Year labels too like:
+    # Year 1, Year 2
+    #
+    # rows = [
+    #   benchmark_by_years_table_headers
+    # ]
+
+    rows = []
 
     rows += if form_answer.trade?
       [
         benchmarks_row("growth_overseas_earnings"),
         benchmarks_row("sales_exported"),
-        benchmarks_row("sector_average_growth")
+        benchmarks_row("average_growth_for")
       ]
     else
       [
@@ -336,11 +341,11 @@ module PdfAuditCertificates::General::SharedElements
     when 2
       [340, 100, 100]
     when 3
-      [300, 50, 50, 50]
+      [324, 72, 72, 72]
     when 5
-      [300, 50, 50, 50, 50, 50]
+      [180, 72, 72, 72, 72, 72]
     when 6
-      [300, 50, 50, 50, 50, 50, 50]
+      [150, 65, 65, 65, 65, 65, 65]
     end
 
     hashed_columns(res)
@@ -351,11 +356,11 @@ module PdfAuditCertificates::General::SharedElements
     when 2
       [340, 200]
     when 3
-      [300, 100]
+      [324, 216]
     when 5
-      [300, 100]
+      [180, 360]
     when 6
-      [300, 100]
+      [150, 390]
     end
 
     hashed_columns(res)

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -32,53 +32,114 @@ module PdfAuditCertificates::General::SharedElements
     render_text_line(p2, 5, { leading: 2 })
   end
 
+  ###################################
+  # Financial Data: Version 1 - begin
+  ###################################
+
+  # def render_financial_table
+  #   rows = [financial_table_headers.unshift("")]
+
+  #   table_headers.map do |label|
+  #     question_key = label["id"]
+
+  #     rows << financial_data(
+  #       question_key,
+  #       get_audit_data(question_key)
+  #     ).unshift(label["label"])
+  #   end
+
+  #   table rows, table_default_ops
+  # end
+
+  # def table_headers
+  #   QuestionLabels::AuditCertificateLabel.find(form_answer.award_type).labels.reject do |l|
+  #     # TODO: remove this rejecting once will be clear with unknown keys
+  #     l["id"].blank?
+  #   end
+  # end
+
+  # def number_with_delimiter(val)
+  #   ApplicationController.helpers.number_with_delimiter(val)
+  # end
+
+  # def financial_data(question_key, question_data)
+  #   question_data.map do |entry|
+  #     if entry.is_a?(Array)
+  #       entry.join("/")
+  #     elsif entry.is_a?(Hash)
+  #       data_by_type(question_key, entry)
+  #     else # CALCULATED_DATA
+  #       "£#{ApplicationController.helpers.formatted_uk_sales_value(entry)}"
+  #     end
+  #   end
+  # end
+
+  # def data_by_type(question_key, entry)
+  #   if entry[:value].present?
+  #     if NOT_CURRENCY_QUESTION_KEYS.include?(question_key)
+  #       number_with_delimiter(entry[:value])
+  #     else
+  #       "£#{number_with_delimiter(entry[:value])}" if entry[:value] != "-"
+  #     end
+  #   end
+  # end
+
+  ###################################
+  # Financial Data: Version 1 - end
+  ###################################
+
+  ###################################
+  # Financial Data: Version 2 - begin
+  ###################################
+
   def render_financial_table
-    rows = [financial_table_headers.unshift("")]
+    render_financial_main_table
+    render_financial_benchmarks
+  end
 
-    table_headers.map do |label|
-      question_key = label["id"]
+  def render_financial_main_table
+    rows = [financial_pointer.years_list.unshift("")]
 
-      rows << financial_data(
-        question_key,
-        get_audit_data(question_key)
-      ).unshift(label["label"])
+    financial_pointer.data.each_with_index do |row, index|
+      next if row[:financial_year_changed_dates]
+
+      rows << if row[:uk_sales]
+        render_financial_uk_sales_row(row)
+      else
+        render_financial_row(row)
+      end
     end
 
     table rows, table_default_ops
   end
 
-  def table_headers
-    QuestionLabels::AuditCertificateLabel.find(form_answer.award_type).labels.reject do |l|
-      # TODO: remove this rejecting once will be clear with unknown keys
-      l["id"].blank?
+  def render_financial_uk_sales_row(row)
+    res = [I18n.t("#{financials_i18_prefix}.uk_sales_row.uk_sales")]
+
+    res += row.values.flatten.map do |field|
+      formatted_uk_sales_value(field)
     end
+
+    res
   end
 
-  def number_with_delimiter(val)
-    ApplicationController.helpers.number_with_delimiter(val)
+  def render_financial_row(row)
+    res = [I18n.t("#{financials_i18_prefix}.row.#{row.keys.first}")]
+
+    res += row.values.flatten.map do |field|
+      number_with_delimiter(field[:value])
+    end
+
+    res
   end
 
-  def financial_data(question_key, question_data)
-    question_data.map do |entry|
-      if entry.is_a?(Array)
-        entry.join("/")
-      elsif entry.is_a?(Hash)
-        data_by_type(question_key, entry)
-      else # CALCULATED_DATA
-        "£#{ApplicationController.helpers.formatted_uk_sales_value(entry)}"
-      end
-    end
+  def render_financial_benchmarks
+
   end
 
-  def data_by_type(question_key, entry)
-    if entry[:value].present?
-      if NOT_CURRENCY_QUESTION_KEYS.include?(question_key)
-        number_with_delimiter(entry[:value])
-      else
-        "£#{number_with_delimiter(entry[:value])}" if entry[:value] != "-"
-      end
-    end
-  end
+  ###################################
+  # Financial Data: Version 2 - end
+  ###################################
 
   def render_user_filling_block
     b1 = %{Signed ..................................................................................................................}

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -134,6 +134,49 @@ module PdfAuditCertificates::General::SharedElements
   end
 
   def render_financial_benchmarks
+    render_financial_benchmarks_by_years
+    render_financial_overall_benchmarks
+  end
+
+  def render_financial_benchmarks_by_years
+    rows = [benchmark_by_years_table_headers]
+
+    rows += if form_answer.trade?
+      [
+        benchmarks_row("growth_overseas_earnings"),
+        benchmarks_row("sales_exported"),
+        benchmarks_row("sector_average_growth")
+      ]
+    else
+      [
+        benchmarks_row("growth_in_total_turnover")
+      ]
+    end
+
+    table rows, table_default_ops
+  end
+
+  def benchmark_by_years_table_headers
+    res = [""]
+
+    res += financial_pointer.period_length.times do |i|
+      "Year #{i + 1}"
+    end
+
+    res
+  end
+
+  def benchmarks_row(metric)
+    res = [I18n.t("#{financials_i18_prefix}.benchmarks.#{metric}")]
+
+    res += financial_pointer.send("#{metric}_list").map do |entry|
+      formatted_uk_sales_value(entry)
+    end
+
+    res
+  end
+
+  def render_financial_overall_benchmarks
 
   end
 

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -113,7 +113,7 @@ module PdfAuditCertificates::General::SharedElements
       end
     end
 
-    table rows, table_default_ops
+    table rows, table_default_ops(:main_table)
   end
 
   def render_financial_uk_sales_row(row)
@@ -137,7 +137,9 @@ module PdfAuditCertificates::General::SharedElements
   end
 
   def render_financial_benchmarks
+    move_down 3.mm
     render_financial_benchmarks_by_years
+    move_down 3.mm
     render_financial_overall_benchmarks
   end
 
@@ -158,7 +160,7 @@ module PdfAuditCertificates::General::SharedElements
       ]
     end
 
-    table rows, table_default_ops
+    table rows, table_default_ops(:main_table)
   end
 
   def benchmark_by_years_table_headers
@@ -205,7 +207,7 @@ module PdfAuditCertificates::General::SharedElements
       ]
     ]
 
-    table rows, table_default_ops
+    table rows, table_default_ops(:overall_benchmarks)
   end
 
   ###################################
@@ -299,15 +301,71 @@ module PdfAuditCertificates::General::SharedElements
     }
   end
 
-  def table_default_ops
+
+  #######################################
+  # Financial Data: Version 1 - table ops
+  #######################################
+  # def table_default_ops
+  #   {
+  #     column_widths: {
+  #       0 => 200
+  #     },
+  #     cell_style: {
+  #       size: 10,
+  #       padding: [3, 3, 3, 3]
+  #     }
+  #   }
+  # end
+
+  #############################################
+  # Financial Data: Version 2 - table ops begin
+  #############################################
+
+  def table_default_ops(table_type)
     {
-      column_widths: {
-        0 => 200
-      },
+      column_widths: send("#{table_type}_column_widths"),
       cell_style: {
         size: 10,
         padding: [3, 3, 3, 3]
       }
     }
   end
+
+  def main_table_column_widths
+    res = case financial_pointer.years_list.size
+    when 2
+      [340, 100, 100]
+    when 3
+      [300, 50, 50, 50]
+    when 5
+      [300, 50, 50, 50, 50, 50]
+    when 6
+      [300, 50, 50, 50, 50, 50, 50]
+    end
+
+    hashed_columns(res)
+  end
+
+  def overall_benchmarks_column_widths
+    res = case financial_pointer.years_list.size
+    when 2
+      [340, 200]
+    when 3
+      [300, 100]
+    when 5
+      [300, 100]
+    when 6
+      [300, 100]
+    end
+
+    hashed_columns(res)
+  end
+
+  def hashed_columns(arr)
+    Hash[arr.map.with_index { |x, i| [i, x] }]
+  end
+
+  #############################################
+  # Financial Data: Version 2 - table ops end
+  #############################################
 end

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -25,10 +25,10 @@ module PdfAuditCertificates::General::SharedElements
 
   def render_base_paragraph
     p1 = %{This certificate should confirm all the figures quoted in the table below, or as amended in the revised table on page 2. By completing this certificate, you are confirming that you have carried out such work as you consider necessary to confirm the relevant figures and that the applicant has complied with the accounting standards applicable to the applicant status in preparing the entry.}
-    render_text_line(p1, 2, { leading: 2 })
+    render_text_line(p1, 2, { leading: 1 })
 
     p2 = "If you tick option 1, then you should only complete the signatory and company details below. If you tick option 2, you should complete the signatory and company details below and revise the figures in the table on page 2 of this form, initial and provide an explanation of the changes. This certificate should be completed in writing on a printed copy of this document. Please return the completed certificate to your client."
-    render_text_line(p2, 5, { leading: 2 })
+    render_text_line(p2, 2, { leading: 1 })
   end
 
   ###################################
@@ -226,7 +226,7 @@ module PdfAuditCertificates::General::SharedElements
     render_text_line(b2, 1)
 
     b3 = %{Company Registration Number: ...........................................................................}
-    render_text_line(b3, 5)
+    render_text_line(b3, 1)
 
     b4 = %{Address: ...............................................................................................................}
     render_text_line(b4, 1)
@@ -235,12 +235,14 @@ module PdfAuditCertificates::General::SharedElements
     render_text_line(b5, 1)
 
     b6 = %{Email: ...................................................................................................................}
-    render_text_line(b6, 5)
+    render_text_line(b6, 1)
 
     b7 = %{Date: .....................................................................................................................}
-    render_text_line(b7, 5)
+    render_text_line(b7, 1)
 
-    render_text_line(%{Company stamp:}, 5)
+    text_box "Company stamp:", default_text_ops.merge({
+      at: [120.mm, cursor + 33.mm]
+    })
   end
 
   def render_revised_schedule

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -98,7 +98,10 @@ module PdfAuditCertificates::General::SharedElements
   end
 
   def render_financial_main_table
-    rows = [financial_pointer.years_list.unshift("")]
+    rows = [
+      financial_pointer.years_list.unshift(""),
+      financial_table_year_and_date_data
+    ]
 
     financial_pointer.data.each_with_index do |row, index|
       next if row[:financial_year_changed_dates]
@@ -140,8 +143,7 @@ module PdfAuditCertificates::General::SharedElements
 
   def render_financial_benchmarks_by_years
     rows = [
-      benchmark_by_years_table_headers,
-      benchmark_by_year_and_date_data
+      benchmark_by_years_table_headers
     ]
 
     rows += if form_answer.trade?
@@ -169,7 +171,7 @@ module PdfAuditCertificates::General::SharedElements
     benchmark_year_headers.unshift("")
   end
 
-  def benchmark_by_year_and_date_data
+  def financial_table_year_and_date_data
     res = [I18n.t("#{financials_i18_prefix}.years_row.financial_year_changed_dates")]
 
     res += if financial_pointer.data.first[:financial_year_changed_dates].present?

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -259,7 +259,7 @@ module PdfAuditCertificates::General::SharedElements
   def render_options(opt1, opt2)
     move_down 6.mm
     render_text_line("#{LIST_POINTER}#{opt1}", 2, default_list_ops)
-    render_text_line("#{LIST_POINTER}#{opt1}", 6, default_list_ops)
+    render_text_line("#{LIST_POINTER}#{opt2}", 6, default_list_ops)
   end
 
   def render_footer_note

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -1,6 +1,5 @@
 module PdfAuditCertificates::General::SharedElements
   DEFAULT_OFFSET = 110.mm
-  LIST_POINTER = "o   "
   NOT_CURRENCY_QUESTION_KEYS = %w(employees)
 
   def render_main_header
@@ -263,8 +262,10 @@ module PdfAuditCertificates::General::SharedElements
 
   def render_options(opt1, opt2)
     move_down 6.mm
-    render_text_line("#{LIST_POINTER}#{opt1}", 2, default_list_ops)
-    render_text_line("#{LIST_POINTER}#{opt2}", 6, default_list_ops)
+    stroke_rectangle [0, cursor], 7, 7
+    render_text_line(opt1, 2, default_list_ops)
+    stroke_rectangle [0, cursor], 7, 7
+    render_text_line(opt2, 6, default_list_ops)
   end
 
   def render_footer_note
@@ -294,7 +295,7 @@ module PdfAuditCertificates::General::SharedElements
 
   def default_list_ops
     {
-      leading: 2.2,
+      leading: 1.8,
       indent_paragraphs: 10
     }
   end

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -139,7 +139,10 @@ module PdfAuditCertificates::General::SharedElements
   end
 
   def render_financial_benchmarks_by_years
-    rows = [benchmark_by_years_table_headers]
+    rows = [
+      benchmark_by_years_table_headers,
+      benchmark_by_year_and_date_data
+    ]
 
     rows += if form_answer.trade?
       [
@@ -164,6 +167,18 @@ module PdfAuditCertificates::General::SharedElements
     end
 
     benchmark_year_headers.unshift("")
+  end
+
+  def benchmark_by_year_and_date_data
+    res = [I18n.t("#{financials_i18_prefix}.years_row.financial_year_changed_dates")]
+
+    res += if financial_pointer.data.first[:financial_year_changed_dates].present?
+      financial_pointer.financial_year_changed_dates
+    else
+      financial_pointer.financial_year_dates
+    end
+
+    res
   end
 
   def benchmarks_row(metric)

--- a/app/views/admin/form_answers/financial_summary/_benchmarks.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_benchmarks.html.slim
@@ -30,7 +30,7 @@
             td.value = formatted_uk_sales_value(entry)
         tr.sector-average-growth
           th
-            = t('.sector_average_growth')
+            = t('.average_growth_for')
 
           - financial_pointer.average_growth_for_list.each do |entry|
             td = formatted_uk_sales_value(entry)

--- a/app/views/admin/form_answers/financial_summary/_benchmarks.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_benchmarks.html.slim
@@ -17,23 +17,27 @@
     tbody
       - if @form_answer.trade?
         tr.exports-growth
-          th % Growth overseas earnings
+          th
+            = t('.growth_overseas_earnings')
 
           - financial_pointer.growth_overseas_earnings_list.each do |entry|
             td.value = formatted_uk_sales_value(entry)
         tr.exports-percentage
-          th % Sales exported
+          th
+            = t('.sales_exported')
 
           - financial_pointer.sales_exported_list.each do |entry|
             td.value = formatted_uk_sales_value(entry)
         tr.sector-average-growth
-          th % Sector average growth
+          th
+            = t('.sector_average_growth')
 
           - financial_pointer.average_growth_for_list.each do |entry|
             td = formatted_uk_sales_value(entry)
       - else
         tr.turnover-growth
-          th % Growth in total turnover
+          th
+            = t('.growth_in_total_turnover')
 
           - financial_pointer.growth_in_total_turnover_list.each do |entry|
             td.value = formatted_uk_sales_value(entry)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,7 +119,7 @@ en:
         benchmarks:
           growth_overseas_earnings: "% Growth overseas earnings"
           sales_exported: "% Sales exported"
-          sector_average_growth: "% Sector average growth"
+          average_growth_for: "% Sector average growth"
           growth_in_total_turnover: "% Growth in total turnover"
 
   errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,12 @@ en:
           overseas_yearly_percentage: Overseas Yearly Percentage
         uk_sales_row:
           uk_sales: UK sales (£)
+        benchmarks:
+          growth_overseas_earnings: "% Growth overseas earnings"
+          sales_exported: "% Sales exported"
+          sector_average_growth: "% Sector average growth"
+          growth_in_total_turnover: "% Growth in total turnover"
+
   errors:
     messages:
       wrong_size: "is the wrong size (should be %{file_size})"


### PR DESCRIPTION
For the audit certificate template - change the financials table to be the same as the financial summary in the admin view

[Trello Story](https://trello.com/c/zSuswff6/228-for-the-audit-certificate-template-change-the-financials-table-to-be-the-same-as-the-financial-summary-in-the-admin-view)

1. the second option title on page one should be amended to "Option 2" otherwise there are two 'Option 1"s, and is it possible to have a box symbol to tick rather than a circle

2. The name of the applicant in both the 'Options' paragraphs should be the same name as the one that appears at the top of the template.

3. The correct Award year should be displayed in both the 'Options' paragraphs

4. Option 2 – the paragraph to be amended by inserting “,as revised by the included Schedule and explanation of the changes,” between the words “entry” and “correctly” in the second sentence

5. The side headings in the figures tables (on both pages of the template) to be amended as per the attached document (depending on the category ), and the boxes should populate with the figures that are in the ‘Financial Summary’ section of the Assessment site. (Matt just to point out that some of the boxes on this audit template will not necessarily have figures populating in e.g. for Innovation and Sustainable Development unit costs see in staging site e.g. 0013/16I and for International Trade see 0032/16