### PR TITLE
[Admin / Assessor] simple_format helper issue

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -165,7 +165,7 @@ ready = ->
     formGroup.removeClass("form-edit")
 
     if area.val().length
-      formGroup.find(".form-value p").text(area.val())
+      formGroup.find(".form-value p").html(area.val().replace(/\n/g, '<br />'))
       updatedSection = link.data("updated-section")
       $(this).closest(".panel-body").find(".field-with-errors").removeClass("field-with-errors")
       $(this).closest(".panel-body").find(".feedback-holder.error").html("")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,4 +85,17 @@ module ApplicationHelper
   def format_date(date)
     date.strftime("%e %b %Y at %H:%M")
   end
+
+  # Custom version of http://apidock.com/rails/v4.2.1/ActionView/Helpers/TextHelper/simple_format
+  # Because we do not need tag wrappers
+  def qae_simple_format(text)
+    text = sanitize(text)
+    paragraphs = split_paragraphs(text)
+
+    if paragraphs.present?
+      paragraphs.map! { |paragraph|
+        raw(paragraph)
+      }.join("\n\n").html_safe
+    end
+  end
 end

--- a/app/views/admin/form_answers/_comment.html.slim
+++ b/app/views/admin/form_answers/_comment.html.slim
@@ -29,7 +29,7 @@
             = f.submit 'Delete', class: "btn btn-danger link-delete-comment-confirm"
 
   .comment-content
-    = simple_format comment.body
+    = qae_simple_format comment.body
 
   = form_for([namespace_name, @form_answer, comment],
              remote: true,

--- a/app/views/admin/form_answers/_comment_read_only.html.slim
+++ b/app/views/admin/form_answers/_comment_read_only.html.slim
@@ -4,7 +4,7 @@
       = comment_read_only.author_email
 
   .comment-content
-    = simple_format comment_read_only.body
+    = qae_simple_format comment_read_only.body
 
 
   label.if-js-hide Flag

--- a/app/views/admin/form_answers/_section_draft_notes.html.slim
+++ b/app/views/admin/form_answers/_section_draft_notes.html.slim
@@ -19,7 +19,7 @@
             .form-value
               p
                 - if f.object.content.present?
-                  = simple_format f.object.content
+                  = qae_simple_format f.object.content
                 - else
                   em.text-muted No draft notes added yet.
             = f.input :content,

--- a/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
@@ -4,7 +4,7 @@
     .form-value
       p
         - if f.object.application_background_section_desc.present?
-          = simple_format f.object.application_background_section_desc
+          = qae_simple_format f.object.application_background_section_desc
         - else
           em.text-muted No comment has been added yet.
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_non_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_non_rag_section.html.slim
@@ -10,7 +10,7 @@
     .form-value
       p
         - if f.object.public_send(section.desc).present?
-          = simple_format f.object.public_send(section.desc)
+          = qae_simple_format f.object.public_send(section.desc)
         - else
           em.text-muted No comment has been added yet.
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -29,7 +29,7 @@
     .form-value
       p
         - if f.object.public_send(section.desc).present?
-          = simple_format f.object.public_send(section.desc)
+          = qae_simple_format f.object.public_send(section.desc)
         - else
           em.text-muted No comment has been added yet.
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -38,7 +38,7 @@
     .form-value
       p
         - if f.object.public_send(section.desc).present?
-          = simple_format f.object.public_send(section.desc)
+          = qae_simple_format f.object.public_send(section.desc)
         - else
           em.text-muted No comment has been added yet.
       .clear


### PR DESCRIPTION
Related to [Trello Story](https://trello.com/c/DnykSDMv/246-qae-issue-with-qa0590-16s-admins-should-be-able-to-change-verdict-on-moderated-forms)

So we use simple_format helper for displaying linebreaks in assessor / admin
comments/ drafts and other 'textarea' content blocks.
http://apidock.com/rails/v4.2.1/ActionView/Helpers/TextHelper/simple_format

Problem is that simple_format always adds wrapper tags (p - by default)
It causes issue on JS code after clicking on 'Save'. (Attached screenshot below)
And there are no way to skip it as if you pass empty 'wrapper_tag' option like:

```
simple_format text, {}, wrapper_tag: ""
```
it will add brackets without any tag:
```
<>
```

So that's we overrided source code of simple_format and now
will use own qae_simple_format helper.