### PR TITLE
Hide feedback before the user receives the email

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -43,6 +43,14 @@ class Settings < ActiveRecord::Base
     DateTime.now >= deadline.trigger_at if deadline.present?
   end
 
+  def self.unsuccessful_stage?
+    deadline = Rails.cache.fetch("unsuccessful_notification_notification", expires_in: 1.minute) do
+      current.email_notifications.where(kind: "unsuccessful_notification").first
+    end
+
+    DateTime.now >= deadline.trigger_at if deadline.present?
+  end
+
   def self.not_shortlisted_deadline
     Rails.cache.fetch("not_shortlisted_notifier_notification", expires_in: 1.minute) do
       current.email_notifications.not_shortlisted.first.try(:trigger_at)

--- a/app/views/content_only/post_submission/_unsuccessful.html.slim
+++ b/app/views/content_only/post_submission/_unsuccessful.html.slim
@@ -28,7 +28,7 @@
           p The application was not submitted on time.
         - else
           h4 Feedback
-          - if award.feedback.try(:approved?)
+          - if award.feedback.try(:approved?) && Settings.unsuccessful_stage?
             p
               ' Please
               = link_to "download and read the feedback document", users_form_answer_feedback_path(award, format: :pdf)


### PR DESCRIPTION
Applicants should not be able to see their feedback until we have sent the email to them (i.e. notifying shortlisted applicants who have not been successful and also the email to those who were not shortlisted in then first place).
https://trello.com/c/VCTL6Cdh/487-qae-feedback-only-applies-to-business-awards