### PR TITLE
show both unsuccessful email previews in admin

### DIFF
--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -14,6 +14,16 @@ class MailRenderer
 
     assigns[:user] = dummy_user("Jon", "Doe", "Jane's Company")
     assigns[:form_answer] = form_answer
+    assigns[:company_name] = "Company Name"
+
+    render(assigns, "users/unsuccessful_feedback_mailer/notify")
+  end
+
+  def unsuccessful_ep_notification
+    assigns = {}
+
+    assigns[:user] = dummy_user("Jon", "Doe", "Jane's Company")
+    assigns[:form_answer] = form_answer
     assigns[:nominee_name] = "Nominee Name"
 
     render(assigns, "users/unsuccessful_feedback_mailer/ep_notify")

--- a/app/views/admin/settings/_section_final_stage_email_notifications.html.slim
+++ b/app/views/admin/settings/_section_final_stage_email_notifications.html.slim
@@ -7,4 +7,5 @@
     .panel-body
       = render 'email_notification', kind: 'winners_notification'
       = render 'email_notification', kind: 'winners_press_release_comments_request'
+      = render 'email_notification', kind: 'unsuccessful_ep_notification'
       = render 'email_notification', kind: 'unsuccessful_notification'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,7 +134,7 @@ en:
     buckingham_palace_attendees_details: Buckingham Palace reception attendees details due by
     buckingham_palace_media_information: Buckingham Palace provides information to the media of the winners on
     buckingham_palace_confirm_press_book_notes: Buckingham Palace Press Book Notes confirmation due by
-    buckingham_palace_attendees_invite: Buckingham Palace invites two representatives for the winners to attend HM The Queen's Reception on 
+    buckingham_palace_attendees_invite: Buckingham Palace invites two representatives for the winners to attend HM The Queen's Reception on
     press_release_comments: Press release comments due by
     audit_certificates: Audit certificates due by
 
@@ -145,6 +145,7 @@ en:
     winners_reminder_to_submit:" WINNERS : Reminder to submit *palace reception attendee details* (for winning applicants who haven't submitted yet)."
     winners_press_release_comments_request: "WINNERS : Email requesting comments on press release."
     unsuccessful_notification: "UNSUCCESSFUL : Email notifying shortlisted applicants who have not been successful."
+    unsuccessful_ep_notification: "UNSUCCESSFUL : Email notifying shortlisted companies who have not been successful."
     shortlisted_notifier: "SHORTLISTED : Email notifying shortlisted applicants of their success, including audit certificate instructions."
     shortlisted_audit_certificate_reminder: "SHORTLISTED : Reminder to submit audit certificates (for shortlisted applicants who have not yet done so)."
     not_shortlisted_notifier: "NOT SHORTLISTED : Email notifying unsuccessful applicants."

--- a/spec/renderers/mail_renderer_spec.rb
+++ b/spec/renderers/mail_renderer_spec.rb
@@ -58,7 +58,7 @@ describe MailRenderer do
     it "renders e-mail" do
       rendered = described_class.new.unsuccessful_notification
       expect(rendered).to match("Jon Doe")
-      expect(rendered).to match("Nominee Name")
+      expect(rendered).to match("Company Name")
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/eKrgQ02Y/631-qae-support-change-unsuccessful-ep-email-copy-for-as-they-do-not-get-feedback