### PR TITLE
[Audit Certificate] fixes by client notes

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -245,6 +245,10 @@ class FormAnswer < ActiveRecord::Base
     submission_ended? ? version_before_deadline : self
   end
 
+  def shortlisted?
+    state == "reserved" || state == "recommended"
+  end
+
   private
 
   def nominator_full_name_from_document

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -25,10 +25,10 @@ module PdfAuditCertificates::General::SharedElements
 
   def render_base_paragraph
     p1 = %{This certificate should confirm all the figures quoted in the table below, or as amended in the revised table on page 2. By completing this certificate, you are confirming that you have carried out such work as you consider necessary to confirm the relevant figures and that the applicant has complied with the accounting standards applicable to the applicant status in preparing the entry.}
-    render_text_line(p1, 2, { leading: 1 })
+    render_text_line(p1, 2, { leading: 2 })
 
     p2 = "If you tick option 1, then you should only complete the signatory and company details below. If you tick option 2, you should complete the signatory and company details below and revise the figures in the table on page 2 of this form, initial and provide an explanation of the changes. This certificate should be completed in writing on a printed copy of this document. Please return the completed certificate to your client."
-    render_text_line(p2, 2, { leading: 1 })
+    render_text_line(p2, 2, { leading: 2 })
   end
 
   ###################################
@@ -93,7 +93,10 @@ module PdfAuditCertificates::General::SharedElements
 
   def render_financial_table
     render_financial_main_table
-    render_financial_benchmarks
+    # Uncomment lines below if need to display
+    # benchmark tables too
+    #
+    # render_financial_benchmarks
   end
 
   def render_financial_main_table
@@ -226,7 +229,7 @@ module PdfAuditCertificates::General::SharedElements
     render_text_line(b2, 1)
 
     b3 = %{Company Registration Number: ...........................................................................}
-    render_text_line(b3, 1)
+    render_text_line(b3, 5)
 
     b4 = %{Address: ...............................................................................................................}
     render_text_line(b4, 1)
@@ -235,13 +238,13 @@ module PdfAuditCertificates::General::SharedElements
     render_text_line(b5, 1)
 
     b6 = %{Email: ...................................................................................................................}
-    render_text_line(b6, 1)
+    render_text_line(b6, 5)
 
     b7 = %{Date: .....................................................................................................................}
-    render_text_line(b7, 1)
+    render_text_line(b7, 5)
 
     text_box "Company stamp:", default_text_ops.merge({
-      at: [120.mm, cursor + 33.mm]
+      at: [120.mm, cursor + 45.mm]
     })
   end
 

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -68,6 +68,6 @@ class FormAnswerPolicy < ApplicationPolicy
   end
 
   def can_download_initial_pdf?
-    admin?
+    admin? && record.shortlisted?
   end
 end


### PR DESCRIPTION
Related to [Trello Story](https://trello.com/c/zSuswff6/228-for-the-audit-certificate-template-change-the-financials-table-to-be-the-same-as-the-financial-summary-in-the-admin-view)

1. The "percentage growth" grids and the "overall growth" grids are not required on the audit templates
2. The audit templates are not required for applicants who are 'Not recommeded'.
   They are only for the shortlisted entrants i.e. those who are 'Recommended' or 'Reserved'