### PR TITLE
head of organization email date fixes

### DIFF
--- a/app/mailers/users/winners_head_of_organisation_mailer.rb
+++ b/app/mailers/users/winners_head_of_organisation_mailer.rb
@@ -12,8 +12,18 @@ class Users::WinnersHeadOfOrganisationMailer < ApplicationMailer
     @last_name = @form_answer.document["head_of_business_last_name"]
     @name = "#{@title} #{@last_name}"
 
-    @media_deadline = Settings.current.deadlines.where(kind: "buckingham_palace_media_information").first
-    @media_deadline = @media_deadline.try :strftime, "%H.%M on %A %d %B %Y"
+    deadlines = Settings.current.deadlines
+
+    @media_deadline =
+      deadlines.buckingham_palace_media_information.strftime("%H.%M on %A %d %B %Y")
+    @end_of_embargo_date =
+      deadlines.end_of_embargo.strftime("%-d %B %Y")
+    @end_of_embargo_datetime =
+      deadlines.end_of_embargo.strftime("%H.%Mhrs on %-d %B %Y")
+    @press_book_entry_datetime =
+      deadlines.buckingham_palace_confirm_press_book_notes.strftime("%l:%M %p on %A %-d %B")
+    @attendees_invite_date =
+      deadlines.buckingham_palace_attendees_invite.strftime("%A %d %B %Y")
 
     @subject = "[Queen's Awards for Enterprise] Important information about your Queen's Award Entry!"
 

--- a/app/models/deadline.rb
+++ b/app/models/deadline.rb
@@ -34,8 +34,28 @@ class Deadline < ActiveRecord::Base
     where(kind: "submission_start").first
   end
 
+  def self.end_of_embargo
+    where(kind: "buckingham_palace_attendees_details").first
+  end
+
+  def self.buckingham_palace_confirm_press_book_notes
+    where(kind: "buckingham_palace_confirm_press_book_notes").first
+  end
+
+  def self.buckingham_palace_attendees_invite
+    where(kind: "buckingham_palace_attendees_invite").first
+  end
+
+  def self.buckingham_palace_media_information
+    where(kind: "buckingham_palace_media_information").first
+  end
+
   def passed?
     trigger_at && trigger_at < Time.zone.now
+  end
+
+  def strftime(format)
+    trigger_at ? trigger_at.strftime(format) : "-"
   end
 
   private

--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -131,6 +131,12 @@ class MailRenderer
     assigns[:head_email] = "john@example.com"
     assigns[:head_of_business_full_name] = "Jon Doe"
 
+    assigns[:media_deadline] = deadline_str("buckingham_palace_media_information", "%H.%M on %A %d %B %Y")
+    assigns[:end_of_embargo_date] = deadline_str("buckingham_palace_attendees_details", "%-d %B %Y")
+    assigns[:end_of_embargo_datetime] = deadline_str("buckingham_palace_attendees_details","%H.%Mhrs on %-d %B %Y")
+    assigns[:press_book_entry_datetime] = deadline_str("buckingham_palace_confirm_press_book_notes", "%l:%M %p on %A %-d %B")
+    assigns[:attendees_invite_date] = deadline_str("buckingham_palace_attendees_invite","%A %d %B %Y")
+
     render(assigns, "users/winners_head_of_organisation_mailer/notify")
   end
 
@@ -161,7 +167,7 @@ class MailRenderer
     if d.present?
       d.strftime(format)
     else
-      "21/09/#{Date.current.year}"
+      DateTime.new(Date.current.year, 9, 21, 10, 30).strftime(format)
     end
   end
 

--- a/app/views/users/winners_head_of_organisation_mailer/notify.html.slim
+++ b/app/views/users/winners_head_of_organisation_mailer/notify.html.slim
@@ -16,33 +16,36 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | this year.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  | The Award will be conferred on Thursday 21 April
-  =< @award_year
-  |, Her Majesty's birthday. Although you can make arrangements for publicity now, <strong>there is a strict embargo preventing public announcement or publication of any Awards information until 00.01hrs on 21 April
-  =< @award_year
+  | The Award will be conferred on
+  =< @end_of_embargo_date
+  |, Her Majesty's birthday. Although you can make arrangements for publicity now, <strong>there is a strict embargo preventing public announcement or publication of any Awards information until
+  =< @end_of_embargo_datetime
   |. You must not make any announcement about your Award, either to employees or outside your organisation, before this date.</strong>
 
 div style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | We have emailed your online account holder with a link to the Winners' Dashboard to check:
   ul
     li the Press Book entry (a factual account of why you have won the Award and not a promotional press opportunity)
