### PR TITLE
Feedback changes

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -165,20 +165,28 @@ ready = ->
     area = formGroup.find("textarea:visible")
     formGroup.removeClass("form-edit")
 
-    if area.val().length
-      formGroup.find(".form-value p").html(area.val().replace(/\n/g, '<br />'))
-      updatedSection = link.data("updated-section")
-      $(this).closest(".panel-body").find(".field-with-errors").removeClass("field-with-errors")
-      $(this).closest(".panel-body").find(".feedback-holder.error").html("")
-      $(this).closest(".panel-body").find(".feedback-holder").removeClass("error")
-      formGroup.find("textarea").each ->
-        if $(this).val().length
-          $(this).closest(".input").removeClass("field-with-errors")
-      if updatedSection
-        input = form.find("input[name='updated_section']")
-        if input.length
-          input.val(updatedSection)
-      form.submit()
+    if area.length == 1
+      if area.val().length
+        formGroup.find(".form-value p").html(area.val().replace(/\n/g, '<br />'))
+        updatedSection = link.data("updated-section")
+        $(this).closest(".panel-body").find(".field-with-errors").removeClass("field-with-errors")
+        $(this).closest(".panel-body").find(".feedback-holder.error").html("")
+        $(this).closest(".panel-body").find(".feedback-holder").removeClass("error")
+        formGroup.find("textarea").each ->
+          if $(this).val().length
+            $(this).closest(".input").removeClass("field-with-errors")
+        if updatedSection
+          input = form.find("input[name='updated_section']")
+          if input.length
+            input.val(updatedSection)
+        form.submit()
+     else
+       if area.first().val().length
+         formGroup.find(".form-value p:first").html(area.first().val().replace(/\n/g, '<br />'))
+       if area.last().val().length
+         formGroup.find(".form-value p:last").html(area.last().val().replace(/\n/g, '<br />'))
+       form.submit()
+
   $("#new_review_audit_certificate input[type='radio']").on "change", ->
     area = $(".audit-cert-description")
     if $(this).val() == "confirmed_changes"

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,0 +1,6 @@
+module FeedbackHelper
+  def submit_feedback_title(feedback)
+    prefix = policy(feedback).can_be_submitted? ? "Submit" : "Re-submit"
+    "#{prefix} Feedback"
+  end
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -5,4 +5,8 @@ class Feedback < ActiveRecord::Base
 
   scope :submitted, -> { where submitted: true }
   belongs_to :authorable, polymorphic: true
+
+  def locked?
+    locked_at.present?
+  end
 end

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -47,7 +47,7 @@ class Reports::FormAnswer
   end
 
   def feedback_complete
-    bool(obj.feedback.present?)
+    obj.feedback && obj.feedback.submitted? && obj.feedback.locked? ? "Submitted" : "Not Submitted"
   end
 
   def ac_received

--- a/app/services/assessment_submission_service.rb
+++ b/app/services/assessment_submission_service.rb
@@ -1,4 +1,12 @@
 class AssessmentSubmissionService
+  SEVEN_KEYS_STRENGTHS = [:environment_protection,
+                          :benefiting_the_wilder_community,
+                          :sustainable_resource,
+                          :economic_sustainability,
+                          :supporting_employees,
+                          :internal_leadership,
+                          :industry_sector]
+
   attr_reader :resource, :current_subject
 
   def initialize(assignment, current_subject)
@@ -22,6 +30,7 @@ class AssessmentSubmissionService
 
       if resource.case_summary?
         perform_state_transition!
+        populate_feedback!
       end
     end
   end
@@ -61,6 +70,24 @@ class AssessmentSubmissionService
       case_summary.document = document
       case_summary.save
     end
+  end
+
+  def populate_feedback!
+    return unless form_answer.development?
+    return if form_answer.feedback
+
+    feedback = form_answer.build_feedback
+    feedback.authorable = current_subject
+    feedback.document = {}
+
+    AppraisalForm::DEVELOPMENT.keys.each do |attr|
+      if SEVEN_KEYS_STRENGTHS.include?(attr)
+        feedback.document["#{attr}_desc"] = resource.document["#{attr}_desc"]
+        feedback.document["#{attr}_rate"] = resource.document["#{attr}_rate"]
+      end
+    end
+
+    feedback.save!
   end
 
   def primary_and_lead_is_the_same_person?

--- a/app/views/admin/feedbacks/_feedback_fields.html.slim
+++ b/app/views/admin/feedbacks/_feedback_fields.html.slim
@@ -20,5 +20,5 @@ strong = feedback_field_value[:label]
       ' Edit
     .form-actions.text-right
       = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
-      = f.submit "Save", class: "btn btn-primary form-save-button pull-right"
+      = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
 .clear

--- a/app/views/admin/feedbacks/_overall_feedback_field.html.slim
+++ b/app/views/admin/feedbacks/_overall_feedback_field.html.slim
@@ -12,5 +12,5 @@ strong Overall Summary
       ' Edit
     .form-actions.text-right
       = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
