### PR TITLE
[PDF generators] pull proper award year

### DIFF
--- a/app/form_pointers/form_financial_pointer.rb
+++ b/app/form_pointers/form_financial_pointer.rb
@@ -36,7 +36,7 @@ class FormFinancialPointer
     @options = options
     @answers = fetch_answers
     @award_form = form_answer.award_form.decorate(answers: answers)
-    @form_answer_award_year = options[:award_year] if options[:award_year].present?
+    @form_answer_award_year = form_answer.award_year.year
 
     @steps = award_form.steps
     @financial_step = steps.third

--- a/app/pdf_generators/case_summary_pdfs/base.rb
+++ b/app/pdf_generators/case_summary_pdfs/base.rb
@@ -24,7 +24,6 @@ class CaseSummaryPdfs::Base < ReportPdfBase
   end
 
   def all_mode
-    award_year = current_year.year
     set_form_answers
 
     if form_answers.present?
@@ -48,10 +47,10 @@ class CaseSummaryPdfs::Base < ReportPdfBase
                               .where("assessor_assignments.submitted_at IS NOT NULL AND assessor_assignments.position IN (3,4)")
                               .order("form_answers.award_year_id, form_answers.sic_code")
                               .group("form_answers.id")
-                              .where("form_answers.award_year_id =?", current_year.id)
+                              .where("form_answers.award_year_id =?", award_year.id)
   end
 
-  def render_item(form_answer, award_year=nil)
-    CaseSummaryPdfs::Pointer.new(self, form_answer, award_year)
+  def render_item(form_answer)
+    CaseSummaryPdfs::Pointer.new(self, form_answer)
   end
 end

--- a/app/pdf_generators/case_summary_pdfs/base.rb
+++ b/app/pdf_generators/case_summary_pdfs/base.rb
@@ -29,7 +29,7 @@ class CaseSummaryPdfs::Base < ReportPdfBase
     if form_answers.present?
       form_answers.each_with_index do |form_answer, index|
         start_new_page if index.to_i != 0
-        render_item(form_answer, award_year)
+        render_item(form_answer)
       end
     else
       @missing_data_name = "case summaries"

--- a/app/pdf_generators/case_summary_pdfs/pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/pointer.rb
@@ -19,6 +19,7 @@ class CaseSummaryPdfs::Pointer < ReportPdfFormAnswerPointerBase
 
   def initialize(pdf_doc, form_answer)
     @pdf_doc = pdf_doc
+    @award_year = pdf_doc.award_year
     @form_answer = form_answer
     @answers = fetch_answers
     @award_form = form_answer.award_form.decorate(answers: answers)

--- a/app/pdf_generators/case_summary_pdfs/pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/pointer.rb
@@ -17,8 +17,7 @@ class CaseSummaryPdfs::Pointer < ReportPdfFormAnswerPointerBase
               :overall_growth,
               :overall_growth_in_percents
 
-  def initialize(pdf_doc, form_answer, award_year=nil)
-    @award_year = award_year
+  def initialize(pdf_doc, form_answer)
     @pdf_doc = pdf_doc
     @form_answer = form_answer
     @answers = fetch_answers

--- a/app/pdf_generators/feedback_pdfs/base.rb
+++ b/app/pdf_generators/feedback_pdfs/base.rb
@@ -20,11 +20,11 @@ class FeedbackPdfs::Base < ReportPdfBase
                          .includes(:form_answer)
                          .joins(form_answer: :award_year)
                          .where("form_answers.award_type = ?", options[:category])
-                         .where("form_answers.award_year_id = ?", current_year.id)
+                         .where("form_answers.award_year_id = ?", award_year.id)
 
   end
 
   def render_item(form_answer)
-    FeedbackPdfs::Pointer.new(self, form_answer, options)
+    FeedbackPdfs::Pointer.new(self, form_answer)
   end
 end

--- a/app/pdf_generators/report_pdf_base.rb
+++ b/app/pdf_generators/report_pdf_base.rb
@@ -7,7 +7,8 @@ class ReportPdfBase < Prawn::Document
               :form_answer,
               :options,
               :pdf_doc,
-              :missing_data_name
+              :missing_data_name,
+              :award_year
 
   def initialize(mode, form_answer=nil, options={})
     super(page_size: "A4", page_layout: :landscape)
@@ -17,7 +18,11 @@ class ReportPdfBase < Prawn::Document
     @form_answer = form_answer
     @options = options
 
-    options[:award_year] = form_answer.award_year if mode == "singular"
+    @award_year = if mode == "singular"
+      form_answer.award_year
+    else
+      options[:award_year]
+    end
 
     generate!
   end

--- a/app/pdf_generators/report_pdf_form_answer_pointer_base.rb
+++ b/app/pdf_generators/report_pdf_form_answer_pointer_base.rb
@@ -15,17 +15,17 @@ class ReportPdfFormAnswerPointerBase
               :filled_answers,
               :data,
               :pdf_doc,
-              :options
+              :award_year
 
-  def initialize(pdf_doc, form_answer, options={})
+  def initialize(pdf_doc, form_answer)
     @pdf_doc = pdf_doc
+    @award_year = pdf_doc.award_year
     @form_answer = form_answer
     @user = form_answer.user
     @answers = fetch_answers
     @award_form = form_answer.award_form.decorate(answers: answers)
     @all_questions = award_form.steps.map(&:questions).flatten
     @filled_answers = fetch_filled_answers
-    @options = options
 
     generate!
   end

