### PR TITLE
[Form Dashboard] Investigate why user cannot see their past applications

### DIFF
--- a/app/models/form_answer_transition.rb
+++ b/app/models/form_answer_transition.rb
@@ -1,6 +1,15 @@
 class FormAnswerTransition < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordTransition
 
+  POSSIBLE_STATES_BEFORE_SHORTLISED_STAGE = [
+    "assessment_in_progress",
+    "submitted",
+    "not_submitted",
+    "application_in_progress",
+    "reserved",
+    "recommended"
+  ]
+
   belongs_to :form_answer, inverse_of: :form_answer_transitions
 
   def transitable

--- a/app/views/content_only/post_submission/_submitted.html.slim
+++ b/app/views/content_only/post_submission/_submitted.html.slim
@@ -1,4 +1,4 @@
-- applications = FormAnswerDecorator.decorate_collection(award_applications.where(state: %w(assessment_in_progress submitted not_submitted application_in_progress)))
+- applications = FormAnswerDecorator.decorate_collection(award_applications.where(state: FormAnswerTransition::POSSIBLE_STATES_BEFORE_SHORTLISED_STAGE))
 - if applications.present?
   - applications.each do |award|
     .container-split.award-list


### PR DESCRIPTION
[Trello Story](https://trello.com/c/QZa0iOQ6/233-investigate-why-alister-dell-metricell-com-cannot-see-their-past-applications)

So applications can have status of shortlisted states ('reserved' and 'recommended')
before system settings transition to shortlisted mode.
System settings are shortlisted once Admin will schedule Shortlisted Mailer.
System were displaying only applications in "assessment_in_progress submitted not_submitted application_in_progress"
states, because system settings are not in after_shortlisting_stage.
So that some applications with states ('reserved' and 'recommended') were missing
in Dashboard.