### PR TITLE
[Assessor] added ability to download original application PDF

### DIFF
--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -16,18 +16,6 @@ class Admin::FormAnswersController < Admin::BaseController
     })
   end
 
-  expose(:original_form_answer) do
-    @form_answer.original_form_answer
-  end
-
-  expose(:pdf_data) do
-    original_form_answer.decorate.pdf_generator
-  end
-
-  expose(:pdf_filename) do
-    "original_pdf_before_deadline_#{@form_answer.decorate.pdf_filename}"
-  end
-
   def index
     params[:search] ||= FormAnswerSearch::DEFAULT_SEARCH
     authorize :form_answer, :index?
@@ -37,18 +25,6 @@ class Admin::FormAnswersController < Admin::BaseController
     @form_answers = @search.results.group("form_answers.id")
                                    .page(params[:page])
                                    .includes(:comments)
-  end
-
-  def original_pdf_before_deadline
-    authorize @form_answer, :can_download_original_pdf_of_application_before_deadline?
-
-    respond_to do |format|
-      format.pdf do
-        send_data pdf_data.render,
-                  filename: pdf_filename,
-                  type: "application/pdf"
-      end
-    end
   end
 
   private

--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -1,7 +1,7 @@
 class Assessor::FormAnswersController < Assessor::BaseController
   include FormAnswerMixin
 
