### PR TITLE
[Awards Emblems] fixes

### DIFF
--- a/app/views/content_only/award_winners_section/2016.html.slim
+++ b/app/views/content_only/award_winners_section/2016.html.slim
@@ -16,7 +16,7 @@ div
 
         br
 
-        h2 Download the The Queen's Awards for Enterprise Winners' Manual 2015
+        h2 Download the The Queen's Awards for Enterprise Winners' Manual 2016
 
         .form-download
           p
@@ -30,109 +30,109 @@ div
         - if any_promotion_winner
           .form-download
             p
-              = link_to "Queen's Award for Enterprise 2016 Emblem (EPS, 656KB)",
+              = link_to "Queen's Awards for Enterprise 2016 Emblem (EPS, 656KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise 2016 Emblem.eps"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise 2016 Emblem (JPG, 519KB)",
+              = link_to "Queen's Awards for Enterprise 2016 Emblem (JPG, 519KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise 2016 Emblem.jpg"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise 2016 Emblem - black on white (EPS, 641KB)",
+              = link_to "Queen's Awards for Enterprise 2016 Emblem - black on white (EPS, 641KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise 2016 Emblem - black on white.eps"),
                         class: "thumbnail",
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise 2016 Emblem - black on white (JPG, 266KB)",
+              = link_to "Queen's Awards for Enterprise 2016 Emblem - black on white (JPG, 266KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise 2016 Emblem - black on white.jpg"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise Promotion 2016 Emblem - white on black (JPG, 834KB)",
+              = link_to "Queen's Awards for Enterprise 2016 Emblem - white on black (JPG, 834KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise 2016 Emblem - white on black.jpg"),
                         target: "_blank"
 
         - if any_innovation_winner
           .form-download
             p
-              = link_to "Queen's Award for Enterprise: Innovation 2016 Emblem (EPS, 686KB)",
+              = link_to "Queen's Awards for Enterprise: Innovation 2016 Emblem (EPS, 686KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Innovation 2016 Emblem.eps"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: Innovation 2016 Emblem (JPG, 555KB)",
+              = link_to "Queen's Awards for Enterprise: Innovation 2016 Emblem (JPG, 555KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Innovation 2016 Emblem.jpg"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: Innovation 2016 Emblem - black on white (EPS, 683KB)",
+              = link_to "Queen's Awards for Enterprise: Innovation 2016 Emblem - black on white (EPS, 683KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Innovation 2016 Emblem - black on white.eps"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: Innovation 2016 Emblem - black on white (JPG, 283KB)",
+              = link_to "Queen's Awards for Enterprise: Innovation 2016 Emblem - black on white (JPG, 283KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Innovation 2016 Emblem - black on white.jpg"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: Innovation 2016 Emblem - white on black (JPG, 889KB)",
+              = link_to "Queen's Awards for Enterprise: Innovation 2016 Emblem - white on black (JPG, 889KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Innovation 2016 Emblem - white on black.jpg"),
                         target: "_blank"
 
         - if any_trade_winner
           .form-download
             p
-              = link_to "Queen's Award for Enterprise: International Trade 2016 Emblem (EPS, 698KB)",
+              = link_to "Queen's Awards for Enterprise: International Trade 2016 Emblem (EPS, 698KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise International Trade 2016 Emblem.eps"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: International Trade 2016 Emblem (JPG, 574KB)",
+              = link_to "Queen's Awards for Enterprise: International Trade 2016 Emblem (JPG, 574KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise International Trade 2016 Emblem.jpg"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: International Trade 2016 Emblem - black on white (EPS, 693KB)",
+              = link_to "Queen's Awards for Enterprise: International Trade 2016 Emblem - black on white (EPS, 693KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise International Trade 2016 Emblem - black on white.eps"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: International Trade 2016 Emblem - black on white (JPG, 291KB)",
+              = link_to "Queen's Awards for Enterprise: International Trade 2016 Emblem - black on white (JPG, 291KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise International Trade 2016 Emblem - black on white.jpg"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: International Trade 2016 Emblem - white on black (JPG, 327KB)",
+              = link_to "Queen's Awards for Enterprise: International Trade 2016 Emblem - white on black (JPG, 327KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise International Trade 2016 Emblem - white on black.jpg"),
                         target: "_blank"
 
         - if any_development_winner
           .form-download
             p
-              = link_to "Queen's Award for Enterprise: Sustainable Development 2016 Emblem (EPS, 754KB)",
+              = link_to "Queen's Awards for Enterprise: Sustainable Development 2016 Emblem (EPS, 754KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Sustainable Development 2016 Emblem.eps"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: Sustainable Development 2016 Emblem (JPG, 601KB)",
+              = link_to "Queen's Awards for Enterprise: Sustainable Development 2016 Emblem (JPG, 601KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Sustainable Development 2016 Emblem.jpg"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: Sustainable Development 2016 Emblem - black on white (EPS, 749KB)",
+              = link_to "Queen's Awards for Enterprise: Sustainable Development 2016 Emblem - black on white (EPS, 749KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Sustainable Development 2016 Emblem - black on white.eps"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: Sustainable Development 2016 Emblem - black on white (JPG, 307KB)",
-                        asset_path("winners assets 2016/Queen's Award for Enterprise Sustainable Development 2016 Emblem - black on white.jpg"),
+              = link_to "Queen's Awards for Enterprise: Sustainable Development 2016 Emblem - black on white (JPG, 307KB)",
+                        asset_path("winners assets 2016/Queen's Award for Enterprise Sustainable Development 2016 Emblem- black on white.jpg"),
                         target: "_blank"
 
             p
-              = link_to "Queen's Award for Enterprise: Sustainable Development 2016 Emblem - white on black (JPG, 951KB)",
+              = link_to "Queen's Awards for Enterprise: Sustainable Development 2016 Emblem - white on black (JPG, 951KB)",
                         asset_path("winners assets 2016/Queen's Award for Enterprise Sustainable Development 2016 Emblem - white on black.jpg"),
                         target: "_blank"
 


### PR DESCRIPTION
In screen shot 1 in the circled text please change the year to 2016

In screen shot 2 in the circled text please delete the word "Promotion"

In screen shot 3 - when I click on the link in the circled text it brings up a message "Page not found If you entered a web address please check it was correct You can also search GOV.UK or browse from the homepage to find the information you need.". It only seems top happen wihtn this one

General point that with the all the emblem links title, the word "Award" should be plural

[Trello Story](https://trello.com/c/wRr20lHw/282-qae-support-update-winners-sections-with-new-emblems-manual)