### PR TITLE
[Admin | Assessor] ability to mark / unmark Form DCR as reviewed

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -379,8 +379,34 @@ handleReviewAuditCertificate = ->
 handleReviewCorpResponsibility = ->
   $("form.corp-responsibility-review").on "click", ".save-corp-responsibility", (e) ->
     e.preventDefault()
+
     $("form.corp-responsibility-review").submit()
+    $("form.corp-responsibility-review .form-fields").hide()
+    $("form.corp-responsibility-review.form-actions").hide()
+    $(".edit-corp-responsibility").show()
+
+    if $("input[name='form_answer[corp_responsibility_reviewed]']").is(':checked')
+      state_text = "Reviewed"
+    else
+      state_text = "Not reviewed"
+
+    $(".js-corp-responsibility-status").text(state_text)
+
+    return false
 
   $(".edit-corp-responsibility").on "click", (e) ->
+    $(this).hide()
+    $("form.corp-responsibility-review .form-fields").show()
+    $("form.corp-responsibility-review.form-actions").show()
     $(".save-corp-responsibility").show()
+
+    return false
+
+  $(".js-corp-responsibility-form-cancel-link").on "click", (e) ->
+    $("form.corp-responsibility-review .form-fields").hide()
+    $("form.corp-responsibility-review.form-actions").hide()
+    $(".edit-corp-responsibility").show()
+
+    return false
+
 $(document).ready(ready)

--- a/app/controllers/admin/review_corp_responsibility_controller.rb
+++ b/app/controllers/admin/review_corp_responsibility_controller.rb
@@ -3,5 +3,9 @@ class Admin::ReviewCorpResponsibilityController < Admin::BaseController
     FormAnswer.find(params[:form_answer_id]).decorate
   end
 
+  expose(:corp_responsibility_reviewed) do
+    params[:form_answer][:corp_responsibility_reviewed].to_s == "1"
+  end
+
   include ReviewCorpResponsibilityMixin
 end

--- a/app/controllers/assessor/review_corp_responsibility_controller.rb
+++ b/app/controllers/assessor/review_corp_responsibility_controller.rb
@@ -3,5 +3,9 @@ class Assessor::ReviewCorpResponsibilityController < Assessor::BaseController
     FormAnswer.find(params[:form_answer_id]).decorate
   end
 
+  expose(:corp_responsibility_reviewed) do
+    params[:form_answer][:corp_responsibility_reviewed].to_s == "1"
+  end
+
   include ReviewCorpResponsibilityMixin
 end

--- a/app/controllers/concerns/review_corp_responsibility_mixin.rb
+++ b/app/controllers/concerns/review_corp_responsibility_mixin.rb
@@ -2,7 +2,8 @@ module ReviewCorpResponsibilityMixin
   def create
     authorize form_answer, :can_review_corp_responsibility?
 
-    # form_answer.update_column(:corp_responsibility_submitted, true)
+    form_answer.corp_responsibility_reviewed = corp_responsibility_reviewed
+    form_answer.save!
 
     respond_to do |format|
       format.js { render(nothing: true) }

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -205,13 +205,17 @@ class FormAnswerDecorator < ApplicationDecorator
 
     if version.present?
       user_class, user_id = version.whodunnit.split(":")
-      user_class.constantize.find(user_id).full_name
+      user_class.capitalize
+                .constantize
+                .find(user_id)
+                .decorate
+                .full_name
     end
   end
 
   def corp_responsibility_reviewed_updated_at
     version = corp_responsibility_reviewed_changes
-    version.created_at.strftime("%d%m%Y_%H%M") if version.present?
+    version.created_at if version.present?
   end
 
   def lead_assessors

--- a/app/views/admin/form_answers/_section_corp_responsibility.html.slim
+++ b/app/views/admin/form_answers/_section_corp_responsibility.html.slim
@@ -11,4 +11,10 @@
           |  Incomplete
 
         - if @form_answer.corp_responsibility_submitted?
+          br
+          strong.js-corp-responsibility-status
+            - if @form_answer.corp_responsibility_reviewed?
+              ' Reviewed
+            - else
+              ' Not reviewed
           = render "admin/form_answers/corp_responsibility/review_form"

--- a/app/views/admin/form_answers/corp_responsibility/_review_form.html.slim
+++ b/app/views/admin/form_answers/corp_responsibility/_review_form.html.slim
@@ -20,7 +20,7 @@
 
     .form-actions.text-right
       .form-fields
-        = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
+        = link_to "Cancel", "#", class: "btn btn-default js-corp-responsibility-form-cancel-link if-no-js-hide"
         = link_to "Save", "#", class: "btn btn-primary save-corp-responsibility pull-right", style: "display: none"
 
     .clear


### PR DESCRIPTION
[NOTE]: after deploy need to run:

```
bundle exec rake form_answers:set_corp_responsibility_trigger
```

[Trello Story](https://trello.com/c/QvAzlMX6/422-qae-once-the-dcr-is-completed-do-not-allow-the-users-to-edit)

Bunch of final fixes