### PR TITLE
Changes to the not shortlisted email

### DIFF
--- a/app/mailers/users/notify_non_shortlisted_mailer.rb
+++ b/app/mailers/users/notify_non_shortlisted_mailer.rb
@@ -8,6 +8,7 @@ class Users::NotifyNonShortlistedMailer < AccountMailer
     mail to: @user.email, subject: @subject
   end
 
+  # ep_notify is disabled for now
   def ep_notify(form_answer_id)
     @form_answer = FormAnswer.find(form_answer_id).decorate
     @user = @form_answer.user.decorate

--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -55,6 +55,7 @@ class MailRenderer
   def not_shortlisted_notifier
     assigns = {}
     assigns[:user] = dummy_user("Jon", "Doe", "John's Company")
+    assigns[:current_year] = AwardYear.current.year
     render(assigns, "users/notify_non_shortlisted_mailer/notify")
   end
 

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -43,12 +43,8 @@ class Notifiers::EmailNotificationService
   end
 
   def not_shortlisted_notifier(award_year)
-    award_year.form_answers.not_shortlisted.each do |form_answer|
-      if form_answer.promotion?
-        Users::NotifyNonShortlistedMailer.ep_notify(form_answer.id).deliver_later!
-      else
-        Users::NotifyNonShortlistedMailer.notify(form_answer.id).deliver_later!
-      end
+    award_year.form_answers.business.not_shortlisted.each do |form_answer|
+      Users::NotifyNonShortlistedMailer.notify(form_answer.id).deliver!
     end
   end
 

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -44,7 +44,7 @@ class Notifiers::EmailNotificationService
 
   def not_shortlisted_notifier(award_year)
     award_year.form_answers.business.not_shortlisted.each do |form_answer|
-      Users::NotifyNonShortlistedMailer.notify(form_answer.id).deliver!
+      Users::NotifyNonShortlistedMailer.notify(form_answer.id).deliver_later!
     end
   end
 


### PR DESCRIPTION
List of changes:
* Enterprise nominators whose nomination has been unsuccessful should not receive this email.
* Admin / Settings: email template should display current Award Year.

[Trello Story](https://trello.com/c/taVpyygH/230-qae-changes-to-the-not-shortlisted-email)