### PR TITLE
[Admin / Assessors] Appraisal Form and Case Summary permission corrects

### DIFF
--- a/app/helpers/case_summary_helper.rb
+++ b/app/helpers/case_summary_helper.rb
@@ -22,4 +22,9 @@ module CaseSummaryHelper
       title: title
     )
   end
+
+  def submit_case_summary_title(assessment)
+    prefix = policy(assessment).can_be_submitted? ? "Confirm" : "Re-submit"
+    "#{prefix} case summary"
+  end
 end

--- a/app/policies/assessor_assignment_policy.rb
+++ b/app/policies/assessor_assignment_policy.rb
@@ -9,4 +9,12 @@ class AssessorAssignmentPolicy < ApplicationPolicy
     record.assessor == subject ||
       subject.lead?(record.form_answer)
   end
+
+  def can_be_submitted?
+    submit? && !record.submitted?
+  end
+
+  def can_be_re_submitted?
+    submit? && record.submitted? && record.case_summary?
+  end
 end

--- a/app/services/assessment_submission_service.rb
+++ b/app/services/assessment_submission_service.rb
@@ -9,18 +9,28 @@ class AssessmentSubmissionService
   delegate :form_answer, to: :resource
 
   def perform
-    return if resource.submitted?
-    if submit_assessment
-      populate_case_summary
-    end
+    if resource.submitted?
+      resubmit! if resource.case_summary?
+    else
+      if submit_assessment
+        populate_case_summary
+      end
 
-    if resource.moderated?
-      form_answer.state_machine.assign_lead_verdict(resource.verdict_rate, current_subject)
-    end
+      if resource.moderated?
+        form_answer.state_machine.assign_lead_verdict(resource.verdict_rate, current_subject)
+      end
 
-    if resource.case_summary?
-      perform_state_transition!
+      if resource.case_summary?
+        perform_state_transition!
+      end
     end
+  end
+
+  def resubmit!
+    # TODO: probably need further actions!
+    # NEED TO CONFIRM!
+    #
+    set_submitted_at_as_now!
   end
 
   delegate :as_json, to: :resource
@@ -28,6 +38,10 @@ class AssessmentSubmissionService
   private
 
   def submit_assessment
+    set_submitted_at_as_now!
+  end
+
+  def set_submitted_at_as_now!
     resource.update(submitted_at: DateTime.now)
   end
 

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -31,14 +31,14 @@
           .clear
           br
 
-          - unless assessment.submitted?
+          - if policy(assessment).can_be_submitted? || policy(assessment).can_be_re_submitted?
             = form_tag(url_for([namespace_name, :assessment_submissions]), remote: true, authenticity_token: true, class: "submit-assessment", "data-type" => "json")
               = hidden_field_tag :assessment_id, assessment.id
 
               .feedback-holder
 
               .pull-right
-                = submit_tag "Confirm case summary", class: "btn btn-primary btn-confirm-submit"
+                = submit_tag submit_case_summary_title(assessment), class: "btn btn-primary btn-confirm-submit"
               .clear
           - else
             / Only show once primary assessor has submitted the case summary

--- a/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
@@ -1,4 +1,6 @@
-.form-group.application-background-section class="#{'form-edit' if f.object.application_background_section_desc.blank?}"
+- editable = f.object.editable_for?(current_subject)
+
+.form-group.application-background-section class="#{'form-edit' if f.object.application_background_section_desc.blank? && editable}"
   .form-container
     label.form-label Application background
     .form-value
@@ -14,8 +16,10 @@
               input_html: { class: "form-control", rows: 10 },
               as: :text,
               label: false
-    = link_to "#", class: "form-edit-link pull-right"
-      span.glyphicon.glyphicon-pencil
-      ' Edit
-    = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide"
-    .clear
+
+    - if editable
+      = link_to "#", class: "form-edit-link pull-right"
+        span.glyphicon.glyphicon-pencil
+        ' Edit
+      = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide"
+      .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_non_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_non_rag_section.html.slim
@@ -2,7 +2,7 @@
 
 - editable = f.object.editable_for?(current_subject)
 
-.form-group.rag-section class="#{'form-edit' if f.object.public_send(section.desc).blank?}"
+.form-group.rag-section class="#{'form-edit' if f.object.public_send(section.desc).blank? && editable}"
   .form-container
     label.form-label
       = section.label
@@ -21,7 +21,7 @@
               as: :text,
               label: false
 
-    - if f.object.editable_for?(current_subject)
+    - if editable
       = link_to "#", class: "form-edit-link pull-right"
         span.glyphicon.glyphicon-pencil
         ' Edit

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -2,7 +2,7 @@
 
 - editable = f.object.editable_for?(current_subject)
 
-.form-group.rag-section class="#{'form-edit' if f.object.public_send(section.desc).blank?} form-#{section.label.parameterize}"
+.form-group.rag-section class="#{'form-edit' if f.object.public_send(section.desc).blank? && editable} form-#{section.label.parameterize}"
   .form-container
     = f.input section.rate,
               as: :select,
@@ -40,7 +40,7 @@
               as: :text,
               label: false
 
-    - if f.object.editable_for?(current_subject)
+    - if editable
       = link_to "#", class: "form-edit-link pull-right"
         span.glyphicon.glyphicon-pencil
         ' Edit

--- a/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
@@ -1,4 +1,4 @@
-- unless assessment.submitted?
+- if policy(assessment).can_be_submitted?
   = form_tag(url_for([namespace_name, :assessment_submissions]),
             remote: true,
             authenticity_token: true,

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -2,7 +2,7 @@
 - editable = f.object.editable_for?(current_subject)
 - rag_editable = f.object.moderated_rag_editable_for?(current_subject, moderated_assessment)
 
-.form-group.verdict-section class="#{'form-edit' if f.object.public_send(section.desc).blank?} form-#{section.label.parameterize}"
+.form-group.verdict-section class="#{'form-edit' if f.object.public_send(section.desc).blank? && editable} form-#{section.label.parameterize}"
   .form-container
     = f.input section.rate,
               as: :select,


### PR DESCRIPTION
[Trello Story](https://trello.com/c/oWn49UIf/449-qae-admin-and-lead-assessors-should-be-able-to-re-submit-case-summary-if-the-details-have-changed-in-between-assessment-rounds)

Corrects rules:

* Primary can edit APPRAISAL FORM (PRIMARY) and Case Summary before submitted
* Secondary can edit APPRAISAL FORM (SECONDARY) before submitted
* Leads and Admin can edit all (PRIMARY, SECONDARY, MODERATED and CASE SUMMARY) any time and re-submit Case Summary