### PR TITLE
unsuccessful ep email fixes: removed full stop after heading; modifie…

### DIFF
--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -25,7 +25,7 @@ class MailRenderer
     assigns[:user] = dummy_user("Jon", "Doe", "Jane's Company")
     assigns[:form_answer] = form_answer
     assigns[:nominee_name] = "Nominee Name"
-
+    form_answer.urn = "QA0128/16EP"
     render(assigns, "users/unsuccessful_feedback_mailer/ep_notify")
   end
 

--- a/app/views/users/unsuccessful_feedback_mailer/ep_notify.html.slim
+++ b/app/views/users/unsuccessful_feedback_mailer/ep_notify.html.slim
@@ -3,7 +3,7 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
 
 h4 style="font-size: 19px; font-weight:bold"
   ' THE QUEEN’S AWARD FOR ENTERPRISE PROMOTION 2016
-  |. [
+  | [
   = @form_answer.urn
   |]
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"

--- a/app/views/users/unsuccessful_feedback_mailer/ep_notify.text.slim
+++ b/app/views/users/unsuccessful_feedback_mailer/ep_notify.text.slim
@@ -1,6 +1,6 @@
 = "Dear #{@user.full_name},"
 ' THE QUEEN’S AWARD FOR ENTERPRISE PROMOTION 2016
-|. [
+| [
 = @form_answer.urn
 |]
 


### PR DESCRIPTION
…d email example to show a EP urn


https://trello.com/c/TVZVlcMT/270-qae-support-change-unsuccessful-ep-email-copy-for-as-they-do-not-get-feedback