### PR TITLE
[Admin] should be able to change verdict on moderated forms

### DIFF
--- a/app/models/assessor_assignment.rb
+++ b/app/models/assessor_assignment.rb
@@ -80,7 +80,8 @@ class AssessorAssignment < ActiveRecord::Base
   end
 
   def moderated_rag_editable_for?(subject,  moderated_assessment)
-    subject.is_a?(Admin) || position != "moderated" || !moderated_assessment.submitted?
+    editable_for?(subject) &&
+    (subject.is_a?(Admin) || position != "moderated" || !moderated_assessment.submitted?)
   end
 
   def as_json

--- a/app/models/assessor_assignment.rb
+++ b/app/models/assessor_assignment.rb
@@ -79,6 +79,16 @@ class AssessorAssignment < ActiveRecord::Base
     owner_or_administrative?(subject)
   end
 
+  def moderated_rag_editable_for?(subject,  moderated_assessment)
+    rag_editable = true
+
+    if position == "moderated" && moderated_assessment.submitted?
+      rag_editable = subject.is_a?(Admin)
+    end
+
+    rag_editable
+  end
+
   def as_json
     if errors.blank?
       {}

--- a/app/models/assessor_assignment.rb
+++ b/app/models/assessor_assignment.rb
@@ -80,13 +80,7 @@ class AssessorAssignment < ActiveRecord::Base
   end
 
   def moderated_rag_editable_for?(subject,  moderated_assessment)
-    rag_editable = true
-
-    if position == "moderated" && moderated_assessment.submitted?
-      rag_editable = subject.is_a?(Admin)
-    end
-
-    rag_editable
+    subject.is_a?(Admin) || position != "moderated" || !moderated_assessment.submitted?
   end
 
   def as_json

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -12,13 +12,13 @@
 
     label.form-label.form-label-rag
       = section.label
-      .btn-group.btn-rag class="#{'rag-editable' if editable && rag_editable}"
-        button.btn.btn-link.dropdown-toggle class="#{'non-editable' if !editable || !rag_editable}" type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
+      .btn-group.btn-rag class="#{'rag-editable' if rag_editable}"
+        button.btn.btn-link.dropdown-toggle class="#{'non-editable' if !rag_editable}" type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
           span.rag-text= form.option[0]
           span.glyphicon.icon-rag
-          - if editable && rag_editable
+          - if rag_editable
             span.caret
-        - if editable && rag_editable
+        - if rag_editable
           ul.dropdown-menu.pull-right role="menu"
             - form.options.each do |opt|
               li class="rag-#{opt[1]}"

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -1,15 +1,6 @@
 - form = AppraisalForm.verdict_options_for(f.object, section)
 - editable = f.object.editable_for?(current_subject)
-
-/ # TODO will probably need to move this into policies
-- rag_editable = true
-/ If this is a moderated verdict
-- if f && f.object && f.object.position == "moderated"
-  / If moderacted assessment has been submitted
-  - if moderated_assessment.submitted?
-    / Only admins can edit moderated verdict RAGs after submission
-    - unless (current_user && current_user.account_admin?)
-      - rag_editable = false
+- rag_editable = f.object.moderated_rag_editable_for?(current_subject, moderated_assessment)
 
 .form-group.verdict-section class="#{'form-edit' if f.object.public_send(section.desc).blank?} form-#{section.label.parameterize}"
   .form-container


### PR DESCRIPTION
[Trello Story](https://trello.com/c/DnykSDMv/246-qae-issue-with-qa0590-16s-admins-should-be-able-to-change-verdict-on-moderated-forms)

Rules:

1) Admin can edit Rags for "APPRAISAL FORM (MODERATED)" always
2) Primary and Lead can edit Rags for "APPRAISAL FORM (MODERATED)" only BEFORE "APPRAISAL FORM (MODERATED)" submitted?