### PR TITLE
[User Dashboard] fix applications list content

### DIFF
--- a/app/views/content_only/_submitted_applications.html.slim
+++ b/app/views/content_only/_submitted_applications.html.slim
@@ -6,7 +6,6 @@
     = render("content_only/post_submission/winners", award_applications: award_applications)
   - elsif Settings.after_shortlisting_stage?
     = render("content_only/post_submission/shortlisted", award_applications: award_applications)
+    = render("content_only/post_submission/unsuccessful", award_applications: @user_award_forms.where(state: [:not_recommended, :not_awarded]))
   - else
     = render("content_only/post_submission/submitted", award_applications: award_applications)
-
-  = render("content_only/post_submission/unsuccessful", award_applications: @user_award_forms.where(state: [:not_recommended, :not_awarded]))


### PR DESCRIPTION
[Trello Story](https://trello.com/c/wqZlJuGz/244-qae-fix-display-of-applications-in-progress-we-should-not-be-displaying-this-before-the-shortlisted-state-is-announced)

FIX display of applications in progress/We should not be displaying
this before the shortlisted state is announced.

People should only know if they are shortlisted or not after
the short listed date is passed. ( and email sent out etc)