-    li the other details for your organisation are correct.
+    li the other details for your organisation are correct
     li provide details of a contact for press enquiries
-  | Your account holder needs to respond by <strong>5 pm on Monday 28 March</strong>, otherwise we will use the proposed text together with the contact details that we already hold.
+  | Your account holder needs to respond by
+  strong
+    =< @press_book_entry_datetime
+  |, otherwise we will use the proposed text together with the contact details that we already hold.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Under the terms of the embargo we will provide information to the media about each of the winners at
   =< @media_deadline
-  |, and the list of winners will be published in the Supplement to the London Gazette on 21 April
-  =< @award_year
+  |, and the list of winners will be published in the Supplement to the London Gazette on
+  =< @end_of_embargo_date
   |.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | A link to the Queen's Awards emblems and Winners' Manual is also on the online account.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  | Two representatives from your winning organisation will be invited to attend HM The Queen's Reception at Buckingham Palace on Thursday 14 July
-  =< @award_year
+  | Two representatives from your winning organisation will be invited to attend HM The Queen's Reception at Buckingham Palace on
+  =< @attendees_invite_date
   | .  We will contact your online account holder closer to the time with instructions for submitting the details of the attendees.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
@@ -64,7 +67,7 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | , or call the Business Support Helpline, tel: 0300 456 3565 (Monday to Friday, 9.00am – 6.00pm). For business support outside of England go to
   | &nbsp;
   a href="http://www.bgateway.com/"
-    | Scotland
+    | the Scotland
   | ,&nbsp;
   a href="http://business.wales.gov.uk/"
     | Wales

--- a/app/views/users/winners_head_of_organisation_mailer/notify.text.slim
+++ b/app/views/users/winners_head_of_organisation_mailer/notify.text.slim
@@ -11,35 +11,37 @@
 =>< @award_category_title
 | this year.
 '
-' The Award will be conferred on Thursday 21 April
-=< @award_year
-|, Her Majesty's birthday. Although you can make arrangements for publicity now, there is a strict embargo preventing public announcement or publication of any Awards information until 00.01hrs on 21 April
-=< @award_year
+' The Award will be conferred on
+=< @end_of_embargo_date
+|, Her Majesty's birthday. Although you can make arrangements for publicity now, there is a strict embargo preventing public announcement or publication of any Awards information until
+=< @end_of_embargo_datetime
 |. You must not make any announcement about your Award, either to employees or outside your organisation, before this date.
 '
 ' We have emailed your online account holder with a link to the Winners' Dashboard to check:
 | - the Press Book entry (a factual account of why you have won the Award and not a promotional press opportunity)
-| - the other details for your organisation are correct.
+| - the other details for your organisation are correct
 | - provide details of a contact for press enquiries
 '
-' Your account holder needs to respond by 5 pm on Monday 28 March, otherwise we will use the proposed text together with the contact details that we already hold"
+' Your account holder needs to respond by
+=< @press_book_entry_datetime
+|, otherwise we will use the proposed text together with the contact details that we already hold"
 '
 ' Under the terms of the embargo we will provide information to the media about each of the winners at
 =< @media_deadline
-|, and the list of winners will be published in the Supplement to the London Gazette on 21 April
-=< @award_year
+|, and the list of winners will be published in the Supplement to the London Gazette on
+=< @end_of_embargo_date
 |.
 '
 ' A link to the Queen's Awards emblems and Winners Manual is also on the online account.
 '
-' Two representatives from your winning organisation will be invited to attend HM The Queen's Reception at Buckingham Palace on Thursday 14 July
-=< @award_year
+' Two representatives from your winning organisation will be invited to attend HM The Queen's Reception at Buckingham Palace on
+=< @attendees_invite_date
 | .  We will contact your online account holder closer to the time with instructions for submitting the details of the attendees.
 '
 ' Further Information
 '
 ' UKTI - Award winners will be contacted by UK Trade & Investment who will assist with any help needed on export strategies, routes to market, sources of additional expertise, or access to its overseas network in tailoring support to meet your needs.