-  before_filter :load_resource, only: [:update_financials]
+  before_filter :load_resource, only: [:update_financials, :original_pdf_before_deadline]
 
   expose(:financial_pointer) do
     FormFinancialPointer.new(@form_answer, {

--- a/app/controllers/concerns/form_answer_mixin.rb
+++ b/app/controllers/concerns/form_answer_mixin.rb
@@ -57,6 +57,18 @@ module FormAnswerMixin
     redirect_to edit_form_path(@form_answer)
   end
 
+  def original_pdf_before_deadline
+    authorize @form_answer, :can_download_original_pdf_of_application_before_deadline?
+
+    respond_to do |format|
+      format.pdf do
+        send_data pdf_data.render,
+                  filename: pdf_filename,
+                  type: "application/pdf"
+      end
+    end
+  end
+
   private
 
   def primary_assessment
@@ -112,5 +124,17 @@ module FormAnswerMixin
       updated_by_id: pundit_user.id,
       updated_by_type: pundit_user.class
     }.merge(params[:financial_data])
+  end
+
+  def original_form_answer
+    @form_answer.original_form_answer
+  end
+
+  def pdf_data
+    original_form_answer.decorate.pdf_generator
+  end
+
+  def pdf_filename
+    "original_pdf_before_deadline_#{@form_answer.decorate.pdf_filename}"
   end
 end

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -77,10 +77,10 @@ class FormAnswerPolicy < ApplicationPolicy
 
   def can_review_corp_responsibility?
     can_see_corp_responsibility? &&
-    (admin? || subject.lead?(record) || subject.primary?(record))
+    can_update_by_admin_lead_and_primary_assessors?
   end
 
   def can_download_original_pdf_of_application_before_deadline?
-    admin? && record.submission_ended?
+    can_update_by_admin_lead_and_primary_assessors? && record.submission_ended?
   end
 end

--- a/app/views/admin/form_answers/docs/_download_original_application_pdf_before_deadline.html.slim
+++ b/app/views/admin/form_answers/docs/_download_original_application_pdf_before_deadline.html.slim
@@ -1,5 +1,8 @@
 - if policy(@form_answer).can_download_original_pdf_of_application_before_deadline?
-  = link_to original_pdf_before_deadline_admin_form_answer_url(@form_answer, format: :pdf),
+
+  - target_url = pundit_user.is_a?(Admin) ? original_pdf_before_deadline_admin_form_answer_url(@form_answer, format: :pdf) : original_pdf_before_deadline_assessor_form_answer_url(@form_answer, format: :pdf)
+
+  = link_to target_url,
             class: "btn btn-default btn-block",
             target: "_blank"
     span.glyphicon.glyphicon-file

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,10 @@ Rails.application.routes.draw do
     resources :review_audit_certificates, only: [:create]
 
     resources :form_answers do
+      member do
+        get :original_pdf_before_deadline
+      end
+
       resources :form_answer_state_transitions, only: [:create]
       resources :comments
       resources :form_answer_attachments, only: [:create, :show, :destroy]

--- a/spec/features/admin/form_answers/download_original_pdf_before_deadline_ends_spec.rb
+++ b/spec/features/admin/form_answers/download_original_pdf_before_deadline_ends_spec.rb
@@ -9,122 +9,17 @@ So that I can see original application data was at the deadline moment
 
   let!(:admin) { create(:admin) }
 
+  let(:target_url) do
+    admin_form_answer_path(form_answer)
+  end
+
+  let(:pdf_url) do
+    original_pdf_before_deadline_admin_form_answer_url(form_answer, format: :pdf)
+  end
+
   before do
     login_admin(admin)
   end
 
-  let!(:form_answer) do
-    f = create(:form_answer, :trade, :submitted)
-    f.document["corp_responsibility_form"] = "declare_now"
-    f.save!
-
-    f
-  end
-
-  let!(:deadline) do
-    Settings.current_submission_deadline
-  end
-
-  describe "Policies" do
-    describe "Submission not ended" do
-      before do
-        deadline.trigger_at = DateTime.now + 1.day
-        deadline.save!
-
-        visit admin_form_answer_path(form_answer)
-      end
-
-      it "should do not display download button" do
-        expect_to_see_no "Download original PDF before deadline"
-      end
-    end
-  end
-
-  describe "Download" do
-    let(:pdf_url) do
-      original_pdf_before_deadline_admin_form_answer_url(form_answer, format: :pdf)
-    end
-
-    before do
-      deadline.trigger_at = DateTime.now - 1.day
-      deadline.save!
-    end
-
-    describe "Button displaying" do
-      before do
-        visit admin_form_answer_path(form_answer)
-      end
-
-      it "should display download button" do
-        expect(page).to have_link(
-          "Download original PDF before deadline", pdf_url
-        )
-      end
-    end
-
-    describe "PDF generation" do
-      let(:pdf_filename) do
-        "original_pdf_before_deadline_#{form_answer.decorate.pdf_filename}"
-      end
-
-      before do
-        visit pdf_url
-      end
-
-      it "should generate pdf file" do
-        expect(page.status_code).to eq(200)
-        expect(page.response_headers["Content-Disposition"]).to be_eql(
-          "attachment; filename=\"#{pdf_filename}\""
-        )
-        expect(page.response_headers["Content-Type"]).to be_eql "application/pdf"
-      end
-    end
-
-    describe "PDF content" do
-      let(:registration_number_at_the_deadline) {
-        "1111111111".upcase
-      }
-
-      let(:registration_number_after_deadline) {
-        "2222222222".upcase
-      }
-
-      let(:original_form_answer) do
-        form_answer.original_form_answer
-      end
-
-      let(:pdf_generator) do
-        original_form_answer.decorate.pdf_generator
-      end
-
-      let(:pdf_content) do
-        PDF::Inspector::Text.analyze(pdf_generator.render).strings
-      end
-
-      before do
-        # Turn onn Papertrail
-        PaperTrail.enabled = true
-
-        # Set current time to date before deadline
-        Timecop.freeze(DateTime.now - 2.days) do
-          form_answer.reload
-          form_answer.document["registration_number"] = registration_number_at_the_deadline
-          form_answer.save!
-        end
-
-        # Update value after deadline
-        form_answer.reload
-        form_answer.document["registration_number"] = registration_number_after_deadline
-        form_answer.save!
-
-        # Turn off Papertrail
-        PaperTrail.enabled = false
-      end
-
-      it "should include main header information" do
-        expect(pdf_content).to include(registration_number_at_the_deadline)
-        expect(pdf_content).to_not include(registration_number_after_deadline)
-      end
-    end
-  end
+  it_behaves_like "download original pdf before deadline ends"
 end

--- a/spec/features/assessor/download_original_pdf_before_deadline_ends_spec.rb
+++ b/spec/features/assessor/download_original_pdf_before_deadline_ends_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+describe "Assessor: Download original pdf of application at the deadline", %q{
+As an Assessor (Lead / Primary)
+I want to download original PDF of application at the deadline
+So that I can see original application data was at the deadline moment
+} do
+
+  let(:target_url) do
+    assessor_form_answer_path(form_answer)
+  end
+
+  let(:pdf_url) do
+    original_pdf_before_deadline_assessor_form_answer_url(form_answer, format: :pdf)
+  end
+
+  describe "Lead Assessor" do
+    let!(:lead_assessor) { create(:assessor, :lead_for_all) }
+
+    before do
+      login_as(lead_assessor, scope: :assessor)
+    end
+
+    it_behaves_like "download original pdf before deadline ends"
+  end
+
+  describe "Primary Assessor" do
+    let!(:primary_assessor) { create(:assessor, :regular_for_trade) }
+    let!(:primary) { form_answer.assessor_assignments.primary }
+
+    before do
+      primary.assessor = primary_assessor
+      primary.save
+
+      login_as(primary_assessor, scope: :assessor)
+    end
+
+    it_behaves_like "download original pdf before deadline ends"
+  end
+end

--- a/spec/support/shared_contexts/download_original_pdf_before_deadline_ends.rb
+++ b/spec/support/shared_contexts/download_original_pdf_before_deadline_ends.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+shared_context "download original pdf before deadline ends" do
+  let!(:form_answer) do
+    f = create(:form_answer, :trade, :submitted)
+    f.document["corp_responsibility_form"] = "declare_now"
+    f.save!
+
+    f
+  end
+
+  let!(:deadline) do
+    Settings.current_submission_deadline
+  end
+
+  describe "Policies" do
+    describe "Submission not ended" do
+      before do
+        deadline.trigger_at = DateTime.now + 1.day
+        deadline.save!
+
+        visit target_url
+      end
+
+      it "should do not display download button" do
+        expect_to_see_no "Download original PDF before deadline"
+      end
+    end
+  end
+
+  describe "Download" do
+    before do
+      deadline.trigger_at = DateTime.now - 1.day
+      deadline.save!
+    end
+
+    describe "Button displaying" do
+      before do
+        visit target_url
+      end
+
+      it "should display download button" do
+        expect(page).to have_link(
+          "Download original PDF before deadline", pdf_url
+        )
+      end
+    end
+
+    describe "PDF generation" do
+      let(:pdf_filename) do
+        "original_pdf_before_deadline_#{form_answer.decorate.pdf_filename}"
+      end
+
+      before do
+        visit pdf_url
+      end
+
+      it "should generate pdf file" do
+        expect(page.status_code).to eq(200)
+        expect(page.response_headers["Content-Disposition"]).to be_eql(
+          "attachment; filename=\"#{pdf_filename}\""
+        )
+        expect(page.response_headers["Content-Type"]).to be_eql "application/pdf"
+      end
+    end
+
+    describe "PDF content" do
+      let(:registration_number_at_the_deadline) {
+        "1111111111".upcase
+      }
+
+      let(:registration_number_after_deadline) {
+        "2222222222".upcase
+      }
+
+      let(:original_form_answer) do
+        form_answer.original_form_answer
+      end
+
+      let(:pdf_generator) do
+        original_form_answer.decorate.pdf_generator
+      end
+
+      let(:pdf_content) do
+        PDF::Inspector::Text.analyze(pdf_generator.render).strings
+      end
+
+      before do
+        # Turn onn Papertrail
+        PaperTrail.enabled = true
+
+        # Set current time to date before deadline
+        Timecop.freeze(DateTime.now - 2.days) do
+          form_answer.reload
+          form_answer.document["registration_number"] = registration_number_at_the_deadline
+          form_answer.save!
+        end
+
+        # Update value after deadline
+        form_answer.reload
+        form_answer.document["registration_number"] = registration_number_after_deadline
+        form_answer.save!
+
+        # Turn off Papertrail
+        PaperTrail.enabled = false
+      end
+
+      it "should include main header information" do
+        expect(pdf_content).to include(registration_number_at_the_deadline)
+        expect(pdf_content).to_not include(registration_number_after_deadline)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello Story](https://trello.com/c/TS7BZGtA/243-display-a-button-for-admins-to-download-the-original-pdf-of-the-application-at-the-deadline)

```
Assessors should also be able to download the orginal pdf
of the application at the deadline
```