### PR TITLE
Change successful business winners

### DIFF
--- a/app/controllers/users/press_summaries_controller.rb
+++ b/app/controllers/users/press_summaries_controller.rb
@@ -49,7 +49,7 @@ class Users::PressSummariesController < Users::BaseController
   end
 
   def check_deadline
-    if settings.deadlines.where(kind: "press_release_comments").first.passed?
+    if settings.deadlines.where(kind: "buckingham_palace_confirm_press_book_notes").first.passed?
       redirect_to action: :failure
     end
   end

--- a/app/mailers/users/buckingham_palace_invite_mailer.rb
+++ b/app/mailers/users/buckingham_palace_invite_mailer.rb
@@ -3,7 +3,10 @@ class Users::BuckinghamPalaceInviteMailer < ApplicationMailer
     invite = PalaceInvite.find(invite_id)
     @token = invite.token
     @form_answer = invite.form_answer.decorate
-    @name = @form_answer.head_of_business
+    account_holder = @form_answer.user
+
+    @name = "#{account_holder.title} #{account_holder.last_name}"
+
     @deadline = Settings.current.deadlines.where(kind: "buckingham_palace_attendees_details").first
     @deadline = @deadline.trigger_at
     @media_deadline = Settings.current.deadlines.where(kind: "buckingham_palace_media_information").first

--- a/app/mailers/users/buckingham_palace_invite_mailer.rb
+++ b/app/mailers/users/buckingham_palace_invite_mailer.rb
@@ -3,7 +3,7 @@ class Users::BuckinghamPalaceInviteMailer < ApplicationMailer
     invite = PalaceInvite.find(invite_id)
     @token = invite.token
     @form_answer = invite.form_answer.decorate
-    account_holder = @form_answer.user
+    account_holder = @form_answer.account.owner
 
     @name = "#{account_holder.title} #{account_holder.last_name}"
 

--- a/app/mailers/users/buckingham_palace_invite_mailer.rb
+++ b/app/mailers/users/buckingham_palace_invite_mailer.rb
@@ -7,7 +7,7 @@ class Users::BuckinghamPalaceInviteMailer < ApplicationMailer
     @deadline = Settings.current.deadlines.where(kind: "buckingham_palace_attendees_details").first
     @deadline = @deadline.trigger_at
     @media_deadline = Settings.current.deadlines.where(kind: "buckingham_palace_media_information").first
-    @media_deadline = @media_deadline.try :strftime, "%A %d %B %Y"
+    @media_deadline = @media_deadline.try :strftime, "%H.%M on %A %d %B %Y"
     @book_notes_deadline = Settings.current.deadlines.where(kind: "buckingham_palace_confirm_press_book_notes").first
     @book_notes_deadline = @book_notes_deadline.try :strftime, "%l %p on %A %d %B"
     @attendees_invite_date = Settings.current.deadlines.where(kind: "buckingham_palace_attendees_invite").first

--- a/app/mailers/users/promotion_buckingham_palace_invite_mailer.rb
+++ b/app/mailers/users/promotion_buckingham_palace_invite_mailer.rb
@@ -4,7 +4,7 @@ class Users::PromotionBuckinghamPalaceInviteMailer < AccountMailer
     @form_answer = invite.form_answer.decorate
     @token = invite.token
     @name = @form_answer.nominee_full_name
-    @user = @form_answer.user.decoarate
+    @user = @form_answer.user.decorate
     @deadline = Settings.current.deadlines.where(kind: "buckingham_palace_attendees_details").first
     @deadline = @deadline.trigger_at.strftime("%d/%m/%Y")
 

--- a/app/mailers/users/winners_head_of_organisation_mailer.rb
+++ b/app/mailers/users/winners_head_of_organisation_mailer.rb
@@ -11,6 +11,9 @@ class Users::WinnersHeadOfOrganisationMailer < ApplicationMailer
     @title = @form_answer.head_of_bussines_title
     @last_name = @form_answer.document["head_of_business_last_name"]
 
+    @media_deadline = Settings.current.deadlines.where(kind: "buckingham_palace_media_information").first
+    @media_deadline = @media_deadline.try :strftime, "%H.%M on %A %d %B %Y"
+
     @subject = "[Queen's Awards for Enterprise] Important information about your Queen's Award Entry!"
 
     mail to: @head_email, subject: @subject

--- a/app/mailers/users/winners_press_release.rb
+++ b/app/mailers/users/winners_press_release.rb
@@ -9,7 +9,7 @@ class Users::WinnersPressRelease < AccountMailer
       @user.email
     end
 
-    @deadline = Settings.current.deadlines.where(kind: "press_release_comments").first
+    @deadline = Settings.current.deadlines.where(kind: "buckingham_palace_confirm_press_book_notes").first
     @deadline = @deadline.trigger_at.strftime("%d/%m/%Y")
 
     @token = @form_answer.press_summary.token

