### PR TITLE
[Admin / Assessor] Preserve line breaks in the QAE assessor forms

### DIFF
--- a/app/views/admin/form_answers/_comment.html.slim
+++ b/app/views/admin/form_answers/_comment.html.slim
@@ -29,7 +29,7 @@
             = f.submit 'Delete', class: "btn btn-danger link-delete-comment-confirm"
 
   .comment-content
-    = comment.body
+    = simple_format comment.body
 
   = form_for([namespace_name, @form_answer, comment],
              remote: true,

--- a/app/views/admin/form_answers/_comment_read_only.html.slim
+++ b/app/views/admin/form_answers/_comment_read_only.html.slim
@@ -4,7 +4,7 @@
       = comment_read_only.author_email
 
   .comment-content
-    = comment_read_only.body
+    = simple_format comment_read_only.body
 
 
   label.if-js-hide Flag

--- a/app/views/admin/form_answers/_section_draft_notes.html.slim
+++ b/app/views/admin/form_answers/_section_draft_notes.html.slim
@@ -19,7 +19,7 @@
             .form-value
               p
                 - if f.object.content.present?
-                  = f.object.content
+                  = simple_format f.object.content
                 - else
                   em.text-muted No draft notes added yet.
             = f.input :content,

--- a/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
@@ -4,7 +4,7 @@
     .form-value
       p
         - if f.object.application_background_section_desc.present?
-          = f.object.application_background_section_desc
+          = simple_format f.object.application_background_section_desc
         - else
           em.text-muted No comment has been added yet.
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_non_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_non_rag_section.html.slim
@@ -10,7 +10,7 @@
     .form-value
       p
         - if f.object.public_send(section.desc).present?
-          = f.object.public_send(section.desc)
+          = simple_format f.object.public_send(section.desc)
         - else
           em.text-muted No comment has been added yet.
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -29,7 +29,7 @@
     .form-value
       p
         - if f.object.public_send(section.desc).present?
-          = f.object.public_send(section.desc)
+          = simple_format f.object.public_send(section.desc)
         - else
           em.text-muted No comment has been added yet.
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -38,7 +38,7 @@
     .form-value
       p
         - if f.object.public_send(section.desc).present?
-          = f.object.public_send(section.desc)
+          = simple_format f.object.public_send(section.desc)
         - else
           em.text-muted No comment has been added yet.
       .clear


### PR DESCRIPTION
[Trello Story](https://trello.com/c/KY2Rb2pq/213-preserve-line-breaks-in-the-qae-assessor-forms)

When adding comments in their assessments line breaks are not saved.