### PR TITLE
[Press Summary] bunch of corrects and improvements

### DIFF
--- a/app/assets/stylesheets/frontend/views/dashboard.scss
+++ b/app/assets/stylesheets/frontend/views/dashboard.scss
@@ -325,3 +325,7 @@ $status-green: #3b816f;
 .submit-corp-declaration {
   margin-left: 10px;
 }
+
+.save-press-summary-button {
+  margin-right: 10px;
+}

--- a/app/controllers/users/press_summaries_controller.rb
+++ b/app/controllers/users/press_summaries_controller.rb
@@ -5,6 +5,8 @@ class Users::PressSummariesController < Users::BaseController
   before_action :check_promotion_award_acceptance,
                 except: [:acceptance, :update_acceptance, :success, :failure]
 
+  before_action :require_press_summary_to_be_not_submitted_by_user!, only: [:show, :update]
+
   expose(:form_answer) do
     FormAnswer.find(params[:form_answer_id])
   end
@@ -21,10 +23,16 @@ class Users::PressSummariesController < Users::BaseController
 
   def update
     @press_summary.reviewed_by_user = true
+    @press_summary.applicant_submitted = params[:submit].present?
 
     if @press_summary.update(press_summary_params)
-      flash.notice = "Press Book Notes successfully updated"
-      redirect_to action: :show, token: params[:token]
+      if @press_summary.applicant_submitted?
+        flash.notice = "Press Book Notes successfully submitted"
+        redirect_to dashboard_url
+      else
+        flash.notice = "Press Book Notes successfully updated"
+        redirect_to action: :show, token: params[:token]
+      end
     else
       render :show
     end
@@ -72,5 +80,13 @@ class Users::PressSummariesController < Users::BaseController
       exclude_ignored_questions: true,
       financial_summary_view: true
     ).data.detect { |r| r[:employees].present? }
+  end
+
+  def require_press_summary_to_be_not_submitted_by_user!
+    if @press_summary.applicant_submitted?
+      redirect_to dashboard_url,
+                  notice: "Press Summary already submitted!"
+      return
+    end
   end
 end

--- a/app/policies/press_summary_policy.rb
+++ b/app/policies/press_summary_policy.rb
@@ -21,6 +21,29 @@ class PressSummaryPolicy < ApplicationPolicy
     record.submitted? && subject.lead?(form_answer) && !Settings.winners_stage?
   end
 
+  def can_see_contact_details?
+    record.reviewed_by_user? || deadline_passed?
+  end
+
+  def can_update_contact_details?
+    (
+      !deadline_passed? &&
+      update?
+    ) ||
+    (
+      deadline_passed? &&
+      admin?
+    )
+  end
+
+  def deadline_passed?
+    Settings.current
+            .deadlines
+            .where(kind: "buckingham_palace_confirm_press_book_notes")
+            .first
+            .passed?
+  end
+
   private
 
   def form_answer

--- a/app/policies/press_summary_policy.rb
+++ b/app/policies/press_summary_policy.rb
@@ -26,14 +26,7 @@ class PressSummaryPolicy < ApplicationPolicy
   end
 
   def can_update_contact_details?
-    (
-      !deadline_passed? &&
-      update?
-    ) ||
-    (
-      deadline_passed? &&
-      admin?
-    )
+    ( !deadline_passed? && update? ) || admin?
   end
 
   def deadline_passed?

--- a/app/views/admin/press_summaries/_section.html.slim
+++ b/app/views/admin/press_summaries/_section.html.slim
@@ -1,5 +1,6 @@
 - press_summary = form_answer.press_summary || form_answer.build_press_summary
 - url = press_summary.persisted? ? polymorphic_url([namespace_name, form_answer, press_summary]) : polymorphic_url([namespace_name, form_answer, :press_summaries])
+
 = simple_form_for press_summary, url: url, remote: true, authenticity_token: true do |f|
   .form-group
     label.form-label Body
@@ -20,7 +21,8 @@
         = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
         = f.submit "Save", class: "btn btn-primary form-save-link pull-right"
       .clear
-- if press_summary.reviewed_by_user
+
+- if policy(press_summary).can_see_contact_details?
   = simple_form_for press_summary, url: url, remote: true, authenticity_token: true do |f|
     .form-group
       label.form-label Contact details for press enquiries
@@ -31,22 +33,23 @@
           = press_summary.phone_number
         p data-for="press_summary_email"
           = press_summary.email
-      .input.form-group.form-fields.form-block
-        = f.input :name,
-                  as: :string,
-                  label: "Name",
-                  input_html: { class: 'form-control' }
-        = f.input :phone_number,
-                  as: :string,
-                  label: "Telephone",
-                  input_html: { class: 'form-control' }
-        = f.input :email,
-                  as: :string,
-                  label: "Email",
-                  input_html: { class: 'form-control' }
-      .clear
 
