### PR TITLE
[Admin Settings] add new notifier about submission started

### DIFF
--- a/app/mailers/users/submission_started_notification_mailer.rb
+++ b/app/mailers/users/submission_started_notification_mailer.rb
@@ -1,0 +1,8 @@
+class Users::SubmissionStartedNotificationMailer < ApplicationMailer
+  def notify(user_id)
+    @user = User.find(user_id)
+
+    mail to: @user.email,
+         subject: "Queen's Awards for Enterprise Reminder: applications for the new Award year are open"
+  end
+end

--- a/app/models/email_notification.rb
+++ b/app/models/email_notification.rb
@@ -7,6 +7,7 @@ class EmailNotification < ActiveRecord::Base
   belongs_to :settings
 
   enumerize :kind, in: [
+                         :submission_started_notification,
                          :reminder_to_submit,
                          :ep_reminder_support_letters,
                          :winners_notification,

--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -9,6 +9,14 @@ class MailRenderer
     end
   end
 
+  def submission_started_notification
+    assigns = {}
+
+    assigns[:user] = dummy_user("Jon", "Doe", "Jane's Company")
+
+    render(assigns, "users/submission_started_notification_mailer/notify")
+  end
+
   def unsuccessful_notification
     assigns = {}
 

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -24,6 +24,14 @@ class Notifiers::EmailNotificationService
     end
   end
 
+  def submission_started_notification(award_year)
+    User.confirmed.each do |user|
+      Users::SubmissionStartedNotificationMailer.notify(
+        user.id
+      ).deliver_later!
+    end
+  end
+
   def ep_reminder_support_letters(award_year)
     award_year.form_answers.promotion.includes(:support_letters).each do |form_answer|
       if form_answer.support_letters.count < 2

--- a/app/views/admin/settings/deadlines/_registration_stage_email_notifications.html.slim
+++ b/app/views/admin/settings/deadlines/_registration_stage_email_notifications.html.slim
@@ -1,0 +1,8 @@
+.panel.panel-default
+  .panel-heading#registration-stage-email-notifications-heading role="tab"
+    h4.panel-title
+      a data-toggle="collapse" data-parent="#panel-final-stage" href="#section-registration-stage-email-notifications" aria-expanded="true" aria-controls="section-registration-stage-email-notifications"
+        ' Email notification
+  #section-registration-stage-email-notifications.section-appraisal-form.section-registration-stage-email-notifications.panel-collapse.collapse.in role="tabpanel" aria-labelledby="registration-stage-email-notifications-heading"
+    .panel-body
+      = render 'email_notification', kind: 'submission_started_notification'

--- a/app/views/admin/settings/stages/_registration_stage.html.slim
+++ b/app/views/admin/settings/stages/_registration_stage.html.slim
@@ -7,3 +7,4 @@
     .panel-body
       .panel-group#panel-registration-stage-parent role="tablist" aria-multiselectable="true"
         = render "admin/settings/deadlines/registration_stage_deadlines"
+        = render "admin/settings/deadlines/registration_stage_email_notifications"

--- a/app/views/users/submission_started_notification_mailer/notify.html.slim
+++ b/app/views/users/submission_started_notification_mailer/notify.html.slim
@@ -1,0 +1,17 @@
+p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
+  strong
+    = "Dear #{@user.decorate.full_name},"
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+ | We're emailing to remind you that applications for the new Award year are open.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  ' Please
+  => link_to "log in", new_user_session_url
+  ' to your Queen’s Award account to access it.
+
+p style="font-weight: 700; font-size: 19px; line-height: 1.315789474; margin: 38px 0 38px 0;"
+  ' Kind regards,
+  br
+  br
+  ' The Queen’s Awards Office

--- a/app/views/users/submission_started_notification_mailer/notify.text.slim
+++ b/app/views/users/submission_started_notification_mailer/notify.text.slim
@@ -1,0 +1,11 @@
+= "Dear #{@user.decorate.full_name},"
+
+| We're emailing to remind you that applications for the new Award year are open.
+
+' Please
+=> link_to "log in", new_user_session_url
+' to your Queen’s Award account to access it.
+
+' Kind regards,
+
+' The Queen’s Awards Office

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,7 @@ en:
     audit_certificates: Audit certificates due by
 
   email_notification_headers:
+    submission_started_notification: "Notify users that applications for the new Award year are open"
     reminder_to_submit: Reminder to submit the applications (to all those who have started but not yet submitted applications).
     ep_reminder_support_letters: "ENTERPRISE PROMOTION : Reminder to follow up supporter letters (to all those who have started EP applications, but have fewer than 2 support letters submitted)."
     winners_notification: "WINNERS : Email notifying all winning business applicants of their success & requesting their confirmation of their Press Book entry."

--- a/spec/mailers/users/submission_started_notification_mailer_spec.rb
+++ b/spec/mailers/users/submission_started_notification_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe Users::SubmissionStartedNotificationMailer do
+
+  let(:user) { create(:user) }
+
+  let(:subject) do
+    "Queen's Awards for Enterprise Reminder: applications for the new Award year are open"
+  end
+
+  let(:mail) do
+    Users::SubmissionStartedNotificationMailer.notify(user.id)
+  end
+
+  describe "#notify" do
+    it "renders the headers" do
+      expect(mail.subject).to eq(subject)
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+    end
+
+    it "renders the body" do
+      expect(mail.html_part.decoded).to match(user.decorate.full_name)
+      expect(mail.html_part.decoded).to have_link("log in", href: new_user_session_url)
+    end
+  end
+end

--- a/spec/renderers/mail_renderer_spec.rb
+++ b/spec/renderers/mail_renderer_spec.rb
@@ -1,6 +1,25 @@
 require "rails_helper"
 
 describe MailRenderer do
+  describe "#submission_started_notification" do
+    let(:login_link) do
+      "http://queens-awards-enterprise.service.gov.uk/users/sign_in"
+    end
+
+    let(:user_full_name) do
+      "Jon Doe"
+    end
+
+    let(:rendered_email) do
+      described_class.new.submission_started_notification
+    end
+
+    it "renders e-mail" do
+      expect(rendered_email).to match(user_full_name)
+      expect(rendered_email).to match(login_link)
+    end
+  end
+
   describe "#shortlisted_audit_certificate_reminder" do
     it "renders e-mail" do
       rendered = described_class.new.shortlisted_audit_certificate_reminder

--- a/spec/services/notifiers/email_notification_service_spec.rb
+++ b/spec/services/notifiers/email_notification_service_spec.rb
@@ -17,6 +17,26 @@ describe Notifiers::EmailNotificationService do
     form_answer.user
   end
 
+  context "submission_started_notification" do
+    let(:kind) { "submission_started_notification" }
+
+    let(:user) do
+      create(:user)
+    end
+
+    it "triggers current notification" do
+      mailer = double(deliver_later!: true)
+
+      expect(Users::SubmissionStartedNotificationMailer).to receive(:notify).with(
+        user.id
+      ) { mailer }
+
+      described_class.run
+
+      expect(current_notification.reload).to be_sent
+    end
+  end
+
   context "shortlisted_audit_certificate_reminder" do
     let(:kind) { "shortlisted_audit_certificate_reminder" }
     let(:form_answer) { create(:form_answer, :trade, :submitted) }


### PR DESCRIPTION
Notifies users that the applications for the new year are open

[Trello Story](https://trello.com/c/lzNBgzvl/321-qae2015-admin-settings-add-in-a-new-notifier-for-when-the-applications-for-the-new-year-are-open-submission-started)