### PR TITLE
[Form PDF and Read Only View] Make the font colour darker so its easier to read

### DIFF
--- a/app/assets/stylesheets/frontend/views/award_form.scss
+++ b/app/assets/stylesheets/frontend/views/award_form.scss
@@ -177,6 +177,15 @@ label > .visible-read-only,
   }
 }
 
+input.read-only, textarea.read-only {
+  color: #000000;
+  opacity: 0.6;
+}
+
+select.read-only {
+  color: #5B5757;
+}
+
 .view-value {
   display: block;
 }

--- a/app/pdf_generators/form_pdf.rb
+++ b/app/pdf_generators/form_pdf.rb
@@ -11,6 +11,7 @@ class FormPdf < Prawn::Document
   JUST_NOTES = [
     "QAEFormBuilder::HeaderQuestion"
   ]
+  DEFAULT_ANSWER_COLOR = "5B5656"
 
   attr_reader :user,
               :form_answer,

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
@@ -7,7 +7,7 @@ module QaePdfForms::CustomQuestions::ByYear
   AS_AT_DATE_PREFIX_QUESTION_KEYS = [
     :total_net_assets
   ]
-  ANSWER_FONT_START = "<font name='Times-Roman'><color rgb='999999'>"
+  ANSWER_FONT_START = "<font name='Times-Roman'><color rgb='#{FormPdf::DEFAULT_ANSWER_COLOR}'>"
   ANSWER_FONT_END = "</font></color>"
   CALCULATED_FINANCIAL_DATA = [
     :uk_sales

--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -78,7 +78,7 @@ module QaePdfForms::General::DrawElements
 
         if description.present?
           text description,
-               color: "999999"
+               color: FormPdf::DEFAULT_ANSWER_COLOR
         end
       end
     end
@@ -159,7 +159,7 @@ module QaePdfForms::General::DrawElements
 
     indent 7.mm do
       font("Times-Roman") do
-        render_text title, color: "999999"
+        render_text title, color: FormPdf::DEFAULT_ANSWER_COLOR
       end
     end
   end
@@ -191,7 +191,7 @@ module QaePdfForms::General::DrawElements
 
   def render_nothing_uploaded_message
     font("Times-Roman") do
-      render_text "Nothing uploaded yet...", color: "999999"
+      render_text "Nothing uploaded yet...", color: FormPdf::DEFAULT_ANSWER_COLOR
     end
   end
 

--- a/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
@@ -26,7 +26,7 @@ class QaePdfForms::General::QuestionPointer
                       "international_trade" => "International Trade",
                       "sustainable_development" => "Sustainable Development" }
 
-  ANSWER_FONT_START = "<font name='Times-Roman'><color rgb='999999'>"
+  ANSWER_FONT_START = "<font name='Times-Roman'><color rgb='#{FormPdf::DEFAULT_ANSWER_COLOR}'>"
   ANSWER_FONT_END = "</font></color>"
 
   BLOCK_QUESTIONS = [
@@ -364,7 +364,7 @@ class QaePdfForms::General::QuestionPointer
         form_pdf.font("Times-Roman") do
           list_rows.each do |award|
             form_pdf.render_text "#{award[1]} - #{PREVIOUS_AWARDS[award[0].to_s]}",
-                                 color: "999999"
+                                 color: FormPdf::DEFAULT_ANSWER_COLOR
           end
         end
       end
@@ -531,7 +531,7 @@ class QaePdfForms::General::QuestionPointer
   def sub_question_block_without_title(sub_answer)
     form_pdf.font("Times-Roman") do
       form_pdf.render_text (q_visible? ? sub_answer : FormPdf::UNDEFINED_TITLE),
-                           color: "999999"
+                           color: FormPdf::DEFAULT_ANSWER_COLOR
     end
   end
 


### PR DESCRIPTION
[Trello Story](https://trello.com/c/9WyzDrar/232-make-the-font-colour-on-the-pdf-for-test-and-the-read-only-form-darker-so-its-easier-to-read)