-      - if policy(press_summary).update?
+      - if policy(press_summary).can_update_contact_details?
+        .input.form-group.form-fields.form-block
+          = f.input :name,
+                    as: :string,
+                    label: "Name",
+                    input_html: { class: 'form-control' }
+          = f.input :phone_number,
+                    as: :string,
+                    label: "Telephone",
+                    input_html: { class: 'form-control' }
+          = f.input :email,
+                    as: :string,
+                    label: "Email",
+                    input_html: { class: 'form-control' }
+        .clear
+
         = link_to "#", class: "form-edit-link pull-right" do
           span.glyphicon.glyphicon-pencil
           ' Edit
@@ -56,23 +59,22 @@
         .clear
 
     - if press_summary.body.present?
-      - if press_summary.reviewed_by_user
-        - if press_summary.correct
-          .form-group
-            label.form-label
-              ' Comments by Applicant
-            p
-              - if press_summary.comment.present?
-                = press_summary.comment
-              - else
-                ' No comment by applicant
-        - else
-          br
-          .alert.alert-success
-            ' Applicant has confirmed the Press Book Notes
+      - if press_summary.correct
+        .form-group
+          label.form-label
+            ' Comments by Applicant
+          p
+            - if press_summary.comment.present?
+              = press_summary.comment
+            - else
+              ' No comment by applicant
 
-      - else
-        p.p-empty Applicant hasn't confirmed the Press Book Notes
+    - if press_summary.applicant_submitted?
+      .alert.alert-success
+        ' Applicant has confirmed the Press Book Notes
+    - else
+      p.p-empty
+        | Applicant hasn't confirmed the Press Book Notes
 
 - if press_summary.submitted?
   - if policy(press_summary).unlock?

--- a/app/views/content_only/post_submission/_winners.html.slim
+++ b/app/views/content_only/post_submission/_winners.html.slim
@@ -1,14 +1,21 @@
-- winners = FormAnswerDecorator.decorate_collection(award_applications).select{ |app| app.awarded? }
+- winners = FormAnswerDecorator.decorate_collection(award_applications).select{ |app| app.awarded? && !app.promotion? }
 - if winners.present?
   .container-split
     .content-left
       h2 Successful
     .content-right.content-offset-36
-      p Congratulations on winning a Queen's Award for Enterprise
       p
-        ' We know you'll be keen to share your success. However, please remember there is a strict embargo preventing public announcement or publication of any Awards information until
-        = deadline_for("buckingham_palace_attendees_details", "%H.%M on %A %d %B %Y")
-        ' . You must not make any announcements about your Award, either to employees or outside your organisation, before this date.
+        strong
+          ' Congratulations on winning a Queen's Award for Enterprise
+      p
+        ' We know you'll be keen to share your success. However, please remember there is a
+        strong
+          ' strict embargo
+        preventing public announcement or publication of any Awards information
+        strong
+          '  until
+          = deadline_for("buckingham_palace_attendees_details", "%H.%M on %A %d %B %Y")
+          ' . You must not make any announcements about your Award, either to employees or outside your organisation, before this date.
       p
         strong Approve your Press Book entry
       p
@@ -37,16 +44,19 @@
           - if award.press_summary.present? && award.press_summary.body.present?
             ul.post-dashboard-actions
               li
-                = link_to "Press Book Notes", users_form_answer_press_summary_url(award, token: award.press_summary.token)
+                - if award.press_summary.applicant_submitted?
+                  ' Press Book Notes
+                - else
+                  = link_to "Press Book Notes", users_form_answer_press_summary_url(award, token: award.press_summary.token)
                 span.award-info
                   span.pull-right
                     ' Due by
                     = application_deadline_short(:buckingham_palace_confirm_press_book_notes)
-                  = link_to users_form_answer_press_summary_url(award, token: award.press_summary.token)
-                    - if award.press_summary.reviewed_by_user
-                      span.label-status.label-status-green
-                        ' Complete
-                    - else
+                  - if award.press_summary.applicant_submitted?
+                    span.label-status.label-status-green
+                      ' Complete
+                  - else
+                    = link_to users_form_answer_press_summary_url(award, token: award.press_summary.token)
                       span.label-status.label-status-red
                         ' Incomplete
             .clear

--- a/app/views/users/press_summaries/award_summary/_organisation_head.html.slim
+++ b/app/views/users/press_summaries/award_summary/_organisation_head.html.slim
@@ -5,6 +5,8 @@ p
     = award.head_of_bussines_title
     '
   = award.head_of_business_full_name
-
+  - if award.head_of_business_honours.present?
+    '
+    = award.head_of_business_honours
   br
   = award.head_job_title

--- a/app/views/users/press_summaries/failure.html.slim
+++ b/app/views/users/press_summaries/failure.html.slim
@@ -1,4 +1,4 @@
 div
   header.group.page-header.page-header-wider
     div
-      h1 Sorry, you can not amend Press Book Notes comments anymore
+      h1 Sorry, you cannot amend Press Book Notes comments anymore

--- a/app/views/users/press_summaries/show.html.slim
+++ b/app/views/users/press_summaries/show.html.slim
@@ -61,4 +61,8 @@ div
                   = link_to dashboard_path
                     span.pagination-label Back
                 li.submit
