### PR TITLE
[Admin] ability to remove Audit Certificate

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -13,6 +13,7 @@ ready = ->
   handleWinnersForm()
   handleReviewAuditCertificate()
   handleReviewCorpResponsibility()
+  handleRemovingOfAuditCertificate()
 
   # Move the attach document button
   moveAttachDocumentButton = ->
@@ -407,6 +408,12 @@ handleReviewCorpResponsibility = ->
     $("form.corp-responsibility-review.form-actions").hide()
     $(".edit-corp-responsibility").show()
 
+    return false
+
+handleRemovingOfAuditCertificate = ->
+  $(document).on "click", ".js-remove-audit-certificate-link", (e) ->
+    $(this).closest("form").submit()
+    $(this).closest("li").remove()
     return false
 
 $(document).ready(ready)

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -625,3 +625,7 @@
     margin-left: 20px;
   }
 }
+
+.js-remove-audit-certificate-link span {
+  margin-top: 0;
+}

--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -6,7 +6,8 @@ class Admin::FormAnswersController < Admin::BaseController
     :show,
     :update,
     :update_financials,
-    :original_pdf_before_deadline
+    :original_pdf_before_deadline,
+    :remove_audit_certificate
   ]
 
   expose(:financial_pointer) do
@@ -25,6 +26,22 @@ class Admin::FormAnswersController < Admin::BaseController
     @form_answers = @search.results.group("form_answers.id")
                                    .page(params[:page])
                                    .includes(:comments)
+  end
+
+  def remove_audit_certificate
+    authorize @form_answer, :remove_audit_certificate?
+
+    @form_answer.audit_certificate.destroy
+
+    respond_to do |format|
+      format.html do
+        flash.notice = "Audit Certificate successfully removed"
+        redirect_to admin_form_answer_url(@form_answer)
+      end
+      format.js do
+        render nothing: true
+      end
+    end
   end
 
   private

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -61,6 +61,10 @@ class FormAnswerPolicy < ApplicationPolicy
     record.audit_certificate.scan.clean?
   end
 
+  def remove_audit_certificate?
+    admin? && record.audit_certificate.present?
+  end
+
   def has_access_to_post_shortlisting_docs?
     download_feedback_pdf? ||
     download_case_summary_pdf? ||

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -4,6 +4,19 @@ ul.list-unstyled.list-actions
     li
       = link_to "View/print Audit Certificate", [url_namespace, @form_answer, @form_answer.audit_certificate], target: "_blank"
 
+      - if policy(resource).remove_audit_certificate?
+        small.pull-right
+          = form_for(@form_answer,
+                     url: remove_audit_certificate_admin_form_answer_url(@form_answer),
+                     html: { remote: true, method: :patch, style: "display:inline-block;"}) do |f|
+
+            = f.submit 'Remove', class: 'if-js-hide'
+
+            = link_to "#", class: "text-danger if-no-js-hide js-remove-audit-certificate-link", data: {confirm: "Are you sure?"}
+              span.glyphicon.glyphicon-remove
+              span.visible-lg.visible-md
+                ' Remove
+
   - if policy(resource).download_case_summary_pdf?
     li
       = link_to "View/print Case Summary", admin_form_answer_case_summaries_path(@form_answer, format: :pdf)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,6 +196,7 @@ Rails.application.routes.draw do
     resources :form_answers do
       member do
         get :original_pdf_before_deadline
+        patch :remove_audit_certificate
       end
 
       resources :form_answer_state_transitions, only: [:create]

--- a/spec/features/admin/form_answers/remove_audit_certificate_spec.rb
+++ b/spec/features/admin/form_answers/remove_audit_certificate_spec.rb
@@ -47,7 +47,7 @@ So that User can re-upload Audit Certificate
     end
   end
 
-  describe "Removing", js: true do
+  describe "Removing", js: true, skip_travis: true do
     let!(:admin) { create(:admin) }
 
     before do

--- a/spec/features/admin/form_answers/remove_audit_certificate_spec.rb
+++ b/spec/features/admin/form_answers/remove_audit_certificate_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+describe "Admin: ability to remove Audit Certificate", %q{
+As an Admin
+I want to have ability to delete the auditors certificate in case the user has uploaded it in error
+So that User can re-upload Audit Certificate
+} do
+
+  let!(:form_answer) do
+    create(:form_answer, :development, :submitted, :with_audit_certificate)
+  end
+
+  describe "Policies" do
+    let(:target_url) do
+      assessor_form_answer_path(form_answer)
+    end
+
+    describe "Lead Assessor" do
+      let!(:lead_assessor) { create(:assessor, :lead_for_all) }
+
+      before do
+        login_as(lead_assessor, scope: :assessor)
+        visit target_url
+      end
+
+      it "should not allow to remove Audit Certificate" do
+        expect(page).to_not have_selector(:css, "a.js-remove-audit-certificate-link")
+      end
+    end
+
+    describe "Primary Assessor" do
+      let!(:primary_assessor) { create(:assessor, :regular_for_all) }
+      let!(:primary) { form_answer.assessor_assignments.primary }
+
+      before do
+        primary.assessor = primary_assessor
+        primary.save!
+
+        login_as(primary_assessor, scope: :assessor)
+        visit target_url
+      end
+
+      it "should not allow to remove Audit Certificate" do
+        expect(page).to_not have_selector(:css, "a.js-remove-audit-certificate-link")
+      end
+    end
+  end
+
+  describe "Removing", js: true do
+    let!(:admin) { create(:admin) }
+
+    before do
+      login_admin(admin)
+
+      visit admin_form_answer_path(form_answer)
+    end
+
+    it "should remove Audit Certificate" do
+      expect(form_answer.audit_certificate.present?).to be_truthy
+
+      find(".js-remove-audit-certificate-link").click
+      wait_for_ajax
+
+      expect(form_answer.reload.audit_certificate.present?).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
[Trello Story](https://trello.com/c/enSgNSte/248-qae-admins-can-delete-the-auditors-certificate-in-case-the-user-has-uploaded-it-in-error)

Some users have uploaded the blank form, and the admins need to be deleted.
And the status will need to go back to incomplete so they can reupload it.
Also need to updated the cases status report so it says the certificate has not been uploaded.