### PR TITLE
fix email recipients

### DIFF
--- a/app/mailers/users/winners_press_release.rb
+++ b/app/mailers/users/winners_press_release.rb
@@ -3,18 +3,12 @@ class Users::WinnersPressRelease < AccountMailer
     @form_answer = FormAnswer.find(form_answer_id).decorate
     @user = @form_answer.user.decorate
 
-    email = if @form_answer.promotion?
-      @form_answer.document["nominee_email"]
-    else
-      @user.email
-    end
-
     @deadline = Settings.current.deadlines.where(kind: "buckingham_palace_confirm_press_book_notes").first
     @deadline = @deadline.trigger_at.strftime("%d/%m/%Y")
 
     @token = @form_answer.press_summary.token
     @subject = "[Queen's Awards for Enterprise] Press Comment"
 
-    mail to: email, subject: @subject
+    mail to: @user.email, subject: @subject
   end
 end

--- a/app/models/press_summary.rb
+++ b/app/models/press_summary.rb
@@ -5,7 +5,6 @@ class PressSummary < ActiveRecord::Base
   validates :name, :email, :phone_number, presence: true, if: :reviewed_by_user?
 
   before_validation :set_token, on: :create
-  after_save :notify_applicant
 
   belongs_to :authorable, polymorphic: true
 
@@ -17,11 +16,5 @@ class PressSummary < ActiveRecord::Base
 
   def set_token
     self.token = SecureRandom.base64(24)
-  end
-
-  def notify_applicant
-    if approved_changed? && approved?
-      Users::WinnersPressRelease.notify(form_answer.id).deliver_later!
-    end
   end
 end

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -87,7 +87,7 @@ class Notifiers::EmailNotificationService
   end
 
   def winners_press_release_comments_request(award_year)
-    award_year.form_answers.winners.includes(:press_summary).each do |form_answer|
+    award_year.form_answers.business.winners.includes(:press_summary).each do |form_answer|
       ps = form_answer.press_summary
 
       if ps && ps.approved? && !ps.reviewed_by_user?


### PR DESCRIPTION
- avoid sending press release emails to QAEP users or nominees
- avoid sending press release emails to users when the assessors approves a press summary