-                  = f.submit "Submit", class: "button", rel: "next"
+                  = f.submit "Save", class: "button save-press-summary-button",
+                                     name: "save"
+                  = f.submit "Submit", class: "button",
+                                       rel: "next",
+                                       name: "submit"

--- a/db/migrate/20160310140650_add_applicant_submitted_to_press_summaries.rb
+++ b/db/migrate/20160310140650_add_applicant_submitted_to_press_summaries.rb
@@ -1,0 +1,5 @@
+class AddApplicantSubmittedToPressSummaries < ActiveRecord::Migration
+  def change
+    add_column :press_summaries, :applicant_submitted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160224174712) do
+ActiveRecord::Schema.define(version: 20160310140650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -307,21 +307,22 @@ ActiveRecord::Schema.define(version: 20160224174712) do
   add_index "palace_invites", ["form_answer_id"], name: "index_palace_invites_on_form_answer_id", using: :btree
 
   create_table "press_summaries", force: :cascade do |t|
-    t.integer  "form_answer_id",                   null: false
+    t.integer  "form_answer_id",                      null: false
     t.text     "body"
     t.text     "comment"
-    t.boolean  "approved",         default: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.boolean  "approved",            default: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.string   "name"
     t.string   "email"
     t.string   "phone_number"
     t.boolean  "correct"
-    t.boolean  "reviewed_by_user", default: false
+    t.boolean  "reviewed_by_user",    default: false
     t.string   "token"
     t.string   "authorable_type"
     t.integer  "authorable_id"
-    t.boolean  "submitted",        default: false
+    t.boolean  "submitted",           default: false
+    t.boolean  "applicant_submitted", default: false
   end
 
   add_index "press_summaries", ["form_answer_id"], name: "index_press_summaries_on_form_answer_id", using: :btree

--- a/spec/features/users/form_answers/press_summary_spec.rb
+++ b/spec/features/users/form_answers/press_summary_spec.rb
@@ -32,7 +32,7 @@ describe "Press Summary" do
 
       visit users_form_answer_press_summary_url(form_answer, token: press_summary.token)
 
-      expect(page).to have_content("Sorry, you can not amend Press Book Notes comments anymore")
+      expect(page).to have_content("Sorry, you cannot amend Press Book Notes comments anymore")
     end
   end
 

--- a/spec/features/users/form_answers/press_summary_spec.rb
+++ b/spec/features/users/form_answers/press_summary_spec.rb
@@ -21,9 +21,10 @@ describe "Press Summary" do
       fill_in "Email", with: "jon@example.com"
       fill_in "Telephone", with: "1234567"
 
-      click_button "Submit"
+      click_button "Save"
 
       expect(page).to have_content("Press Book Notes successfully updated")
+      expect(press_summary.reload.applicant_submitted).to be_falsey
     end
 
     it "should not allow to fill the form after the deadline" do
@@ -54,9 +55,10 @@ describe "Press Summary" do
       fill_in "Email", with: "jon@example.com"
       fill_in "Telephone", with: "1234567"
 
-      click_button "Submit"
+      click_button "Save"
 
       expect(page).to have_content("Press Book Notes successfully updated")
+      expect(press_summary.reload.applicant_submitted).to be_falsey
     end
 
     it "redirects to home page without acceptance" do


### PR DESCRIPTION
[Trello Story](https://trello.com/c/P1xMEUpm/289-qae-support-successful-business-winners-press-book-entry-screens)

1. Top line i.e. ‘Congratulations on winning a Queen's Award for Enterprise’ – to be bolded (see screen shot 1)

2. Also in the first paragraph underneath that the words: "strict embargo" and also "until 00.01 on Thursday 21 April 2016.
   You must not make any announcements about your Award,
   either to employees or outside your organisation, before this date." are to be bolded

3. With the ‘Head of organisation’ details if the person has a personal “Honour”
   it is not being picked up and displayed in the users view (see screen shot 2 & example test case QA0030/16T)

4. I mentioned before on this card (8 March) that we need a "Save" button
   (see attached screen shot) as otherwise the applicant needs to enter their data all in one go.
  Can we perhaps have it next to the "Submit" button (see screen shot 3)

5. Once an applicant has submitted their Press entry details for a particular case,
   although the button turns to say “COMPLETE”(see screen shot 5) we have found that
   they can still do further changes /edits and re-submit. This is not to be allowed.
   Once they have submitted for that particular entry it should lock, otherwise this will casue problems at our end.

6. In the instances whereby the applicant does not respond to the exercise by the deadline,
   then the system, although allowing them to view the details should not alow them to respond, i.e. the system locks to them.

7. For those who do not respond by the “Press Book Entry confirmation due” deadline,
   QA admins need to have the 3 boxes for the Press contact details (all be it blank)
   in the assessment site of the entry so that we can manually populate it and then submit. (see scren shot 4 but as I say the boxes would be blank)

8. Users view should not display any QAEP successful or unsuccesssful entries
   (see screen shot 5) that the account holder may have