### PR TITLE
[International Form] Financial Summary and Audit Certificate tweaks

### DIFF
--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -3,6 +3,13 @@ class Admin::FormAnswersController < Admin::BaseController
 
   before_filter :load_resource, only: [:review, :show, :update, :update_financials]
 
+  expose(:financial_pointer) do
+    FormFinancialPointer.new(@form_answer, {
+      exclude_ignored_questions: true,
+      financial_summary_view: true
+    })
+  end
+
   def index
     params[:search] ||= FormAnswerSearch::DEFAULT_SEARCH
     authorize :form_answer, :index?

--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -3,6 +3,13 @@ class Assessor::FormAnswersController < Assessor::BaseController
 
   before_filter :load_resource, only: [:update_financials]
 
+  expose(:financial_pointer) do
+    FormFinancialPointer.new(@form_answer, {
+      exclude_ignored_questions: true,
+      financial_summary_view: true
+    })
+  end
+
   helper_method :resource,
                 :primary_assessment,
                 :secondary_assessment,

--- a/app/form_pointers/form_financial_pointer.rb
+++ b/app/form_pointers/form_financial_pointer.rb
@@ -26,6 +26,10 @@ class FormFinancialPointer
     :trade,
     :promotion
   ]
+  TRADE_OPTIONAL_OPS = [
+    :total_imported_cost,
+    :overseas_yearly_percentage
+  ]
 
   def initialize(form_answer, options={})
     @form_answer = form_answer
@@ -56,22 +60,28 @@ class FormFinancialPointer
         fetched += [UkSalesCalculator.new(fetched).data] if uk_sales_data.present?
       end
 
+      add_missing_trade_items(fetched) if need_to_populate_missing_trade_ops?
+
       fetched
     end
   end
 
   def period_length
     @period_length ||= begin
-      if obj = data.first
-        case obj
-        when Hash
-          obj.values.flatten(1).length
-        when Array
-          obj.length
-        end
-      else
-        0
+      get_length(data.first)
+    end
+  end
+
+  def get_length(obj)
+    if obj.present?
+      case obj
+      when Hash
+        obj.values.flatten(1).length
+      when Array
+        obj.length
       end
+    else
+      0
     end
   end
 
@@ -253,6 +263,46 @@ class FormFinancialPointer
   def average_growth_for(form_answer, year)
     growth = form_answer.average_growth_for(year)
     growth || "-"
+  end
+
+  def need_to_populate_missing_trade_ops?
+    options[:financial_summary_view].present? &&
+    form_answer.trade?
+  end
+
+  def add_missing_trade_items(fetched)
+    # For International Trade, always display the two optional fields:
+    # Total Imported Cost and Overseas Yearly Percentage
+    # in the financial summary and audit certificate, even if blank.
+
+    years_length = get_length(fetched.first)
+
+    TRADE_OPTIONAL_OPS.each do |option|
+      option_data = fetched.detect do |el|
+        el.has_key?(option)
+      end
+
+      if option_data.blank?
+        option_data_hash = {}
+        option_data_values = []
+
+        years_length.times do |i|
+          option_data_values << {
+            name: "#{option}_#{i + 1}of#{years_length}",
+            value: ""
+          }
+        end
+
+        option_data_hash[option] = option_data_values
+
+        if option == :total_imported_cost &&
+           fetched.detect { |el| el.has_key?(:overseas_yearly_percentage) }.present?
+          fetched.insert(-2, option_data_hash)
+        else
+          fetched << option_data_hash
+        end
+      end
+    end
   end
 
   private

--- a/app/pdf_generators/audit_certificate_pdf.rb
+++ b/app/pdf_generators/audit_certificate_pdf.rb
@@ -21,7 +21,10 @@ class AuditCertificatePdf < Prawn::Document
     @award_type = form_answer.award_type_full_name.downcase
     @award_type_full_name = "#{@form_answer.award_type_full_name} #{form_answer.award_year.year}"
     @company_name = @form_answer.company_name
-    @financial_pointer = FormFinancialPointer.new(@form_answer, {exclude_ignored_questions: true})
+    @financial_pointer = FormFinancialPointer.new(@form_answer, {
+      exclude_ignored_questions: true,
+      financial_summary_view: true
+    })
     @audit_data = financial_pointer.data
     @step_questions = financial_pointer.financial_step.questions
     @filled_answers = financial_pointer.filled_answers

--- a/app/views/admin/form_answers/_section_financial_summary.html.slim
+++ b/app/views/admin/form_answers/_section_financial_summary.html.slim
@@ -1,4 +1,3 @@
-- financial_pointer = FormFinancialPointer.new(@form_answer, {exclude_ignored_questions: true})
 - if !financial_pointer.period_length.zero? && @form_answer.submitted?
   .panel.panel-default
     .panel-heading#financial-summary-heading role="tab"


### PR DESCRIPTION
[Trello Story](https://trello.com/c/3VPDVlC4/231-for-international-trade-always-display-the-two-optional-fields-in-the-financial-summary-and-audit-certificate-even-if-blank)

For International Trade, always display the two optional fields
in the financial summary and audit certificate, even if blank.