### PR TITLE
assessors are not able to unlock the feedback section after the unsuc…

### DIFF
--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -27,7 +27,7 @@ class FeedbackPolicy < ApplicationPolicy
 
   def unlock?
     if assessor?
-      subject.lead?(form_answer) && record.submitted? && record.locked?
+      subject.lead?(form_answer) && record.submitted? && record.locked? && Settings.unsuccessful_stage?
     else
       admin? && record.submitted? && record.locked?
     end

--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -27,7 +27,7 @@ class FeedbackPolicy < ApplicationPolicy
 
   def unlock?
     if assessor?
-      subject.lead?(form_answer) && record.submitted? && record.locked? && Settings.unsuccessful_stage?
+      subject.lead?(form_answer) && record.submitted? && record.locked? && !Settings.unsuccessful_stage?
     else
       admin? && record.submitted? && record.locked?
     end


### PR DESCRIPTION
…cessful email is sent


https://trello.com/c/mITzexFw/696-qae-support-once-unsuccessful-email-is-sent-out-assessors-should-not-be-able-to-unlock-the-feedback-section