### PR TITLE
[Case Summary PDF] corrects

### DIFF
--- a/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
@@ -25,7 +25,7 @@ module CaseSummaryPdfs::General::DataPointer
       employees_year_entry(field)
     end.compact
 
-    res.present? ? res.map(&:to_s).max : undefined_value
+    res.present? ? res.last : undefined_value
   end
 
   def employees_year_entry(field)

--- a/app/pdf_generators/case_summary_pdfs/general/draw_elements.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/draw_elements.rb
@@ -7,10 +7,14 @@ module CaseSummaryPdfs::General::DrawElements
     render_logo(695, 137.5)
     render_urn(0, 137)
     render_applicant(0, 129.5)
-    render_employees
-    render_sic_code
-    render_current_awards
-    render_sub_category(0, 99.5) unless form_answer.promotion?
+
+    unless form_answer.promotion?
+      render_employees
+      render_sic_code
+      render_current_awards
+      render_sub_category(0, 99.5)
+    end
+
     render_award_general_information(130, 137)
     render_award_title(130, 129.5)
   end

--- a/app/pdf_generators/shared_pdf_helpers/data_helpers.rb
+++ b/app/pdf_generators/shared_pdf_helpers/data_helpers.rb
@@ -11,7 +11,7 @@ module SharedPdfHelpers::DataHelpers
         end[1]
 
         if selected_option == options.values.max
-          "Сontinuous"
+          "Continuous"
         else
           "Outstanding"
         end


### PR DESCRIPTION
[Trello Story](https://trello.com/c/gvQ0OgDP/457-qae-case-summary-pdf-changes)

* With the QAEP top headings we only need the QA ref and the nominee name
* When I did a test in staging of a Trade case QA0032/16T, the number of employees is showing as 600 which is the first year, but it should be the last year i.e. 111. This should be the case also for the other two business categories.- So change the pdf to display the last year (the most current)