### PR TITLE
[Admin Audit Certificate] ability to check generated PDF

### DIFF
--- a/app/controllers/admin/audit_certificates_controller.rb
+++ b/app/controllers/admin/audit_certificates_controller.rb
@@ -1,3 +1,20 @@
 class Admin::AuditCertificatesController < Admin::BaseController
   include AuditCertificateContext
+
+  expose(:pdf_data) do
+    form_answer.decorate.pdf_audit_certificate_generator
+  end
+
+  def download_initial_pdf
+    authorize form_answer, :can_download_initial_pdf?
+
+    respond_to do |format|
+      format.html
+      format.pdf do
+        send_data pdf_data.render,
+                  filename: "audit_certificate_#{@form_answer.decorate.pdf_filename}",
+                  type: "application/pdf"
+      end
+    end
+  end
 end

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -66,4 +66,8 @@ class FormAnswerPolicy < ApplicationPolicy
     download_case_summary_pdf? ||
     download_audit_certificate_pdf?
   end
+
+  def can_download_initial_pdf?
+    admin?
+  end
 end

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -4,6 +4,7 @@
       span.icon-view
       span.btn-title
         ' View application
+    = render "admin/form_answers/docs/not_completed_audit_certificate"
 
   .sidebar-section
     h2

--- a/app/views/admin/form_answers/docs/_not_completed_audit_certificate.html.slim
+++ b/app/views/admin/form_answers/docs/_not_completed_audit_certificate.html.slim
@@ -1,0 +1,5 @@
+- if policy(@form_answer).can_download_initial_pdf?
+  = link_to download_initial_pdf_admin_form_answer_audit_certificates_url(@form_answer, format: :pdf), class: "btn btn-default btn-block", target: "_blank"
+    span.glyphicon.glyphicon-file
+    span.btn-title
+      ' View Initial Audit Certificate PDF

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,7 +189,9 @@ Rails.application.routes.draw do
       resources :comments
       resources :form_answer_attachments, only: [:create, :show, :destroy]
       resources :support_letters, only: [:show]
-      resources :audit_certificates, only: [:show]
+      resources :audit_certificates, only: [:show] do
+        get :download_initial_pdf, on: :collection
+      end
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit


### PR DESCRIPTION
Related to [Trello Story](https://trello.com/c/zSuswff6/228-for-the-audit-certificate-template-change-the-financials-table-to-be-the-same-as-the-financial-summary-in-the-admin-view)