--- a/app/models/deadline.rb
+++ b/app/models/deadline.rb
@@ -13,7 +13,6 @@ class Deadline < ActiveRecord::Base
     "buckingham_palace_attendees_invite",
     "buckingham_palace_confirm_press_book_notes",
     "buckingham_palace_media_information",
-    "press_release_comments",
     "audit_certificates"
   ]
 

--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -87,11 +87,11 @@ class MailRenderer
 
     assigns[:token] = "secret"
     assigns[:form_answer] = form_answer
-    assigns[:name] = "Jon Snow"
+    assigns[:name] = "Mr Smith"
     assigns[:deadline] = deadline("buckingham_palace_attendees_details")
     assigns[:media_deadline] = deadline_str(
       "buckingham_palace_media_information",
-      "%A %d %B %Y"
+      "%H.%M on %A %d %B %Y"
     )
     assigns[:book_notes_deadline] = deadline_str(
       "buckingham_palace_confirm_press_book_notes",

--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -110,7 +110,7 @@ class MailRenderer
     assigns[:user] = dummy_user("Jon", "Doe", "John's Company")
     assigns[:token] = "secret"
     assigns[:form_answer] = form_answer
-    assigns[:deadline] = deadline_str("press_release_comments")
+    assigns[:deadline] = deadline_str("buckingham_palace_confirm_press_book_notes")
 
     render(assigns, "users/winners_press_release/notify")
   end

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -71,7 +71,8 @@ class Notifiers::EmailNotificationService
   def winners_notification(award_year)
     award_year.form_answers.winners.each do |form_answer|
       document = form_answer.document
-      email = form_answer.promotion? ? document["nominee_email"] : document["head_email"]
+      account_holder = form_answer.account.owner
+      email = form_answer.promotion? ? document["nominee_email"] : account_holder.email
 
       shoryuken_ops = {
         email: email,

--- a/app/views/admin/settings/_section_final_stage_deadlines.html.slim
+++ b/app/views/admin/settings/_section_final_stage_deadlines.html.slim
@@ -18,4 +18,3 @@
         li = render 'deadline_form', kind: 'buckingham_palace_media_information'
         li = render 'deadline_form', kind: 'buckingham_palace_confirm_press_book_notes'
         li = render 'deadline_form', kind: 'buckingham_palace_attendees_invite'
-        li = render 'deadline_form', kind: 'press_release_comments'

--- a/app/views/content_only/post_submission/_winners.html.slim
+++ b/app/views/content_only/post_submission/_winners.html.slim
@@ -41,7 +41,7 @@
                 span.award-info
                   span.pull-right
                     ' Due by
-                    = application_deadline_short(:press_release_comments)
+                    = application_deadline_short(:buckingham_palace_confirm_press_book_notes)
                   = link_to users_form_answer_press_summary_url(award, token: award.press_summary.token)
                     - if award.press_summary.reviewed_by_user
                       span.label-status.label-status-green

--- a/app/views/content_only/post_submission/_winners.html.slim
+++ b/app/views/content_only/post_submission/_winners.html.slim
@@ -12,8 +12,8 @@
       p
         strong Approve your Press Book entry
       p
-        ' We will be providing a Press Book to the media containing information about all the winners at noon on
-        => deadline_for("buckingham_palace_media_information")
+        ' We will be providing a Press Book to the media containing information about all the winners at
+        => deadline_for("buckingham_palace_media_information", "%H.%M on %A %d %B %Y")
         ' under the terms of the embargo. Click the 'Press Book Notes' link below to check your press piece, organization details and enter details of a contact for press enquiries, and
         strong
           'submit it by

--- a/app/views/users/buckingham_palace_invite_mailer/invite.html.slim
+++ b/app/views/users/buckingham_palace_invite_mailer/invite.html.slim
@@ -25,8 +25,8 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
     ' . You must not make any announcement about your Award, either to employees or outside your organisation, before this date.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' Under the terms of the embargo we will provide information to the media of the winners at noon on
-  = @media_deadline
+  ' Under the terms of the embargo we will provide information to the media of the winners at
+  =< @media_deadline
   ' , and the list of winners will be published in the Supplement to the London Gazette on
   = @deadline.try :strftime, "%d %B %Y"
 

--- a/app/views/users/buckingham_palace_invite_mailer/invite.text.slim
+++ b/app/views/users/buckingham_palace_invite_mailer/invite.text.slim
@@ -17,8 +17,8 @@
 = @deadline.strftime("%H.%Mhrs on %d %B %Y")
 ' . You must not make any announcement about your Award, either to employees or outside your organisation, before this date.
 
-' Under the terms of the embargo we will provide information to the media of the winners at noon on
-= @media_deadline
+' Under the terms of the embargo we will provide information to the media of the winners at
+=< @media_deadline
 ' , and the list of winners will be published in the Supplement to the London Gazette on
 = @deadline.strftime("%d %B %Y")
 

--- a/app/views/users/promotion_buckingham_palace_invite_mailer/notify.html.slim
+++ b/app/views/users/promotion_buckingham_palace_invite_mailer/notify.html.slim
@@ -1,6 +1,5 @@
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  ' Dear
-  = @name,
+  = "Dear #{@name},"
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' Last year

--- a/app/views/users/winners_head_of_organisation_mailer/notify.html.slim
+++ b/app/views/users/winners_head_of_organisation_mailer/notify.html.slim
@@ -31,8 +31,8 @@ div style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Your account holder needs to respond by <strong>5 pm on Monday 28 March</strong>, otherwise we will use the proposed text together with the contact details that we already hold.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  | Under the terms of the embargo we will provide information to the media about each of the winners at noon on Monday 11 April
-  =< @award_year
+  | Under the terms of the embargo we will provide information to the media about each of the winners at
+  =< @media_deadline
   |, and the list of winners will be published in the Supplement to the London Gazette on 21 April
   =< @award_year
   |.

--- a/app/views/users/winners_head_of_organisation_mailer/notify.text.slim
+++ b/app/views/users/winners_head_of_organisation_mailer/notify.text.slim
@@ -24,8 +24,8 @@
 '
 ' Your account holder needs to respond by 5 pm on Monday 28 March, otherwise we will use the proposed text together with the contact details that we already hold"
 '
-' Under the terms of the embargo we will provide information to the media about each of the winners at noon on Monday 11 April
-=< @award_year
+' Under the terms of the embargo we will provide information to the media about each of the winners at
+=< @media_deadline
 |, and the list of winners will be published in the Supplement to the London Gazette on 21 April
 =< @award_year
 |.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,6 @@ en:
     buckingham_palace_media_information: QAO provides information to the media of the winners on
     buckingham_palace_confirm_press_book_notes: Press Book Entry confirmation due by
     buckingham_palace_attendees_invite: Buckingham Palace Reception on
-    press_release_comments: Press release comments due by
     audit_certificates: Audit certificates due by
 
   email_notification_headers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,7 @@ en:
   email_notification_headers:
     reminder_to_submit: Reminder to submit the applications (to all those who have started but not yet submitted applications).
     ep_reminder_support_letters: "ENTERPRISE PROMOTION : Reminder to follow up supporter letters (to all those who have started EP applications, but have fewer than 2 support letters submitted)."
-    winners_notification: "WINNERS : Email notifying all winning applicants of their success, including request for reception attendee details."
+    winners_notification: "WINNERS : Email notifying all winning business applicants of their success & requesting their confirmation of their Press Book entry."
     winners_reminder_to_submit:" WINNERS : Reminder to submit *palace reception attendee details* (for winning applicants who haven't submitted yet)."
     winners_press_release_comments_request: "WINNERS : Email requesting comments on press release."
     winners_head_of_organisation_notification: "WINNERS : Success email to the 'Head of Organisation' of the Business categories Winner."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,10 +131,10 @@ en:
   deadline_messages:
     submission_start: Submission period starts on
     submission_end: Submission period closes on
-    buckingham_palace_attendees_details: Buckingham Palace reception attendees details due by
-    buckingham_palace_media_information: Buckingham Palace provides information to the media of the winners on
-    buckingham_palace_confirm_press_book_notes: Buckingham Palace Press Book Notes confirmation due by
-    buckingham_palace_attendees_invite: Buckingham Palace invites two representatives for the winners to attend HM The Queen's Reception on
+    buckingham_palace_attendees_details: HM The Queen's Birthday (end of embargo)
+    buckingham_palace_media_information: QAO provides information to the media of the winners on
+    buckingham_palace_confirm_press_book_notes: Press Book Entry confirmation due by
+    buckingham_palace_attendees_invite: Buckingham Palace Reception on
     press_release_comments: Press release comments due by
     audit_certificates: Audit certificates due by
 

--- a/spec/features/users/form_answers/press_summary_spec.rb
+++ b/spec/features/users/form_answers/press_summary_spec.rb
@@ -3,7 +3,7 @@ include Warden::Test::Helpers
 
 describe "Press Summary" do
   before do
-    deadline = Settings.current.deadlines.where(kind: "press_release_comments").first
+    deadline = Settings.current.deadlines.where(kind: "buckingham_palace_confirm_press_book_notes").first
     deadline.update_column(:trigger_at, Time.current + 1.day)
   end
 
@@ -27,7 +27,7 @@ describe "Press Summary" do
     end
 
     it "should not allow to fill the form after the deadline" do
-      deadline = Settings.current.deadlines.where(kind: "press_release_comments").first
+      deadline = Settings.current.deadlines.where(kind: "buckingham_palace_confirm_press_book_notes").first
       deadline.update_column(:trigger_at, Time.current - 1.day)
 
       visit users_form_answer_press_summary_url(form_answer, token: press_summary.token)

--- a/spec/mailers/users/buckingham_palace_invite_mailer_spec.rb
+++ b/spec/mailers/users/buckingham_palace_invite_mailer_spec.rb
@@ -13,10 +13,8 @@ describe Users::BuckinghamPalaceInviteMailer do
 
   describe "#notify" do
     let(:mail) { Users::BuckinghamPalaceInviteMailer.invite(palace_invite.id) }
-
-    before do
-      allow_any_instance_of(FormAnswer).to receive(:head_of_business) { "Jon Snow" }
-    end
+    let(:account_holder) { palace_invite.form_answer.user }
+    let(:account_holder_name) { "#{account_holder.title} #{account_holder.last_name}" }
 
     it "renders the headers" do
       expect(mail.to).to eq([palace_invite.email])
@@ -26,7 +24,7 @@ describe Users::BuckinghamPalaceInviteMailer do
     it "renders the body" do
       expect(mail.html_part.decoded).to have_link("Log in here",
                                                   href: dashboard_url)
-      expect(mail.html_part.decoded).to match("Jon Snow")
+      expect(mail.html_part.decoded).to match(account_holder_name)
     end
   end
 end

--- a/spec/mailers/users/winners_press_release_spec.rb
+++ b/spec/mailers/users/winners_press_release_spec.rb
@@ -8,7 +8,7 @@ describe Users::WinnersPressRelease do
   end
 
   let!(:deadline) do
-    deadline = Settings.current.deadlines.where(kind: "press_release_comments").first
+    deadline = Settings.current.deadlines.where(kind: "buckingham_palace_confirm_press_book_notes").first
     deadline.update!(trigger_at: Date.current)
     deadline.trigger_at.strftime("%d/%m/%Y")
   end

--- a/spec/models/settings_spec.rb
+++ b/spec/models/settings_spec.rb
@@ -11,7 +11,6 @@ describe Settings do
         buckingham_palace_attendees_invite
         buckingham_palace_confirm_press_book_notes
         buckingham_palace_media_information
-        press_release_comments
         submission_end submission_start
       )
       expect(settings.deadlines.order(:kind).map(&:kind)).to eq(expected)

--- a/spec/models/settings_spec.rb
+++ b/spec/models/settings_spec.rb
@@ -4,7 +4,7 @@ describe Settings do
   context "after create" do
     let(:settings) { Settings.current }
     it "creates all kinds of deadlines" do
-      expect(settings.deadlines.count).to eq(8)
+      expect(settings.deadlines.count).to eq(7)
       expected = %w(
         audit_certificates
         buckingham_palace_attendees_details

--- a/spec/renderers/mail_renderer_spec.rb
+++ b/spec/renderers/mail_renderer_spec.rb
@@ -73,7 +73,7 @@ describe MailRenderer do
   describe "#winners_notification" do
     it "renders e-mail" do
       rendered = described_class.new.winners_notification
-      expect(rendered).to match("Jon Snow")
+      expect(rendered).to match("Mr Smith")
       expect(rendered).to match("21/09/#{Date.current.year}")
     end
   end

--- a/spec/services/notifiers/email_notification_service_spec.rb
+++ b/spec/services/notifiers/email_notification_service_spec.rb
@@ -64,11 +64,13 @@ describe Notifiers::EmailNotificationService do
 
     it "triggers current notification" do
       form_answer = create(:form_answer, :trade, :submitted)
-      form_answer.document = form_answer.document.merge(head_email: "head@email.com")
+      form_answer.document = form_answer.document
       form_answer.save!
 
+      account_holder = form_answer.account.owner
+
       expect(Notifiers::Winners::BuckinghamPalaceInvite).to receive(:perform_async)
-        .with({email: "head@email.com", form_answer_id: form_answer.id})
+        .with({email: account_holder.email, form_answer_id: form_answer.id})
       expect(FormAnswer).to receive(:winners) { [form_answer] }
 
       described_class.run


### PR DESCRIPTION
Bunch of corrects related to 
[Trello Story](https://trello.com/c/hv5wpJgy/287-qae-support-change-successful-business-winners-email-copy-currently-titled-in-settings-as-winners-email-notifying-all-winning-ap)

* Update the email previews
* Update admin deadline titles
* For winners email, it says "winners at noon on <date>". should change to "winners at <date time>"
* Merge Press release comments due by into the new Press Book Entry confirmation due by date. because these are effectively the same thing (should not be separate deadline settings)
* Bunch of fixes