### PR TITLE
[Admin | Entries Report] add 'Overall Status' column

### DIFF
--- a/app/models/reports/all_entries.rb
+++ b/app/models/reports/all_entries.rb
@@ -72,6 +72,10 @@ class Reports::AllEntries
       method: :case_summary_overall_grade
     },
     {
+      label: "Overall Status",
+      method: :overall_status
+    },
+    {
       label: "SICCode",
       method: :sic_code
     },

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -199,4 +199,8 @@ class Reports::FormAnswer
       "Lead Confirmed"
     end
   end
+
+  def overall_status
+    obj.state.humanize
+  end
 end


### PR DESCRIPTION
[Trello Story](https://trello.com/c/wyxirrHS/234-add-in-a-new-column-in-entries-report-csv)

An additional column in the 'Entries' report that displays the grade
in the white "Status" section in the Assessment site.
This is so that we can compare the grade in the new column with
the one in the existing 'CaseSummaryOverallGrade' to see
if there any differences in the two grades.