### PR TITLE
Unsuccesfull mailer tweaks

### DIFF
--- a/app/controllers/content_only_controller.rb
+++ b/app/controllers/content_only_controller.rb
@@ -51,6 +51,8 @@ class ContentOnlyController < ApplicationController
     @user_award_forms_promotion = forms["promotion"]
 
     @user_award_forms_submitted = @user_award_forms.where(submitted: true)
+
+    set_unsuccessful_business_applications if Settings.unsuccessful_stage?
   end
 
   def award_winners_section
@@ -90,4 +92,9 @@ class ContentOnlyController < ApplicationController
     end
   end
   helper_method :deadline_for
+
+  def set_unsuccessful_business_applications
+    @unsuccessful_business_applications = @user_award_forms.business
+                                                           .unsuccessful_applications
+  end
 end

--- a/app/search/form_answer_search.rb
+++ b/app/search/form_answer_search.rb
@@ -74,7 +74,7 @@ class FormAnswerSearch < Search
       when "missing_feedback"
         out = out.joins(
           "LEFT OUTER JOIN feedbacks on feedbacks.form_answer_id=form_answers.id"
-        ).where("feedbacks.approved = false OR feedbacks.id IS NULL")
+        ).where("feedbacks.submitted = false OR feedbacks.id IS NULL")
       when "missing_press_summary"
         out = out.joins(
           "LEFT OUTER JOIN press_summaries on press_summaries.form_answer_id = form_answers.id"

--- a/app/views/content_only/_submitted_applications.html.slim
+++ b/app/views/content_only/_submitted_applications.html.slim
@@ -4,8 +4,12 @@
 - else
   - if Settings.winners_stage?
     = render("content_only/post_submission/winners", award_applications: award_applications)
+
+    - if Settings.unsuccessful_stage?
+      = render("content_only/post_submission/unsuccessful", award_applications: @unsuccessful_business_applications)
+
   - elsif Settings.after_shortlisting_stage?
     = render("content_only/post_submission/shortlisted", award_applications: award_applications)
-    = render("content_only/post_submission/unsuccessful", award_applications: @user_award_forms.where(state: [:not_recommended, :not_awarded]))
+    = render("content_only/post_submission/unsuccessful", award_applications: @user_award_forms.not_shortlisted)
   - else
     = render("content_only/post_submission/submitted", award_applications: award_applications)

--- a/app/views/content_only/post_submission/_unsuccessful.html.slim
+++ b/app/views/content_only/post_submission/_unsuccessful.html.slim
@@ -28,7 +28,7 @@
           p The application was not submitted on time.
         - else
           h4 Feedback
-          - if award.feedback.try(:approved?)
+          - if award.feedback.try(:submitted?)
             p
               ' Please
               = link_to "download and read the feedback document", users_form_answer_feedback_path(award, format: :pdf)

--- a/db/migrate/20160323103504_remove_approved_from_feedbacks.rb
+++ b/db/migrate/20160323103504_remove_approved_from_feedbacks.rb
@@ -1,0 +1,5 @@
+class RemoveApprovedFromFeedbacks < ActiveRecord::Migration
+  def change
+    remove_column :feedbacks, :approved
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160314141838) do
+ActiveRecord::Schema.define(version: 20160323103504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -193,7 +193,6 @@ ActiveRecord::Schema.define(version: 20160314141838) do
   create_table "feedbacks", force: :cascade do |t|
     t.integer  "form_answer_id"
     t.boolean  "submitted",       default: false
-    t.boolean  "approved",        default: false
     t.hstore   "document"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -2,6 +2,5 @@ FactoryGirl.define do
   factory :feedback do
     association :form_answer
     submitted false
-    approved false
   end
 end

--- a/spec/features/users/post_submission_dashboard_spec.rb
+++ b/spec/features/users/post_submission_dashboard_spec.rb
@@ -28,19 +28,6 @@ describe  "User sees the post submission dashboard" do
       )
       visit dashboard_path
 
-      #expect(page).to have_content("Congratulations! Your application was shortlisted.")
-      #expect(page).to have_content("Declaration of Corporate Responsibility")
-      form_answer.update_column(:state, "not_awarded")
-      visit dashboard_path
-
-      settings.email_notifications.create!(
-        kind: "unsuccessful_notification",
-        trigger_at: DateTime.now - 1.year
-      )
-
-      visit dashboard_path
-      expect(page).to have_content("Your following application was unsuccessful.")
-
       form_answer.update_column(:state, "awarded")
       visit dashboard_path
       expect_to_have_blank_dashboard
@@ -58,6 +45,17 @@ describe  "User sees the post submission dashboard" do
 
       visit dashboard_path
       expect(page).to have_link("Press Book Notes")
+
+      form_answer.update_column(:state, "not_awarded")
+      visit dashboard_path
+
+      settings.email_notifications.create!(
+        kind: "unsuccessful_notification",
+        trigger_at: DateTime.now - 1.year
+      )
+
+      visit dashboard_path
+      expect(page).to have_content("Your following application was unsuccessful.")
     end
   end
 end

--- a/spec/support/form_answer_filtering_test_helper.rb
+++ b/spec/support/form_answer_filtering_test_helper.rb
@@ -35,9 +35,9 @@ module FormAnswerFilteringTestHelper
     end
   end
 
-  def assign_dummy_feedback(form_answers, approved = true)
+  def assign_dummy_feedback(form_answers, submitted = true)
     Array(form_answers).each do |fa|
-      feedback = fa.build_feedback(approved: approved)
+      feedback = fa.build_feedback(submitted: submitted)
       feedback.save(validate: false)
     end
   end


### PR DESCRIPTION
1. Applicant View - Dashboard corrects 

In instances where companies did 2 or more applications and one was successful and one wasn't,
the "Successful" applications should appear at the top as they do now, and the "Unsuccesful" below.

"Unsuccessful" applications should only show once we send out the Unsuccessful email.

2. Feedbacks functionality - replace 'approved' with 'submitted'

[Trello Story](https://trello.com/c/TZn8wVCJ/292-qae-support-email-to-unsuccessful-business-categories-registered-account-holder)