-| Growth Hubs - Government is investing in 39 Growth Hubs in England, and giving them ownership of how they support local businesses to start and scale-up. They can provide national business support, and diagnostic and signposting advice to help businesses find the right support easily, no matter what their size or sector. If you would like to find out more visit http://www.lepnetwork.net/growth-hubs/, or call the Business Support Helpline, tel: 0300 456 3565 (Monday to Friday, 9.00am – 6.00pm). For business support outside of England go to Scotland (http://www.bgateway.com/), Wales (http://businesswales.gov.wales/) and Northern Ireland (http://www.investni.com/index.html) websites.
+| Growth Hubs - Government is investing in 39 Growth Hubs in England, and giving them ownership of how they support local businesses to start and scale-up. They can provide national business support, and diagnostic and signposting advice to help businesses find the right support easily, no matter what their size or sector. If you would like to find out more visit http://www.lepnetwork.net/growth-hubs/, or call the Business Support Helpline, tel: 0300 456 3565 (Monday to Friday, 9.00am – 6.00pm). For business support outside of England go to the Scotland (http://www.bgateway.com/), Wales (http://businesswales.gov.wales/) and Northern Ireland (http://www.investni.com/index.html) websites.
 '
 ' Congratulations once again on your Award.
 '

--- a/spec/renderers/mail_renderer_spec.rb
+++ b/spec/renderers/mail_renderer_spec.rb
@@ -6,7 +6,7 @@ describe MailRenderer do
       rendered = described_class.new.shortlisted_audit_certificate_reminder
       expect(rendered).to match("Jane Doe")
       # placeholder for date if deadlines are not set
-      expect(rendered).to match("21/09/#{Date.current.year}")
+      expect(rendered).to match(deadline_str)
     end
   end
 
@@ -39,7 +39,7 @@ describe MailRenderer do
       rendered = described_class.new.reminder_to_submit
       expect(rendered).to match("Jon Doe")
       expect(rendered).to match(link)
-      expect(rendered).to match("21/09/#{Date.current.year}")
+      expect(rendered).to match(deadline_str)
     end
   end
 
@@ -50,7 +50,7 @@ describe MailRenderer do
       expect(rendered).to match("Jon Doe")
       expect(rendered).to match("Jane Doe")
       expect(rendered).to match(link)
-      expect(rendered).to match("21/09/#{Date.current.year}")
+      expect(rendered).to match(deadline_str)
     end
   end
 
@@ -74,7 +74,7 @@ describe MailRenderer do
     it "renders e-mail" do
       rendered = described_class.new.winners_notification
       expect(rendered).to match("Mr Smith")
-      expect(rendered).to match("21/09/#{Date.current.year}")
+      expect(rendered).to match(deadline_str("%A %d %B %Y"))
     end
   end
 
@@ -83,5 +83,10 @@ describe MailRenderer do
       rendered = described_class.new.winners_head_of_organisation_notification
       expect(rendered).to match("Congratulations on winning a Queen's Award")
     end
+  end
+
+  def deadline_str(format="%d/%m/%Y")
+    DateTime.new(Date.current.year, 9, 21, 10, 30)
+            .strftime(format)
   end
 end


### PR DESCRIPTION
https://trello.com/c/zc97L7dF/288-qae-support-new-email-to-head-of-organisation-of-the-successful-business-categories-winners


A few corrections please

The full stop at the end of the second bullet point in the third paragraph still needs to be removed
The word “the” needs to go between the words “to” and “Scotland” in the paragraph eight (i.e the growth hubs para)
Please clarify point 9 24 Feb
The two dates and times in the second paragraph should change as a result of the date & time set of “HM The Queen's Birthday (end of embargo)”
The date & time in the third paragraph should change as a result of the date/time set of “Press Book Entry confirmation due by”
In the fourth paragraph the time set in the “QAO provides information to the media of the winners on” should display after the word “at” followed by the date. Also the date at the end of the paragraph relating to the London Gazette should be the “HM The Queen's Birthday (end of embargo)” set date.
In the sixth paragraph the date set in the “Buckingham Palace Reception on” should appear at the end of the first sentence.