### PR TITLE
[PDF hard copy] After the closing date, users should be able to see a hard copy PDF

### DIFF
--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -6,7 +6,6 @@ class Admin::FormAnswersController < Admin::BaseController
     :show,
     :update,
     :update_financials,
-    :original_pdf_before_deadline,
     :remove_audit_certificate
   ]
 

--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -1,7 +1,7 @@
 class Assessor::FormAnswersController < Assessor::BaseController
   include FormAnswerMixin
 
-  before_filter :load_resource, only: [:update_financials, :original_pdf_before_deadline]
+  before_filter :load_resource, only: [:update_financials]
 
   expose(:financial_pointer) do
     FormFinancialPointer.new(@form_answer, {

--- a/app/controllers/concerns/form_answer_mixin.rb
+++ b/app/controllers/concerns/form_answer_mixin.rb
@@ -57,18 +57,6 @@ module FormAnswerMixin
     redirect_to edit_form_path(@form_answer)
   end
 
-  def original_pdf_before_deadline
-    authorize @form_answer, :can_download_original_pdf_of_application_before_deadline?
-
-    respond_to do |format|
-      format.pdf do
-        send_data pdf_data.render,
-                  filename: pdf_filename,
-                  type: "application/pdf"
-      end
-    end
-  end
-
   private
 
   def primary_assessment
@@ -124,17 +112,5 @@ module FormAnswerMixin
       updated_by_id: pundit_user.id,
       updated_by_type: pundit_user.class
     }.merge(params[:financial_data])
-  end
-
-  def original_form_answer
-    @form_answer.original_form_answer
-  end
-
-  def pdf_data
-    original_form_answer.decorate.pdf_generator
-  end
-
-  def pdf_filename
-    "original_pdf_before_deadline_#{@form_answer.decorate.pdf_filename}"
   end
 end

--- a/app/controllers/users/form_answers_controller.rb
+++ b/app/controllers/users/form_answers_controller.rb
@@ -1,12 +1,9 @@
 class Users::FormAnswersController < Users::BaseController
+
   expose(:form_answer) do
     current_user.account
                 .form_answers
                 .find(params[:id])
-  end
-
-  expose(:original_form_answer) do
-    form_answer.original_form_answer
   end
 
   expose(:pdf_blank_mode) do
@@ -18,18 +15,32 @@ class Users::FormAnswersController < Users::BaseController
   end
 
   def show
-    respond_to do |format|
-      format.pdf do
-        # TODO:
-        # for now we will display always latest version of form
-        # in future would be special button for this
-        # pdf = original_form_answer.decorate.pdf_generator(pdf_blank_mode)
-        #
-        pdf = form_answer.decorate.pdf_generator(pdf_blank_mode)
-        send_data pdf.render,
-                  filename: original_form_answer.decorate.pdf_filename,
-                  type: "application/pdf"
+    if can_render_pdf_on_fly?
+      respond_to do |format|
+        format.pdf do
+          pdf = form_answer.decorate.pdf_generator(pdf_blank_mode)
+          send_data pdf.render,
+                    filename: form_answer.decorate.pdf_filename,
+                    type: "application/pdf"
+        end
       end
+    else
+      render_hard_copy_pdf
+    end
+  end
+
+  private
+
+  def can_render_pdf_on_fly?
+    !form_answer.submission_ended?
+  end
+
+  def render_hard_copy_pdf
+    if form_answer.pdf_version.present?
+      redirect_to form_answer.pdf_version.url
+    else
+      redirect_to dashboard_path,
+                  notice: "PDF version for your application is not available!"
     end
   end
 end

--- a/app/models/award_year.rb
+++ b/app/models/award_year.rb
@@ -7,6 +7,11 @@ class AwardYear < ActiveRecord::Base
   after_create :create_settings
 
   AVAILABLE_YEARS = [2016, 2017, 2018, 2019]
+
+  def current?
+    self.year == self.class.current.year
+  end
+
   # +1 here is to match URN number of assosiated forms
   def self.mock_current_year?
     Rails.env.test?

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -40,6 +40,8 @@ class FormAnswer < ActiveRecord::Base
 
   enumerize :award_type, in: POSSIBLE_AWARDS, predicates: true
 
+  mount_uploader :pdf_version, FormAnswerPdfVersionUploader
+
   begin :associations
     belongs_to :user
     belongs_to :account
@@ -115,6 +117,7 @@ class FormAnswer < ActiveRecord::Base
     scope :positive, -> { where(state: FormAnswerStateMachine::POSITIVE_STATES) }
     scope :business, -> { where(award_type: %w(trade innovation development)) }
     scope :promotion, -> { where(award_type: "promotion") }
+    scope :in_progress, -> { where(state: ["eligibility_in_progress", "application_in_progress"]) }
   end
 
   begin :callbacks
@@ -256,6 +259,10 @@ class FormAnswer < ActiveRecord::Base
 
   def business?
     %w(trade innovation development).include?(award_type)
+  end
+
+  def generate_pdf_version!
+    ApplicationHardCopyPdfGenerator.new(self).run
   end
 
   private

--- a/app/models/form_answer_state_machine.rb
+++ b/app/models/form_answer_state_machine.rb
@@ -43,10 +43,13 @@ class FormAnswerStateMachine
 
   def self.trigger_deadlines
     if Settings.after_current_submission_deadline?
-      FormAnswer.where(state: "submitted").find_each do |fa|
+      current_year = Settings.current.award_year
+
+      current_year.form_answers.where(state: "submitted").find_each do |fa|
         fa.state_machine.perform_transition("assessment_in_progress")
       end
-      FormAnswer.where(state: ["eligibility_in_progress", "application_in_progress"]).find_each do |fa|
+
+      current_year.form_answers.in_progress.find_each do |fa|
         fa.state_machine.perform_transition("not_submitted")
       end
     end

--- a/app/pdf_generators/application_hard_copy_pdf_generator.rb
+++ b/app/pdf_generators/application_hard_copy_pdf_generator.rb
@@ -1,0 +1,41 @@
+# On the day of the application submission deadline,
+# generates a hard copy of the pdf and saves it
+
+# Use:
+# ApplicationHardCopyPdfGenerator.new(form_answer).run
+#
+
+class ApplicationHardCopyPdfGenerator
+
+  attr_reader :form_answer,
+              :pdf,
+              :tempfile_name
+
+  def initialize(form_answer)
+    @form_answer = form_answer
+    @pdf = form_answer.original_form_answer
+                      .decorate
+                      .pdf_generator
+    timestamp = Time.now.strftime('%d_%b_%Y_%H_%M')
+    @tempfile_name = "application_#{form_answer.urn}_#{timestamp}_SEPARATOR".gsub("/", "_")
+  end
+
+  def run
+    # Create a tempfile
+    tmpfile = Tempfile.new([tempfile_name, '.pdf'])
+
+    # set to binary mode to avoid UTF-8 conversion errors
+    tmpfile.binmode
+
+    # Use render to write the file contents
+    tmpfile.write pdf.render
+
+    # Upload the tempfile with your Carrierwave uploader
+    form_answer.pdf_version = tmpfile
+    form_answer.save!
+
+    # Close the tempfile and delete it
+    tmpfile.close
+    tmpfile.unlink
+  end
+end

--- a/app/pdf_generators/application_hard_copy_pdf_generator.rb
+++ b/app/pdf_generators/application_hard_copy_pdf_generator.rb
@@ -16,7 +16,8 @@ class ApplicationHardCopyPdfGenerator
     @pdf = form_answer.original_form_answer
                       .decorate
                       .pdf_generator
-    timestamp = Time.now.strftime('%d_%b_%Y_%H_%M')
+
+    timestamp = form_answer.submission_end_date.strftime('%d_%b_%Y_%H_%M')
     @tempfile_name = "application_#{form_answer.urn}_#{timestamp}_SEPARATOR".gsub("/", "_")
   end
 

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -9,8 +9,11 @@ class FormAnswerPolicy < ApplicationPolicy
   end
 
   def review?
-    return true if admin?
-    subject.lead_or_assigned?(record)
+    record.award_year.current? &&
+    (
+      admin? ||
+      subject.lead_or_assigned?(record)
+    )
   end
 
   def show?
@@ -85,6 +88,9 @@ class FormAnswerPolicy < ApplicationPolicy
   end
 
   def can_download_original_pdf_of_application_before_deadline?
-    can_update_by_admin_lead_and_primary_assessors? && record.submission_ended?
+    can_update_by_admin_lead_and_primary_assessors? &&
+    record.submitted? &&
+    record.submission_ended? &&
+    record.pdf_version.present?
   end
 end

--- a/app/services/update_deadline_service.rb
+++ b/app/services/update_deadline_service.rb
@@ -23,6 +23,7 @@ class UpdateDeadlineService
         ::SubmissionDeadlineStatesTransitionWorker.perform_async("#{deadline.id}_#{now}")
       end
 
+      # TODO: check this after migration to sidekiq
       ::SubmissionDeadlineApplicationPdfGenerationWorker.set(
         wait_until: trigger_at
       ).perform_later

--- a/app/services/update_deadline_service.rb
+++ b/app/services/update_deadline_service.rb
@@ -18,8 +18,14 @@ class UpdateDeadlineService
     now = DateTime.now
     trigger_at = deadline.trigger_at
 
-    if deadline.submission_end? && trigger_at.present? && now >= trigger_at
-      ::SubmissionDeadlineStatesTransitionWorker.perform_async("#{deadline.id}_#{now}")
+    if deadline.submission_end? && trigger_at.present?
+      if now >= trigger_at
+        ::SubmissionDeadlineStatesTransitionWorker.perform_async("#{deadline.id}_#{now}")
+      end
+
+      ::SubmissionDeadlineApplicationPdfGenerationWorker.set(
+        wait_until: trigger_at
+      ).perform_later
     end
   end
 end

--- a/app/uploaders/form_answer_pdf_version_uploader.rb
+++ b/app/uploaders/form_answer_pdf_version_uploader.rb
@@ -1,0 +1,15 @@
+class FormAnswerPdfVersionUploader < CarrierWave::Uploader::Base
+  def filename
+    if original_filename.present?
+      "#{original_filename.split("_SEPARATOR")[0]}.#{file.extension}"
+    end
+  end
+
+  def extension_white_list
+    %w(pdf)
+  end
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+end

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -1,9 +1,10 @@
 .well
   .sidebar-section
-    = link_to [:review, namespace_name, @form_answer], class: "btn btn-default btn-block", target: "_blank"
-      span.icon-view
-      span.btn-title
-        ' View application
+    - if policy(resource).review?
+      = link_to [:review, namespace_name, @form_answer], class: "btn btn-default btn-block", target: "_blank"
+        span.icon-view
+        span.btn-title
+          ' View application
     = render "admin/form_answers/docs/not_completed_audit_certificate"
     = render "admin/form_answers/docs/download_original_application_pdf_before_deadline"
 

--- a/app/views/admin/form_answers/docs/_download_original_application_pdf_before_deadline.html.slim
+++ b/app/views/admin/form_answers/docs/_download_original_application_pdf_before_deadline.html.slim
@@ -1,8 +1,6 @@
 - if policy(@form_answer).can_download_original_pdf_of_application_before_deadline?
 
-  - target_url = pundit_user.is_a?(Admin) ? original_pdf_before_deadline_admin_form_answer_url(@form_answer, format: :pdf) : original_pdf_before_deadline_assessor_form_answer_url(@form_answer, format: :pdf)
-
-  = link_to target_url,
+  = link_to @form_answer.pdf_version.url,
             class: "btn btn-default btn-block",
             target: "_blank"
     span.glyphicon.glyphicon-file

--- a/app/workers/application_hard_copy_pdf_worker.rb
+++ b/app/workers/application_hard_copy_pdf_worker.rb
@@ -1,0 +1,10 @@
+class ApplicationHardCopyPdfWorker
+  include Shoryuken::Worker
+
+  shoryuken_options queue: "#{Rails.env}_default", auto_delete: true
+
+  def perform(sqs_msg, form_answer_id)
+    form_answer = FormAnswer.find(form_answer_id)
+    form_answer.generate_pdf_version!
+  end
+end

--- a/app/workers/submission_deadline_application_pdf_generation_worker.rb
+++ b/app/workers/submission_deadline_application_pdf_generation_worker.rb
@@ -1,0 +1,11 @@
+class SubmissionDeadlineApplicationPdfGenerationWorker
+  include Shoryuken::Worker
+
+  shoryuken_options queue: "#{Rails.env}_default", auto_delete: true
+
+  def perform(_sqs_msg)
+    AwardYear.current.form_answers.submitted.find_each do |form_answer|
+      ApplicationHardCopyPdfWorker.perform_async(form_answer.id)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,10 +142,6 @@ Rails.application.routes.draw do
     resources :review_audit_certificates, only: [:create]
 
     resources :form_answers do
-      member do
-        get :original_pdf_before_deadline
-      end
-
       resources :form_answer_state_transitions, only: [:create]
       resources :comments
       resources :form_answer_attachments, only: [:create, :show, :destroy]
@@ -199,7 +195,6 @@ Rails.application.routes.draw do
 
     resources :form_answers do
       member do
-        get :original_pdf_before_deadline
         patch :remove_audit_certificate
       end
 

--- a/db/migrate/20160224174712_add_pdf_version_to_form_answers.rb
+++ b/db/migrate/20160224174712_add_pdf_version_to_form_answers.rb
@@ -1,0 +1,5 @@
+class AddPdfVersionToFormAnswers < ActiveRecord::Migration
+  def change
+    add_column :form_answers, :pdf_version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160222175452) do
+ActiveRecord::Schema.define(version: 20160224174712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -268,6 +268,7 @@ ActiveRecord::Schema.define(version: 20160222175452) do
     t.string   "nominator_email"
     t.string   "user_email"
     t.boolean  "corp_responsibility_reviewed",  default: false
+    t.string   "pdf_version"
   end
 
   add_index "form_answers", ["account_id"], name: "index_form_answers_on_account_id", using: :btree

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -9,6 +9,13 @@ namespace :form_answers do
     FormAnswerUserSubmissionService.new(f).perform
   end
 
+  desc "populate hard copy PDF version for current award year applications"
+  task populate_hard_copy_pdf_version_for_applications: :environment do
+    AwardYear.current.form_answers.submitted.find_each do |form_answer|
+      ApplicationHardCopyPdfWorker.perform_async(form_answer.id)
+    end
+  end
+
   desc "fixes eligibility inconsistencies"
   task fix_eligibility: :environment do
     FormAnswer.find_each do |f|

--- a/spec/features/admin/form_answers/download_original_pdf_before_deadline_ends_spec.rb
+++ b/spec/features/admin/form_answers/download_original_pdf_before_deadline_ends_spec.rb
@@ -13,11 +13,8 @@ So that I can see original application data was at the deadline moment
     admin_form_answer_path(form_answer)
   end
 
-  let(:pdf_url) do
-    original_pdf_before_deadline_admin_form_answer_url(form_answer, format: :pdf)
-  end
-
   before do
+    form_answer.generate_pdf_version!
     login_admin(admin)
   end
 

--- a/spec/features/assessor/download_original_pdf_before_deadline_ends_spec.rb
+++ b/spec/features/assessor/download_original_pdf_before_deadline_ends_spec.rb
@@ -11,8 +11,8 @@ So that I can see original application data was at the deadline moment
     assessor_form_answer_path(form_answer)
   end
 
-  let(:pdf_url) do
-    original_pdf_before_deadline_assessor_form_answer_url(form_answer, format: :pdf)
+  before do
+    form_answer.generate_pdf_version!
   end
 
   describe "Lead Assessor" do

--- a/spec/support/shared_contexts/download_original_pdf_before_deadline_ends.rb
+++ b/spec/support/shared_contexts/download_original_pdf_before_deadline_ends.rb
@@ -41,28 +41,12 @@ shared_context "download original pdf before deadline ends" do
 
       it "should display download button" do
         expect(page).to have_link(
-          "Download original PDF before deadline", pdf_url
+          "Download original PDF before deadline",
+          form_answer.pdf_version.url
         )
       end
     end
 
-    describe "PDF generation" do
-      let(:pdf_filename) do
-        "original_pdf_before_deadline_#{form_answer.decorate.pdf_filename}"
-      end
-
-      before do
-        visit pdf_url
-      end
-
-      it "should generate pdf file" do
-        expect(page.status_code).to eq(200)
-        expect(page.response_headers["Content-Disposition"]).to be_eql(
-          "attachment; filename=\"#{pdf_filename}\""
-        )
-        expect(page.response_headers["Content-Type"]).to be_eql "application/pdf"
-      end
-    end
 
     describe "PDF content" do
       let(:registration_number_at_the_deadline) {


### PR DESCRIPTION
Generate a pdf of the application form, so that users can see their answers to past applications.
We will be changing the form in the new year so keep a hard copy that they can view.

* On the day of the application deadline, generate a hard copy of the pdf and save this to the application

* Task to generate the PDF for all the forms for each application and attach these as hard copies,
  as at the moment they are generate live (need to backdate this)

* Make sure the PDF we display for the users and admins,
  at the time of submission is the hard copy stored PDFs, not generated on the fly

* Admins should also when looking at past years, should only be able to see the PDF,
  not the web form as the form will change in the new year

[Trello Story](https://trello.com/c/b2yCzpmm/661-qae-support-after-the-closing-date-users-should-be-able-to-see-a-pdf-of-their-application)