### PR TITLE
[Case Summary PDF] corrects

### DIFF
--- a/app/forms/appraisal_form.rb
+++ b/app/forms/appraisal_form.rb
@@ -274,4 +274,16 @@ class AppraisalForm
   def self.rates(form_answer, type)
     struct(form_answer).select { |_, v| v[:type] == type }
   end
+
+  class << self
+    def group_labels_by(type)
+      %w(rag strength verdict).map do |label_type|
+        const_get("#{label_type.upcase}_OPTIONS").detect do |el|
+          el[1] == type
+        end
+      end.compact
+         .map { |el| el[0] }
+         .flatten
+    end
+  end
 end

--- a/app/pdf_generators/case_summary_pdfs/general/draw_elements.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/draw_elements.rb
@@ -4,33 +4,34 @@ module CaseSummaryPdfs::General::DrawElements
   end
 
   def main_header
-    render_logo(695, 137.5)
-    render_urn(0, 137)
-    render_applicant(0, 129.5)
+    render_official_sensitive(105, 137.5)
+    render_logo(695, 127.5)
+    render_urn(0, 127)
+    render_applicant(0, 119.5)
 
     unless form_answer.promotion?
       render_employees
       render_sic_code
       render_current_awards
-      render_sub_category(0, 99.5)
+      render_sub_category(0, 89.5)
     end
 
-    render_award_general_information(130, 137)
-    render_award_title(130, 129.5)
+    render_award_general_information(130, 127)
+    render_award_title(130, 119.5)
   end
 
   def render_employees
     pdf_doc.text_box "Employees: #{employees}",
-            header_text_properties.merge(at: [0.mm, 122.mm + default_offset])
+            header_text_properties.merge(at: [0.mm, 112.mm + default_offset])
   end
 
   def render_sic_code
     pdf_doc.text_box "SIC code: #{sic_code}",
-            header_text_properties.merge(at: [0.mm, 114.5.mm + default_offset])
+            header_text_properties.merge(at: [0.mm, 104.5.mm + default_offset])
   end
 
   def render_current_awards
     pdf_doc.text_box "Current Awards: #{current_awards}",
-            header_text_properties.merge(width: 650.mm, at: [0.mm, 107.mm + default_offset])
+            header_text_properties.merge(width: 650.mm, at: [0.mm, 97.mm + default_offset])
   end
 end

--- a/app/pdf_generators/shared_pdf_helpers/draw_elements.rb
+++ b/app/pdf_generators/shared_pdf_helpers/draw_elements.rb
@@ -4,6 +4,11 @@ module SharedPdfHelpers::DrawElements
   LOGO_ICON = "logo-pdf.png"
   AWARD_GENERAL_INFO_PREFIX = "The Queen's Awards for Enterprise"
 
+  def render_official_sensitive(x_coord, y_coord)
+    pdf_doc.text_box "OFFICIAL - SENSITIVE",
+                     header_text_properties.merge(at: [x_coord.mm, y_coord.mm + DEFAULT_OFFSET])
+  end
+
   def render_logo(x_coord, y_coord)
     pdf_doc.image "#{IMAGES_PATH}#{LOGO_ICON}",
                   at: [x_coord, y_coord.mm + DEFAULT_OFFSET],


### PR DESCRIPTION
[Trello Story](https://trello.com/c/L3WHDJ3n/252-case-summary-pdf-changes)

* On the first page of a case summary download for each entry
  can we have a security heading centre saying “OFFICIAL – SENSITIVE”

* SD summary seven “Key Strengths and Focuses boxes" Use values that are set in assessment,
  e.g. Positive – Scope for Ongoing Development instead of amber.