### PR TITLE
[Jquery File Upload] issues with 'incorrect' handling of failed callback

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -422,16 +422,19 @@ jQuery ->
       wrapper.removeClass("question-has-errors")
       wrapper.find(".errors-container").empty()
 
-    failed = (e, data) ->
-      error_json = data.jqXHR.responseJSON
-      if error_json
-        error_key = Object.keys(error_json)[0]
-        error_message = data.jqXHR.responseJSON[error_key]
+    success_or_error = (e, data) ->
+      errors = data.result.errors
+
+      if errors
+        failed(errors.toString())
       else
-        error_message = data.jqXHR.responseText
+        upload_done(e, data)
+
+    failed = (error_message) ->
       if error_message
         wrapper.addClass("question-has-errors")
         wrapper.find(".errors-container").html("<li>" + error_message + "</li>")
+
       # Remove `Uploading...`
       list.find(".js-uploading").remove()
       list.removeClass("visuallyhidden")
@@ -514,10 +517,9 @@ jQuery ->
             value: $el.data("question-key")
           }
         ]
-        done: upload_done
         progressall: progress_all
         send: upload_started
-        fail: failed
+        always: success_or_error
       )
 
   $(document).on "click", ".js-upload-wrapper .remove-link", (e) ->

--- a/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
+++ b/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
@@ -36,14 +36,22 @@ window.AuditCertificatesUpload =
       list.find(".li-audit-upload").removeClass("hidden")
       $(".js-audit-certificate-status-message").remove()
 
-    failed = (e, data) ->
-      error_message = data.jqXHR.responseText
+    failed = (error_message) ->
       parent.find(".errors-container").html("<li>" + error_message + "</li>")
       list.addClass("hidden")
       form.removeClass("hidden")
+
       # Remove `Uploading...`
       list.find(".js-uploading").remove()
       list.removeClass("hidden")
+
+    success_or_error = (e, data) ->
+      errors = data.result.errors
+
+      if errors
+        failed(errors.toString())
+      else
+        upload_done(e, data)
 
     $el.fileupload(
       url: form.attr("action") + ".json"
@@ -52,8 +60,7 @@ window.AuditCertificatesUpload =
       formData: [
         { name: "authenticity_token", value: $("meta[name='csrf-token']").attr("content") }
       ]
-      done: upload_done
       progressall: progress_all
       send: upload_started
-      fail: failed
+      always: success_or_error
     )

--- a/app/assets/javascripts/frontend/custom_questions/support_letters.js.coffee
+++ b/app/assets/javascripts/frontend/custom_questions/support_letters.js.coffee
@@ -13,7 +13,7 @@ window.SupportLetters =
     $el = $(el)
     parent = $el.closest("label")
 
-    upload_done = (e, data, link) ->
+    upload_done = (e, data) ->
       SupportLetters.clean_up_system_tags(parent)
 
       if data.result['original_filename']
@@ -29,11 +29,18 @@ window.SupportLetters =
       parent.append(hidden_input)
       SupportLetters.autosave()
 
-    failed = (e, data) ->
+    failed = (error_message) ->
       SupportLetters.clean_up_system_tags(parent)
-      error_message = data.jqXHR.responseText
       parent.find(".errors-container").html("<li>" + error_message + "</li>")
       parent.closest("label").addClass("question-has-errors")
+
+    success_or_error = (e, data) ->
+      errors = data.result.errors
+
+      if errors
+        failed(errors.toString())
+      else
+        upload_done(e, data)
 
     $el.fileupload(
       url: $el.closest(".list-add").data('attachments-url') + ".json"
@@ -42,8 +49,7 @@ window.SupportLetters =
       formData: [
         { name: "authenticity_token", value: $("meta[name='csrf-token']").attr("content") }
       ]
-      done: upload_done
-      fail: failed
+      always: success_or_error
     )
 
   clean_up_system_tags: (parent) ->

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -243,7 +243,8 @@ class FormController < ApplicationController
         # text/plain content type is needed for jquery.fileupload
         render json: @attachment, status: :created, content_type: "text/plain"
       else
-        render json: @attachment.errors, status: 500
+        render json: { errors: humanized_upload_errors }.to_json,
+               status: :unprocessable_entity
       end
     end
   end
@@ -338,5 +339,13 @@ class FormController < ApplicationController
 
       return false
     end
+  end
+
+  def humanized_upload_errors
+    @attachment.errors
+               .full_messages
+               .reject { |m| m == "File This field cannot be blank" }
+               .join(", ")
+               .gsub("File ", "")
   end
 end

--- a/app/controllers/users/audit_certificates_controller.rb
+++ b/app/controllers/users/audit_certificates_controller.rb
@@ -52,9 +52,8 @@ class Users::AuditCertificatesController < Users::BaseController
                  status: :created,
                  content_type: "text/plain"
         else
-          render json: humanized_errors,
-                 status: :unprocessable_entity,
-                 content_type: "text/plain"
+          render json: { errors: humanized_errors }.to_json,
+                 status: :unprocessable_entity
         end
       end
     end
@@ -81,6 +80,7 @@ class Users::AuditCertificatesController < Users::BaseController
                      .full_messages
                      .reject { |m| m == "Attachment This field cannot be blank" }
                      .join(", ")
+                     .gsub("Attachment ", "")
   end
 
   def check_if_audit_certificate_already_exist!

--- a/app/controllers/users/support_letter_attachments_controller.rb
+++ b/app/controllers/users/support_letter_attachments_controller.rb
@@ -21,7 +21,7 @@ class Users::SupportLetterAttachmentsController < Users::BaseController
              status: :created,
              content_type: "text/plain"
     else
-      render json: humanized_errors,
+      render json: { errors: humanized_errors }.to_json,
              status: :unprocessable_entity
     end
   end
@@ -42,6 +42,7 @@ class Users::SupportLetterAttachmentsController < Users::BaseController
       support_letter_attachment.errors.
                                full_messages.
                                reject { |m| m == "Attachment This field cannot be blank" }.
-                               join(", ")
+                               join(", ").
+                               gsub("Attachment ", "")
     end
 end


### PR DESCRIPTION
[Trello Story](https://trello.com/c/AWBB8b9q/459-investigate-upload-issue-with-audit-certificate-for-qa0494-16i)

Once we pass:
```
forceIframeTransport: true
```
which we need for IE support -> then Jquery File Upload handles error responses incorrectly

I debugged it and found that for FileUpload
```
422 Unprocessable Entity
```
then it comes with status = 200, which is wrong.

In other words: plugin things in this case that's all good, so that we see 'undefined' message
                instead of proper error messages.

It's plugin bug.
After researching and bunch of local tests I found that it's possible
to do handling via 'always' callback, where I can check response and then
call 'upload_done' or 'failed' methods manually.