### PR TITLE
sustainable development defaults feedbacks to case summary

### DIFF
--- a/app/services/feedback_creation_service.rb
+++ b/app/services/feedback_creation_service.rb
@@ -20,12 +20,12 @@ class FeedbackCreationService
     feedback = form_answer.build_feedback
     feedback.authorable = user
     feedback.document = {}
-    primary_assignment = form_answer.assessor_assignments.primary
+    case_summary = form_answer.assessor_assignments.case_summary
 
     AppraisalForm::DEVELOPMENT.each do |attr, val|
       next if val[:type] != :strengths
 
-      feedback.document["#{attr}_rate"] = primary_assignment.document["#{attr}_rate"]
+      feedback.document["#{attr}_rate"] = case_summary.document["#{attr}_rate"]
     end
 
     feedback.save!


### PR DESCRIPTION
"With the Sustainable Development category and the '7 Key Strengths an…d Focuses' , although this is now populating into the 'Feedback' it is copying the chosen option from the 'Appraisal Form(Primary)' rather than the 'Case Summary'. See examples in staging of QA0019/16S (supporting employees field) & QA0037/16S (sustainable resource use field)"

https://trello.com/c/VCTL6Cdh/487-qae-feedback-only-applies-to-business-awards