### PR TITLE
[Admin] Cases Status Report corrects

### DIFF
--- a/app/models/reports/cases_status_report.rb
+++ b/app/models/reports/cases_status_report.rb
@@ -47,8 +47,8 @@ class Reports::CasesStatusReport
       method: :case_summary_overall_grade
     },
     {
-      label: "PressReleaseUpdated",
-      method: :press_release_updated
+      label: "Overall Status",
+      method: :overall_status
     },
     {
       label: "ACReceived",
@@ -73,6 +73,10 @@ class Reports::CasesStatusReport
     {
       label: "FeedbackComplete",
       method: :feedback_complete
+    },
+    {
+      label: "PressReleaseUpdated",
+      method: :press_release_updated
     },
     {
       label: "CaseWithdrawn",


### PR DESCRIPTION
[Trello Story](https://trello.com/c/Y8nggZuS/247-qae-new-column-in-the-cases-status-report)

1) Add 'Overall Status' column, it should be positioned after the 'CaseSummaryOverallGrade' column.
2) Move the 'PressReleaseUpdated' column to appear after the 'FeedbackComplete' column.