-      = f.submit "Save", class: "btn btn-primary form-save-button pull-right"
+      = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
 .clear

--- a/app/views/admin/feedbacks/_pdf_reports.html.slim
+++ b/app/views/admin/feedbacks/_pdf_reports.html.slim
@@ -2,7 +2,7 @@
   h2
     ' Feedback
   ul.list-unstyled.list-actions
-    - FormAnswer::AWARD_TYPE_FULL_NAMES.each do |key, value|
+    - FormAnswer::AWARD_TYPE_FULL_NAMES.select { |k, _| k != "promotion" }.each do |key, value|
       li
         .pull-right
           = link_to admin_report_path("feedbacks", category: key, format: :pdf, year: @award_year.year)

--- a/app/views/admin/feedbacks/_section.html.slim
+++ b/app/views/admin/feedbacks/_section.html.slim
@@ -1,6 +1,6 @@
 - feedback = form_answer.feedback || form_answer.build_feedback
 - url = feedback.persisted? ? polymorphic_url([namespace_name, form_answer, feedback]) : polymorphic_url([namespace_name, form_answer, :feedbacks])
-= simple_form_for feedback, url: url, remote: true, authenticity_token: true do |f|
+= simple_form_for feedback, url: url, remote: true, authenticity_token: true, html: { "data-type" => "json" } do |f|
   - if !form_answer.promotion?
     = render "admin/feedbacks/overall_feedback_field", f: f, feedback: feedback
   - FeedbackForm.fields_for_award_type(form_answer.object.award_type).each do |feedback_field, feedback_field_value|
@@ -9,9 +9,4 @@
 br
 br
 
-- if feedback.persisted?
-  - if policy(feedback).submit?
-    = button_to "Submit feedback", polymorphic_url([:submit, namespace_name, form_answer, feedback]), class: "btn btn-default btn-block", remote: true
-
-  - if policy(feedback).approve?
-    = button_to "Approve feedback", polymorphic_url([:approve, namespace_name, form_answer, feedback]), class: "btn btn-default btn-block", remote: true
+= render "admin/feedbacks/submit_block", feedback: feedback, form_answer: form_answer

--- a/app/views/admin/feedbacks/_submit_block.html.slim
+++ b/app/views/admin/feedbacks/_submit_block.html.slim
@@ -1,0 +1,26 @@
+- if policy(feedback).can_be_submitted? || policy(feedback).can_be_re_submitted?
+  - if feedback.persisted?
+    = form_tag(polymorphic_url([:submit, namespace_name, form_answer, feedback]), authenticity_token: true, class: "submit-feedback", "data-type" => "json")
+      .feedback-holder
+
+      .pull-right
+        = submit_tag submit_feedback_title(feedback), class: "btn btn-primary btn-confirm-submit"
+      .clear
+
+- elsif feedback.submitted?
+  - if policy(feedback).unlock?
+    = form_tag polymorphic_url([:unlock, namespace_name, form_answer, feedback]) do
+      .feedback-holder.alert.alert-success
+        ' Feedback Submitted
+
+        .pull-right
+          = submit_tag "Unlock", class: "btn btn-primary"
+        .clear
+
+  - else
+    .feedback-holder.alert.alert-success
+      ' Feedback Submitted
+
+- elsif !feedback.submitted?
+  .feedback-holder.alert.alert-info
+    ' Feedback is not submitted yet!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,7 +154,7 @@ Rails.application.routes.draw do
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit
-          post :approve
+          post :unlock
         end
       end
 
@@ -211,7 +211,7 @@ Rails.application.routes.draw do
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit
-          post :approve
+          post :unlock
         end
 
         get :download_pdf, on: :collection

