### PR TITLE
[Mailers] Implement of scheduling and delivering of Unsuccessful EP Notification

### DIFF
--- a/app/models/email_notification.rb
+++ b/app/models/email_notification.rb
@@ -12,6 +12,7 @@ class EmailNotification < ActiveRecord::Base
                          :winners_notification,
                          :winners_press_release_comments_request,
                          :unsuccessful_notification,
+                         :unsuccessful_ep_notification,
                          :shortlisted_notifier,
                          :shortlisted_audit_certificate_reminder,
                          :not_shortlisted_notifier,
@@ -30,7 +31,7 @@ class EmailNotification < ActiveRecord::Base
   end
 
   def self.not_awarded
-    where(kind: "unsuccessful_notification")
+    where(kind: ["unsuccessful_notification", "unsuccessful_ep_notification"])
   end
 
   private

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -57,12 +57,14 @@ class Notifiers::EmailNotificationService
   end
 
   def unsuccessful_notification(award_year)
-    award_year.form_answers.unsuccessful.each do |form_answer|
-      if form_answer.promotion?
-        Users::UnsuccessfulFeedbackMailer.ep_notify(form_answer.id).deliver_later!
-      else
-        Users::UnsuccessfulFeedbackMailer.notify(form_answer.id).deliver_later!
-      end
+    award_year.form_answers.business.unsuccessful.each do |form_answer|
+      Users::UnsuccessfulFeedbackMailer.notify(form_answer.id).deliver_later!
+    end
+  end
+
+  def unsuccessful_ep_notification(award_year)
+    award_year.form_answers.promotion.unsuccessful.each do |form_answer|
+      Users::UnsuccessfulFeedbackMailer.ep_notify(form_answer.id).deliver_later!
     end
   end
 


### PR DESCRIPTION
[Trello Story](https://trello.com/c/TVZVlcMT/270-qae-support-change-unsuccessful-ep-email-copy-for-as-they-do-not-get-feedback)