### PR TITLE
[Mailers] Added some Rspec tests for Unsuccessful EP Notification

### DIFF
--- a/spec/renderers/mail_renderer_spec.rb
+++ b/spec/renderers/mail_renderer_spec.rb
@@ -62,6 +62,14 @@ describe MailRenderer do
     end
   end
 
+  describe "#unsuccessful_ep_notification" do
+    it "renders e-mail" do
+      rendered = described_class.new.unsuccessful_ep_notification
+      expect(rendered).to match("Jon Doe")
+      expect(rendered).to match("Nominee Name")
+    end
+  end
+
   describe "#winners_notification" do
     it "renders e-mail" do
       rendered = described_class.new.winners_notification

--- a/spec/services/notifiers/email_notification_service_spec.rb
+++ b/spec/services/notifiers/email_notification_service_spec.rb
@@ -164,4 +164,19 @@ describe Notifiers::EmailNotificationService do
       expect(current_notification.reload).to be_sent
     end
   end
+
+  context "unsuccessful_ep_notification" do
+    let(:kind) { "unsuccessful_ep_notification" }
+
+    let(:form_answer) { create(:form_answer, :promotion, state: "not_awarded") }
+
+    it "triggers current notification" do
+      mailer = double(deliver_later!: true)
+      expect(Users::UnsuccessfulFeedbackMailer).to receive(:ep_notify).with(form_answer.id) { mailer }
+
+      described_class.run
+
+      expect(current_notification.reload).to be_sent
+    end
+  end
 end


### PR DESCRIPTION
[Trello Story](https://trello.com/c/TVZVlcMT/270-qae-support-change-unsuccessful-ep-email-copy-for-as-they-do-not-get-feedback)