### PR TITLE
[Admin Settings] Populate of new buckingham palace's deadlines

### DIFF
--- a/lib/tasks/temprary/populate_missing_buckingham_palace_deadlines.rake
+++ b/lib/tasks/temprary/populate_missing_buckingham_palace_deadlines.rake
@@ -1,0 +1,16 @@
+namespace :db do
+  desc "Populate of new buckingham palace's deadlines (media information,  confirm press book notes,  attendees invite) on current Settings"
+  task populate_missing_buckingham_palace_deadlines: :environment do
+    [
+      'buckingham_palace_media_information',
+      'buckingham_palace_confirm_press_book_notes',
+      'buckingham_palace_attendees_invite'
+    ].each do |kind|
+      existing_deadline = Settings.current.deadlines.find_by(kind: kind)
+
+      unless existing_deadline.present?
+        Settings.current.deadlines.create!(kind: kind)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rake script adds new missing deadlines to current settings:

* media information
* confirm press book notes
* attendees invite

Run:

```
bundle exec rake db:populate_missing_buckingham_palace_deadlines
```

[Trello Story](https://trello.com/c/TVZVlcMT/270-qae-support-change-unsuccessful-ep-email-copy-for-as-they-do-not-get-feedback)