### PR TITLE
Case summary pdf corrects

### DIFF
--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -68,6 +68,10 @@ class FormAnswerDecorator < ApplicationDecorator
     object.company_or_nominee_name
   end
 
+  def company_nominee_or_application_name
+    company_or_nominee_name || application_name
+  end
+
   def data
     #object.document
     OpenStruct.new(object.document.merge(persisted?: true))

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -112,6 +112,7 @@ class FormAnswer < ActiveRecord::Base
     scope :winners, -> { where(state: %(recomended awarded)) }
     scope :unsuccessful, -> { where(state: %w(not_recommended not_awarded reserved)) }
     scope :submitted, -> { where(submitted: true) }
+    scope :positive, -> { where(state: FormAnswerStateMachine::POSITIVE_STATES) }
     scope :business, -> { where(award_type: %w(trade innovation development)) }
     scope :promotion, -> { where(award_type: "promotion") }
   end
@@ -153,6 +154,10 @@ class FormAnswer < ActiveRecord::Base
 
   def eligible?
     eligibility && eligibility.eligible? && (promotion? || (form_basic_eligibility && form_basic_eligibility.eligible?))
+  end
+
+  def in_positive_state?
+    FormAnswerStateMachine::POSITIVE_STATES.map(&:to_s).include?(state)
   end
 
   def document

--- a/app/models/form_answer_state_machine.rb
+++ b/app/models/form_answer_state_machine.rb
@@ -16,6 +16,12 @@ class FormAnswerStateMachine
     :not_awarded
   ]
 
+  POSITIVE_STATES = [
+    :reserved,
+    :recommended,
+    :awarded
+  ]
+
   state :eligibility_in_progress, initial: true
   state :application_in_progress
   state :submitted

--- a/app/pdf_generators/case_summary_pdfs/base.rb
+++ b/app/pdf_generators/case_summary_pdfs/base.rb
@@ -17,7 +17,7 @@ class CaseSummaryPdfs::Base < ReportPdfBase
   end
 
   def set_form_answers
-    @form_answers = FormAnswer.submitted
+    @form_answers = FormAnswer.positive
                               .includes(:lead_or_primary_assessor_assignments)
                               .for_award_type(options[:category])
                               .joins(:assessor_assignments)

--- a/app/pdf_generators/shared_pdf_helpers/draw_elements.rb
+++ b/app/pdf_generators/shared_pdf_helpers/draw_elements.rb
@@ -21,7 +21,7 @@ module SharedPdfHelpers::DrawElements
   end
 
   def render_applicant(x_coord, y_coord)
-    pdf_doc.text_box "Applicant: #{form_answer.decorate.application_name}",
+    pdf_doc.text_box "Applicant: #{form_answer.decorate.company_nominee_or_application_name}",
                      header_text_properties.merge(at: [x_coord.mm, y_coord.mm + DEFAULT_OFFSET])
   end
 

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -50,7 +50,7 @@ class FormAnswerPolicy < ApplicationPolicy
   end
 
   def download_case_summary_pdf?
-    admin? && record.submitted? && record.lead_or_primary_assessor_assignments.any?
+    admin? && record.in_positive_state? && record.lead_or_primary_assessor_assignments.any?
   end
 
   def download_audit_certificate_pdf?

--- a/spec/factories/form_answer_factory.rb
+++ b/spec/factories/form_answer_factory.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     end
 
     trait :recommended do
+      submitted true
       state "recommended"
     end
 

--- a/spec/support/shared_contexts/admin_case_summary_pdf_file_checks.rb
+++ b/spec/support/shared_contexts/admin_case_summary_pdf_file_checks.rb
@@ -5,7 +5,7 @@ shared_context "admin case summary pdf file checks" do
 
   let!(:form_answer) do
     create :form_answer,
-           :submitted,
+           :recommended,
            award_type,
            user: user
   end
@@ -46,7 +46,7 @@ shared_context "admin case summary pdf file checks" do
   end
 
   let(:applicant) do
-    "Applicant: #{form_answer.decorate.application_name}"
+    "Applicant: #{form_answer.decorate.company_nominee_or_application_name}"
   end
 
   let(:award_general_information) do

--- a/spec/support/shared_contexts/admin_feedback_pdf_file_checks.rb
+++ b/spec/support/shared_contexts/admin_feedback_pdf_file_checks.rb
@@ -41,7 +41,7 @@ shared_context "admin feedback pdf file checks" do
   end
 
   let(:applicant) do
-    "Applicant: #{form_answer.decorate.application_name}"
+    "Applicant: #{form_answer.decorate.company_nominee_or_application_name}"
   end
 
   let(:award_general_information) do

--- a/spec/unit/pdf_generators/case_summary_pdfs/base_spec.rb
+++ b/spec/unit/pdf_generators/case_summary_pdfs/base_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 describe "CaseSummaryPdfs::Base" do
   let!(:form_answer_current_year_innovation) do
-    FactoryGirl.create :form_answer, :submitted, :innovation
+    FactoryGirl.create :form_answer, :recommended, :innovation
   end
 
   let!(:form_answer_current_year_trade) do
-    FactoryGirl.create :form_answer, :submitted, :trade
+    FactoryGirl.create :form_answer, :recommended, :trade
   end
 
   before do


### PR DESCRIPTION
Covers following stories:

1) Still producing Case Summary downloads for cases that have a ‘Status’ of not eligible,
    assessment in progress and not submitted 
   [Trello Story](https://trello.com/c/L3WHDJ3n/252-case-summary-pdf-changes)

2) Application name issue
    [Trello Story](https://trello.com/c/LefHX1nD/260-qae-on-qaep-case-summary-download-use-nominee-name-not-application-name)

3) Exclude any withdrawn applications in the case summary download
    [Trello Story](https://trello.com/c/Z7fjwftD/477-qae-support-exclude-any-withdrawn-applications-in-the-case-summary-download) 