### PR TITLE
Admins can see and edit press contact information

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -166,7 +166,11 @@ ready = ->
     area = formGroup.find("textarea:visible")
     formGroup.removeClass("form-edit")
 
-    if area.length == 1
+    if formGroup.find(".form-value p[data-for]").length > 0 # use manual mapping
+      formGroup.find(".form-value p[data-for]").each ->
+        $(this).html($("##{$(this).data("for")}").val())
+      form.submit()
+    else if area.length == 1
       if area.val().length
         formGroup.find(".form-value p").html(area.val().replace(/\n/g, '<br />'))
         updatedSection = link.data("updated-section")
@@ -181,7 +185,7 @@ ready = ->
           if input.length
             input.val(updatedSection)
         form.submit()
-     else
+    else
        if area.first().val().length
          formGroup.find(".form-value p:first").html(area.first().val().replace(/\n/g, '<br />'))
        if area.last().val().length

--- a/app/controllers/concerns/press_summary_mixin.rb
+++ b/app/controllers/concerns/press_summary_mixin.rb
@@ -60,7 +60,7 @@ module PressSummaryMixin
   end
 
   def press_summary_params
-    params.require(:press_summary).permit(:body)
+    params.require(:press_summary).permit(:body, :name, :phone_number, :email)
   end
 
   def load_form_answer

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -179,7 +179,7 @@ class Reports::FormAnswer
   end
 
   def press_contact_notes
-    @press_summary.try(:comment)
+    @press_summary.try(:body)
   end
 
   def customer_accepted_press_note

--- a/app/views/admin/press_summaries/_section.html.slim
+++ b/app/views/admin/press_summaries/_section.html.slim
@@ -20,6 +20,40 @@
         = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
         = f.submit "Save", class: "btn btn-primary form-save-link pull-right"
       .clear
+- if press_summary.reviewed_by_user
+  = simple_form_for press_summary, url: url, remote: true, authenticity_token: true do |f|
+    .form-group
+      label.form-label Contact details for press enquiries
+      .form-value.no-js-update
+        p data-for="press_summary_name"
+          = press_summary.name
+        p data-for="press_summary_phone_number"
+          = press_summary.phone_number
+        p data-for="press_summary_email"
+          = press_summary.email
+      .input.form-group.form-fields.form-block
+        = f.input :name,
+                  as: :string,
+                  label: "Name",
+                  input_html: { class: 'form-control' }
+        = f.input :phone_number,
+                  as: :string,
+                  label: "Telephone",
+                  input_html: { class: 'form-control' }
+        = f.input :email,
+                  as: :string,
+                  label: "Email",
+                  input_html: { class: 'form-control' }
+      .clear
+
+      - if policy(press_summary).update?
+        = link_to "#", class: "form-edit-link pull-right" do
+          span.glyphicon.glyphicon-pencil
+          ' Edit
+        .form-actions.text-right
+          = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
+          = f.submit "Save", class: "btn btn-primary form-save-link pull-right"
+        .clear
 
     - if press_summary.body.present?
       - if press_summary.reviewed_by_user
@@ -36,6 +70,7 @@
           br
           .alert.alert-success
             ' Applicant has confirmed the Press Book Notes
+
       - else
         p.p-empty Applicant hasn't confirmed the Press Book Notes
 


### PR DESCRIPTION
fixed press entry csv report: shows press release body instead of applicant comments

https://trello.com/c/475BJSD6/695-qae-support-admin-edit-pressbook-details