--- a/db/migrate/20160121080201_add_locked_at_to_feedbacks.rb
+++ b/db/migrate/20160121080201_add_locked_at_to_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddLockedAtToFeedbacks < ActiveRecord::Migration
+  def change
+    add_column :feedbacks, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160106115349) do
+ActiveRecord::Schema.define(version: 20160121080201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -199,6 +199,7 @@ ActiveRecord::Schema.define(version: 20160106115349) do
     t.datetime "updated_at",                      null: false
     t.string   "authorable_type"
     t.integer  "authorable_id"
+    t.datetime "locked_at"
   end
 
   add_index "feedbacks", ["form_answer_id"], name: "index_feedbacks_on_form_answer_id", using: :btree

--- a/lib/tasks/feedbacks.rake
+++ b/lib/tasks/feedbacks.rake
@@ -1,0 +1,6 @@
+namespace :feedbacks do
+  desc "Add locked_at to all submitted feedbacks"
+  task :populate_locked_at => :environment do
+    Feedback.submitted.where(locked_at: nil).update_all(locked_at: Time.zone.now)
+  end
+end

--- a/spec/features/admin/form_answers/download_all_case_summary_pdf_spec.rb
+++ b/spec/features/admin/form_answers/download_all_case_summary_pdf_spec.rb
@@ -20,13 +20,15 @@ So that I can print and review application case summaries
 
     it "should be links to download feedbacks" do
       FormAnswer::AWARD_TYPE_FULL_NAMES.each do |award_type, value|
-        expect(page).to have_link('Download',
-          href: admin_report_path(
-            id: "feedbacks",
-            category: award_type, format: :pdf,
-            year: AwardYear.current.year
+        if award_type != "promotion"
+          expect(page).to have_link('Download',
+            href: admin_report_path(
+              id: "feedbacks",
+              category: award_type, format: :pdf,
+              year: AwardYear.current.year
+            )
           )
-        )
+        end
       end
     end
   end

--- a/spec/features/admin/form_answers/download_all_feedbacks_spec.rb
+++ b/spec/features/admin/form_answers/download_all_feedbacks_spec.rb
@@ -20,12 +20,14 @@ So that I can print and review application feedbacks
 
     it "should be links to download feedbacks" do
       FormAnswer::AWARD_TYPE_FULL_NAMES.each do |award_type, value|
-        expect(page).to have_link('Download',
-          href: admin_report_path(
-            id: "feedbacks",
-            category: award_type, format: :pdf, year: AwardYear.current.year
+        if award_type != "promotion"
+          expect(page).to have_link('Download',
+            href: admin_report_path(
+              id: "feedbacks",
+              category: award_type, format: :pdf, year: AwardYear.current.year
+            )
           )
-        )
+        end
       end
     end
   end
@@ -42,11 +44,6 @@ So that I can print and review application feedbacks
 
   describe "Sustainable Development Award" do
     let(:award_type) { :development }
-    include_context "admin all feedbacks pdf generation"
-  end
-
-  describe "Enterprise Promotion Award" do
-    let(:award_type) { :promotion }
     include_context "admin all feedbacks pdf generation"
   end
 end

--- a/spec/features/assessor/feedback_spec.rb
+++ b/spec/features/assessor/feedback_spec.rb
@@ -17,28 +17,30 @@ describe "Assessor feedback management" do
       within "#section-feedback .level_of_innovation" do
         find("a.form-edit-link").click
         fill_in "feedback[level_of_innovation_strength]", with: "Feedback 101"
-        click_button "Save"
+        click_link "Save"
 
         expect(page).to have_selector(".form-value", text: "Feedback 101")
       end
     end
   end
 
-  describe "feedback approval" do
+  describe "feedback unlocking" do
     before do
       feedback = form_answer.build_feedback
       feedback.submitted = true
+      feedback.locked_at = Time.zone.now
       feedback.save!
 
       form_answer.reload
     end
 
-    it "approves submitted feedback", js: true do
+    it "unlocks submitted feedback", js: true do
       visit assessor_form_answer_path(form_answer)
       find("#feedback-heading a").click
-      click_button "Approve feedback"
+      expect(page).to have_selector(".feedback-holder", text: "Feedback Submitted")
+      click_button "Unlock"
 
-      expect(page).to have_no_selector(".btn-block", text: "Approve feedback")
+      expect(page).to have_no_selector(".feedback-holder", text: "Feedback Submitted")
     end
   end
 end

--- a/spec/services/assessment_submission_service_spec.rb
+++ b/spec/services/assessment_submission_service_spec.rb
@@ -38,6 +38,7 @@ describe AssessmentSubmissionService do
   end
 
   context "case summary submission" do
+    let(:form_answer) { create(:form_answer, :development, :submitted) }
     let(:assessment) { form_answer.assessor_assignments.case_summary }
 
     it "performs state transition when case summary is submitted" do
@@ -45,6 +46,18 @@ describe AssessmentSubmissionService do
 
       subject.perform
       expect(form_answer.reload.state).to eq("not_recommended")
+    end
+
+    it "creates populated feedback" do
+      assessment.document =  { "environment_protection_desc" => "description to copy", "environment_protection_rate" => "negative", "industry_sector_desc" => "cool", "industry_sector_rate" => "positive" }
+
+      subject.perform
+      expect(form_answer.reload.feedback).not_to be_nil
+
+      expect(form_answer.feedback.document["environment_protection_desc"]).to eq("description to copy")
+      expect(form_answer.feedback.document["environment_protection_rate"]).to eq("negative")
+      expect(form_answer.feedback.document["industry_sector_desc"]).to eq("cool")
+      expect(form_answer.feedback.document["industry_sector_rate"]).to eq("positive")
     end
   end
 end


### PR DESCRIPTION
- autopopulate SD feedback
- change feedback workflow 
- fix text area resize bug

*Note*: need to run migrations & rake task  `rake feedbacks: populate_locked_at` after deploy.