### PR TITLE
[Case Summary] Unlock - ReSubmit corrects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -671,6 +671,3 @@ DEPENDENCIES
   whenever
   wicked (~> 1.1)
   with_advisory_lock
-
-BUNDLED WITH
-   1.10.6

--- a/app/controllers/concerns/assessment_submission_mixin.rb
+++ b/app/controllers/concerns/assessment_submission_mixin.rb
@@ -12,6 +12,13 @@ module AssessmentSubmissionMixin
     end
   end
 
+  def unlock
+    authorize resource, :can_unlock?
+    resource.update_column(:locked_at, nil)
+
+    redirect_to [namespace_name, resource.form_answer]
+  end
+
   private
 
   def json_response

--- a/app/helpers/case_summary_helper.rb
+++ b/app/helpers/case_summary_helper.rb
@@ -25,6 +25,6 @@ module CaseSummaryHelper
 
   def submit_case_summary_title(assessment)
     prefix = policy(assessment).can_be_submitted? ? "Confirm" : "Re-submit"
-    "#{prefix} case summary"
+    "#{prefix} Case Summary"
   end
 end

--- a/app/policies/assessor_assignment_policy.rb
+++ b/app/policies/assessor_assignment_policy.rb
@@ -6,8 +6,15 @@ class AssessorAssignmentPolicy < ApplicationPolicy
   def submit?
     return true if admin?
     return false unless assessor?
-    record.assessor == subject ||
-      subject.lead?(record.form_answer)
+    lead? || primary?
+  end
+
+  def lead?
+    record.assessor == subject || subject.lead?(record.form_answer)
+  end
+
+  def primary?
+    record.assessor == subject || subject.primary?(record.form_answer)
   end
 
   def can_be_submitted?
@@ -15,6 +22,15 @@ class AssessorAssignmentPolicy < ApplicationPolicy
   end
 
   def can_be_re_submitted?
-    submit? && record.submitted? && record.case_summary?
+    !record.locked? &&
+    submit? &&
+    record.submitted? &&
+    record.case_summary?
+  end
+
+  def can_unlock?
+    record.locked? &&
+    record.case_summary? &&
+    (admin? || (assessor? && lead?))
   end
 end

--- a/app/services/assessment_submission_service.rb
+++ b/app/services/assessment_submission_service.rb
@@ -42,7 +42,10 @@ class AssessmentSubmissionService
   end
 
   def set_submitted_at_as_now!
-    resource.update(submitted_at: DateTime.now)
+    resource.update(
+      submitted_at: DateTime.now,
+      locked_at: DateTime.now
+    )
   end
 
   def populate_case_summary

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -31,18 +31,5 @@
           .clear
           br
 
-          - if policy(assessment).can_be_submitted? || policy(assessment).can_be_re_submitted?
-            = form_tag(url_for([namespace_name, :assessment_submissions]), remote: true, authenticity_token: true, class: "submit-assessment", "data-type" => "json")
-              = hidden_field_tag :assessment_id, assessment.id
-
-              .feedback-holder
-
-              .pull-right
-                = submit_tag submit_case_summary_title(assessment), class: "btn btn-primary btn-confirm-submit"
-              .clear
-          - else
-            / Only show once primary assessor has submitted the case summary
-            / Lead assessor must confirm it
-            .feedback-holder.alert.alert-success
-              ' Case summary submitted
-
+          = render "admin/form_answers/appraisal_form_components/case_summary_submit_block",
+                   assessment: assessment

--- a/app/views/admin/form_answers/appraisal_form_components/_case_summary_submit_block.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_case_summary_submit_block.html.slim
@@ -1,0 +1,34 @@
+- if policy(assessment).can_be_submitted? || policy(assessment).can_be_re_submitted?
+
+  = form_tag(url_for([namespace_name, :assessment_submissions]), remote: true, authenticity_token: true, class: "submit-assessment", "data-type" => "json")
+    = hidden_field_tag :assessment_id, assessment.id
+
+    .feedback-holder
+
+    .pull-right
+      = submit_tag submit_case_summary_title(assessment), class: "btn btn-primary btn-confirm-submit"
+    .clear
+
+- elsif assessment.submitted?
+
+  - if policy(assessment).can_unlock?
+
+    - unlock_url = namespace_name == :admin ? unlock_admin_assessment_submission_url(assessment) : unlock_assessor_assessment_submission_url(assessment)
+
+    = form_tag unlock_url, method: :patch do
+      = hidden_field_tag :assessment_id, assessment.id
+      .feedback-holder.alert.alert-success
+        ' Case Summary Submitted
+
+        .pull-right
+          = submit_tag "Unlock", class: "btn btn-primary"
+        .clear
+
+  - else
+    .feedback-holder.alert.alert-success
+      ' Case Summary Submitted
+
+- elsif !assessment.submitted?
+
+  .feedback-holder.alert.alert-info
+    ' Case Summary is not submitted yet!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,7 +173,9 @@ Rails.application.routes.draw do
       resources :review_corp_responsibility, only: [:create]
     end
     resources :assessor_assignments, only: [:update]
-    resources :assessment_submissions, only: [:create]
+    resources :assessment_submissions, only: [:create] do
+      patch :unlock, on: :member
+    end
     resources :assessor_assignment_collections, only: [:create]
     resources :reports, only: [:show]
   end
@@ -238,7 +240,9 @@ Rails.application.routes.draw do
     end
 
     resources :assessor_assignments, only: [:update]
-    resources :assessment_submissions, only: [:create]
+    resources :assessment_submissions, only: [:create] do
+      patch :unlock, on: :member
+    end
 
     resource :custom_email, only: [:show, :create]
     resource :users_feedback, only: [:show]

--- a/db/migrate/20160106115349_add_locked_at_to_assessor_assignments.rb
+++ b/db/migrate/20160106115349_add_locked_at_to_assessor_assignments.rb
@@ -1,0 +1,5 @@
+class AddLockedAtToAssessorAssignments < ActiveRecord::Migration
+  def change
+    add_column :assessor_assignments, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151130145800) do
+ActiveRecord::Schema.define(version: 20160106115349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20151130145800) do
     t.string   "editable_type"
     t.integer  "editable_id"
     t.datetime "assessed_at"
+    t.datetime "locked_at"
   end
 
   add_index "assessor_assignments", ["assessor_id", "form_answer_id"], name: "index_assessor_assignments_on_assessor_id_and_form_answer_id", unique: true, using: :btree

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -16,6 +16,13 @@ namespace :form_answers do
     end
   end
 
+  desc "populate locked_at for case summary assessor assignments"
+  task populate_locked_at_for_case_summaries: :environment do
+    AssessorAssignment.submitted.where(position: 4).each do |assignment|
+      assignment.update_column(:locked_at, assignment.submitted_at)
+    end
+  end
+
   desc "fixes attachment arrays"
   task fix_attachments: :environment do
     FormAnswer.find_each do |f|


### PR DESCRIPTION
[Trello Story](https://trello.com/c/T8DYfTyg/249-qae-admin-and-lead-assessors-should-be-able-to-re-submit-case-summary-if-the-details-have-changed-in-between-assessment-rounds)

* added ability to 'Confirm Case Summary' and 'Re-Submit' for Primary Assessors
* added locking on 'Confirm Case Summary' and 'Re-Submit'
* added ability to 'Unlock' of submitted Case Summary for Admin and Lead Assessor