### PR TITLE
[Admin / Assessment listing Issue] fix

### DIFF
--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -15,7 +15,7 @@ class Admin::FormAnswersController < Admin::BaseController
     authorize :form_answer, :index?
 
     @search = FormAnswerSearch.new(@award_year.form_answers, current_admin).search(params[:search])
-
+    @search.ordered_by = "company_or_nominee_name" unless @search.ordered_by
     @form_answers = @search.results.group("form_answers.id")
                                    .page(params[:page])
                                    .includes(:comments)

--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -32,6 +32,7 @@ class Assessor::FormAnswersController < Assessor::BaseController
     end
 
     @search = FormAnswerSearch.new(scope, current_assessor).search(params[:search])
+    @search.ordered_by = "company_or_nominee_name" unless @search.ordered_by
     @form_answers = @search.results.group("form_answers.id")
                                    .page(params[:page])
                                    .includes(:comments)

--- a/app/search/search.rb
+++ b/app/search/search.rb
@@ -4,7 +4,8 @@ class Search
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 
-  attr_reader :scope, :params, :ordered_by, :ordered_desc, :filter_params, :query
+  attr_reader :scope, :params, :ordered_desc, :filter_params, :query
+  attr_accessor :ordered_by
 
   # Example usage for users
   # scope = User.scoped


### PR DESCRIPTION
[Trello Story](https://trello.com/c/uRySUk9f/410-qae-investigate-assessment-listing-issue)

So, as I found the issue is that first query (without special filter ops)
contains ORDER_BY clause (by form_answers.company_or_nominee_name), but
once User specifies at least of one filter option ORDER_BY clause is missing.
That's the I guess main reason of wrong results at the search with filter options.