--- a/app/pdf_generators/shared_pdf_helpers/draw_elements.rb
+++ b/app/pdf_generators/shared_pdf_helpers/draw_elements.rb
@@ -31,7 +31,7 @@ module SharedPdfHelpers::DrawElements
   end
 
   def render_award_general_information(x_coord, y_coord)
-    pdf_doc.text_box "#{AWARD_GENERAL_INFO_PREFIX} #{current_year.year}",
+    pdf_doc.text_box "#{AWARD_GENERAL_INFO_PREFIX} #{award_year.year}",
                      header_text_properties.merge(at: [x_coord.mm, y_coord.mm + DEFAULT_OFFSET])
   end
 
@@ -61,7 +61,7 @@ module SharedPdfHelpers::DrawElements
   end
 
   def render_not_found_general_information
-    pdf_doc.text_box "#{AWARD_GENERAL_INFO_PREFIX} #{current_year.year}",
+    pdf_doc.text_box "#{AWARD_GENERAL_INFO_PREFIX} #{award_year.year}",
                      header_text_properties.merge(at: [130.mm, 137.mm + DEFAULT_OFFSET])
   end
 
@@ -87,10 +87,5 @@ module SharedPdfHelpers::DrawElements
       valign: :top,
       style: :bold
     }
-  end
-
-  def current_year
-    y = options[:award_year] if defined?(options) && options[:award_year].present?
-    y || AwardYear.current
   end
 end

--- a/spec/unit/pdf_generators/case_summary_pdfs/base_spec.rb
+++ b/spec/unit/pdf_generators/case_summary_pdfs/base_spec.rb
@@ -1,12 +1,16 @@
 require 'rails_helper'
 
 describe "CaseSummaryPdfs::Base" do
+  let!(:award_year) do
+    create :award_year
+  end
+
   let!(:form_answer_current_year_innovation) do
-    FactoryGirl.create :form_answer, :recommended, :innovation
+    FactoryGirl.create :form_answer, :recommended, :innovation, award_year: award_year
   end
 
   let!(:form_answer_current_year_trade) do
-    FactoryGirl.create :form_answer, :recommended, :trade
+    FactoryGirl.create :form_answer, :recommended, :trade, award_year: award_year
   end
 
   before do
@@ -24,17 +28,25 @@ describe "CaseSummaryPdfs::Base" do
 
   describe "#set_form_answers" do
     it "should be ordered in year and filtered by category" do
-      innovation_case_summaries = CaseSummaryPdfs::Base.new("all", nil, {category: "innovation"})
-                                                  .set_form_answers
-                                                  .map(&:id)
+      innovation_case_summaries = CaseSummaryPdfs::Base.new(
+        "all", nil, {
+          category: "innovation",
+          award_year: award_year
+        }
+      ).set_form_answers
+       .map(&:id)
 
       expect(innovation_case_summaries).to match_array([
         form_answer_current_year_innovation.id,
       ])
 
-      trade_case_summaries = CaseSummaryPdfs::Base.new("all", nil, {category: "trade"})
-                                                  .set_form_answers
-                                                  .map(&:id)
+      trade_case_summaries = CaseSummaryPdfs::Base.new(
+        "all", nil, {
+          category: "trade",
+          award_year: award_year
+        }
+      ).set_form_answers
+       .map(&:id)
 
       expect(trade_case_summaries).to match_array([
         form_answer_current_year_trade.id,

--- a/spec/unit/pdf_generators/feedback_pdfs/base_spec.rb
+++ b/spec/unit/pdf_generators/feedback_pdfs/base_spec.rb
@@ -1,12 +1,16 @@
 require 'rails_helper'
 
 describe "FeedbackPdfs::Base" do
+  let!(:award_year) do
+    create :award_year
+  end
+
   let!(:form_answer_innovation) do
-    FactoryGirl.create :form_answer, :submitted, :innovation
+    FactoryGirl.create :form_answer, :submitted, :innovation, award_year: award_year
   end
 
   let!(:form_answer_trade) do
-    FactoryGirl.create :form_answer, :submitted, :trade
+    FactoryGirl.create :form_answer, :submitted, :trade, award_year: award_year
   end
 
   before do
@@ -21,16 +25,25 @@ describe "FeedbackPdfs::Base" do
 
   describe "#set_feedbacks" do
     it "should be ordered in year and filtered by category" do
-      innovation_feedbacks = FeedbackPdfs::Base.new("all", nil, {category: "innovation"})
-                                               .set_feedbacks
-                                               .map(&:id)
+      innovation_feedbacks = FeedbackPdfs::Base.new(
+        "all", nil, {
+          category: "innovation",
+          award_year: award_year
+        }
+      ).set_feedbacks
+       .map(&:id)
+
       expect(innovation_feedbacks).to match_array([
         form_answer_innovation.feedback.id,
       ])
 
-      trade_feedbacks = FeedbackPdfs::Base.new("all", nil, {category: "trade"})
-                                          .set_feedbacks
-                                          .map(&:id)
+      trade_feedbacks = FeedbackPdfs::Base.new(
+        "all", nil, {
+          category: "trade",
+          award_year: award_year
+        }
+      ).set_feedbacks
+       .map(&:id)
 
       expect(trade_feedbacks).to match_array([
         form_answer_trade.feedback.id,


### PR DESCRIPTION
Fixed PDF generators to pull proper award year

[Trello Story](https://trello.com/c/M6jL0w5Q/315-qae-support-when-the-next-year-starts-users-should-still-be-able-to-see-their-older-applications)