### PR TITLE
Exclude reserved applications from unsuccessful email list

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -110,7 +110,7 @@ class FormAnswer < ActiveRecord::Base
     scope :shortlisted, -> { where(state: %w(reserved recommended)) }
     scope :not_shortlisted, -> { where(state: "not_recommended") }
     scope :winners, -> { where(state: "awarded") }
-    scope :unsuccessful, -> { where(state: %w(not_recommended not_awarded reserved)) }
+    scope :non_winners, -> { where("state not in ('awarded', 'withdrawn')") }
     scope :submitted, -> { where(submitted: true) }
     scope :positive, -> { where(state: FormAnswerStateMachine::POSITIVE_STATES) }
     scope :business, -> { where(award_type: %w(trade innovation development)) }

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -57,13 +57,13 @@ class Notifiers::EmailNotificationService
   end
 
   def unsuccessful_notification(award_year)
-    award_year.form_answers.business.unsuccessful.each do |form_answer|
+    award_year.form_answers.business.non_winners.each do |form_answer|
       Users::UnsuccessfulFeedbackMailer.notify(form_answer.id).deliver_later!
     end
   end
 
   def unsuccessful_ep_notification(award_year)
-    award_year.form_answers.promotion.unsuccessful.each do |form_answer|
+    award_year.form_answers.promotion.non_winners.each do |form_answer|
       Users::UnsuccessfulFeedbackMailer.ep_notify(form_answer.id).deliver_later!
     end
   end

--- a/spec/factories/form_answer_factory.rb
+++ b/spec/factories/form_answer_factory.rb
@@ -19,6 +19,25 @@ FactoryGirl.define do
       state "recommended"
     end
 
+    trait :withdrawn do
+      state "withdrawn"
+    end
+
+    trait :not_recommended do
+      submitted true
+      state "not_recommended"
+    end
+
+    trait :not_awarded do
+      submitted true
+      state "not_awarded"
+    end
+
+    trait :reserved do
+      submitted true
+      state "reserved"
+    end
+
     trait :trade do
       award_type "trade"
       document FormAnswer::DocumentParser.parse_json_document(

--- a/spec/models/form_answer_spec.rb
+++ b/spec/models/form_answer_spec.rb
@@ -99,4 +99,25 @@ RSpec.describe FormAnswer, type: :model do
       expect(build(:form_answer, state: "recommended")).to be_recommended
     end
   end
+
+  describe "non_winners" do
+    it "excludes awarded form_answers" do
+      form_answer = create(:form_answer, :promotion, :awarded)
+      expect(FormAnswer.non_winners).not_to include(form_answer)
+    end
+
+    it "excludes withdrawn form_answers" do
+      form_answer = create(:form_answer, :promotion, :withdrawn)
+      expect(FormAnswer.non_winners).not_to include(form_answer)
+    end
+
+    it "includes all other form_answers" do
+      not_recommended = create(:form_answer, :promotion, :not_recommended)
+      not_awarded = create(:form_answer, :promotion, :not_awarded)
+      reserved = create(:form_answer, :promotion, :reserved)
+      expect(FormAnswer.non_winners).to include(not_recommended)
+      expect(FormAnswer.non_winners).to include(not_awarded)
+      expect(FormAnswer.non_winners).to include(reserved)
+    end
+  end
 end


### PR DESCRIPTION
According to the last comment from Kerry:

> Just to clarify again for QAEP, International Trade, Innovation and Sustainable Development the unsuccessful emails should go to those where the "STATUS" in the white section on the left hand side says "Not Recommended" or "Not Awarded".
> Where the STATUS is "Withdrawn" they do not get anything.