### PR TITLE
do not allow unlocking press summary if on winners stage

### DIFF
--- a/app/policies/press_summary_policy.rb
+++ b/app/policies/press_summary_policy.rb
@@ -18,7 +18,7 @@ class PressSummaryPolicy < ApplicationPolicy
   end
 
   def unlock?
-    record.submitted? && subject.lead?(form_answer)
+    record.submitted? && subject.lead?(form_answer) && !Settings.winners_stage?
   end
 
   private


### PR DESCRIPTION
https://trello.com/c/GSA6Lb8h/697-qae-support-once-winners-email-is-sent-out-assessors-should-not-be-able-to-unlock-the-pressbook-section