### PR TITLE
[MAILERS] Winners mailer: fix 'TypeError: no implicit conversion of S…

### DIFF
--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -71,13 +71,17 @@ class Notifiers::EmailNotificationService
   def winners_notification(award_year)
     award_year.form_answers.winners.each do |form_answer|
       document = form_answer.document
+      email = form_answer.promotion? ? document["nominee_email"] : document["head_email"]
+
+      shoryuken_ops = {
+        email: email,
+        form_answer_id: form_answer.id
+      }
 
       if form_answer.promotion?
-        Notifiers::Winners::PromotionBuckinghamPalaceInvite.perform_async(document["nominee_email"],
-                                                                          form_answer.id)
+        Notifiers::Winners::PromotionBuckinghamPalaceInvite.perform_async(shoryuken_ops)
       else
-        Notifiers::Winners::BuckinghamPalaceInvite.perform_async(document["head_email"],
-                                                                 form_answer.id)
+        Notifiers::Winners::BuckinghamPalaceInvite.perform_async(shoryuken_ops)
       end
     end
   end

--- a/app/services/notifiers/winners/buckingham_palace_invite.rb
+++ b/app/services/notifiers/winners/buckingham_palace_invite.rb
@@ -3,7 +3,10 @@ class Notifiers::Winners::BuckinghamPalaceInvite
 
   shoryuken_options queue: "#{Rails.env}_default", auto_delete: true
 
-  def perform(sqs_msg, email, form_answer_id)
+  def perform(sqs_msg, ops={})
+    email = ops[:email]
+    form_answer_id = ops[:form_answer_id]
+
     invite = PalaceInvite.where(email: email, form_answer_id: form_answer_id).first_or_create
     Users::BuckinghamPalaceInviteMailer.invite(invite.id).deliver_later!
   end

--- a/app/services/notifiers/winners/promotion_buckingham_palace_invite.rb
+++ b/app/services/notifiers/winners/promotion_buckingham_palace_invite.rb
@@ -3,7 +3,10 @@ class Notifiers::Winners::PromotionBuckinghamPalaceInvite
 
   shoryuken_options queue: "#{Rails.env}_default", auto_delete: true
 
-  def perform(sqs_msg, email, form_answer_id)
+  def perform(sqs_msg, ops={})
+    email = ops[:email]
+    form_answer_id = ops[:form_answer_id]
+
     invite = PalaceInvite.where(email: email, form_answer_id: form_answer_id).first_or_create
     Users::PromotionBuckinghamPalaceInviteMailer.notify(invite.id).deliver_later!
   end

--- a/spec/services/notifiers/email_notification_service_spec.rb
+++ b/spec/services/notifiers/email_notification_service_spec.rb
@@ -68,7 +68,7 @@ describe Notifiers::EmailNotificationService do
       form_answer.save!
 
       expect(Notifiers::Winners::BuckinghamPalaceInvite).to receive(:perform_async)
-        .with("head@email.com", form_answer.id)
+        .with({email: "head@email.com", form_answer_id: form_answer.id})
       expect(FormAnswer).to receive(:winners) { [form_answer] }
 
       described_class.run
@@ -82,7 +82,7 @@ describe Notifiers::EmailNotificationService do
       form_answer.save!
 
       expect(Notifiers::Winners::PromotionBuckinghamPalaceInvite).to receive(:perform_async)
-        .with("nominee@email.com", form_answer.id)
+        .with({email: "nominee@email.com", form_answer_id: form_answer.id})
       expect(FormAnswer).to receive(:winners) { [form_answer] }
 
       described_class.run


### PR DESCRIPTION
…ymbol into Integer'

Fix of:

```
TypeError: no implicit conversion of Symbol into Integer
    from /home/alkapone/.rvm/gems/ruby-2.1.5@qae/bundler/gems/shoryuken-1ec117620129/lib/shoryuken/worker.rb:10:in `[]'
    from /home/alkapone/.rvm/gems/ruby-2.1.5@qae/bundler/gems/shoryuken-1ec117620129/lib/shoryuken/worker.rb:10:in `perform_async'
    from /home/alkapone/projects/qae/app/services/notifiers/email_notification_service.rb:79:in `block in winners_notification'

```