### PR TITLE
winners stage should be checked on application’s award year

### DIFF
--- a/app/models/email_notification.rb
+++ b/app/models/email_notification.rb
@@ -25,6 +25,10 @@ class EmailNotification < ActiveRecord::Base
 
   scope :current, -> { where("trigger_at < ?", Time.now.utc).where("sent = 'f' OR sent IS NULL") }
 
+  def passed?
+    trigger_at && trigger_at < Time.zone.now
+  end
+
   def self.not_shortlisted
     where(kind: "not_shortlisted_notifier")
   end

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -37,7 +37,7 @@ class Settings < ActiveRecord::Base
 
   def self.winners_stage?
     deadline = Rails.cache.fetch("winners_notification_notification", expires_in: 1.minute) do
-      current.email_notifications.where(kind: "winners_notification").first
+      current.winners_email_notification
     end
 
     DateTime.now >= deadline.trigger_at if deadline.present?
@@ -61,6 +61,10 @@ class Settings < ActiveRecord::Base
     Rails.cache.fetch("unsuccessful_notification_notification", expires_in: 1.minute) do
       current.email_notifications.not_awarded.first.try(:trigger_at)
     end
+  end
+
+  def winners_email_notification
+    email_notifications.where(kind: "winners_notification").first
   end
 
   private

--- a/app/policies/press_summary_policy.rb
+++ b/app/policies/press_summary_policy.rb
@@ -18,11 +18,11 @@ class PressSummaryPolicy < ApplicationPolicy
   end
 
   def unlock?
-    record.submitted? && subject.lead?(form_answer) && !Settings.winners_stage?
+    record.submitted? && subject.lead?(form_answer) && !on_winners_stage?
   end
 
   def admin_signoff?
-    record.applicant_submitted? && admin? && !Settings.winners_stage?
+    record.applicant_submitted? && admin? && !on_winners_stage?
   end
 
   def can_see_contact_details?
@@ -34,10 +34,8 @@ class PressSummaryPolicy < ApplicationPolicy
   end
 
   def deadline_passed?
-    Settings.current
-            .deadlines
-            .where(kind: "buckingham_palace_confirm_press_book_notes")
-            .first
+    settings.deadlines
+            .buckingham_palace_confirm_press_book_notes
             .passed?
   end
 
@@ -45,5 +43,19 @@ class PressSummaryPolicy < ApplicationPolicy
 
   def form_answer
     record.form_answer
+  end
+
+  def on_winners_stage?
+    @winners_email ||= settings.winners_email_notification
+    @winners_email && @winners_email.passed?
+  end
+
+  def settings
+    if form_answer && form_answer.award_year
+      form_answer.award_year.settings
+    else
+      # new records
+      Settings.current
+    end
   end
 end


### PR DESCRIPTION
enhances c783932e0b48a5be597473bbcbf89d5fce9f64b9 & https://github.com/bitzesty/qae/commit/edb09404d76499118ee6e41f63577019bafce535#diff-5fdf07224e4a24d02dd78a293651a53dR25
where we queried *current* award years’ settings to see if we already past deadline.

we now query the application’s award year deadline for winners stage.