### PR TITLE
[Winners Resources] added Queen's Awards for Enterprise Press Book 2016

### DIFF
--- a/app/views/content_only/award_winners_section/2016.html.slim
+++ b/app/views/content_only/award_winners_section/2016.html.slim
@@ -25,6 +25,18 @@ div
                       class: "thumbnail",
                       target: "_blank"
 
+          p
+            ' Please do not publicise the information in the press book until
+            strong
+              => deadline_for("buckingham_palace_attendees_details", "%d %B")
+            ' as it is under embargo.
+
+          p
+            = link_to "Queen's Awards for Enterprise Press Book 2016 (PDF, 5,8 MB)",
+                      static_s3_asset_path(2016, "Queen's Awards for Enterprise Press Book 2016.pdf"),
+                      class: "thumbnail",
+                      target: "_blank"
+
         h2 Download The Queen's Awards for Enterprise 2016 Emblems in various formats
 
         - if any_promotion_winner

--- a/app/views/content_only/award_winners_section/2017.html.slim
+++ b/app/views/content_only/award_winners_section/2017.html.slim
@@ -1,0 +1,6 @@
+div
+  header.group.page-header.page-header-wider
+    div
+      h1 Winners' Resources 2017
+
+    h2 TODO!


### PR DESCRIPTION
Task Description:

Could I also ask you to make a change to the winner's resources page?
Please see my attachment. Underneath "Download The Queen's Awards for Enterprise Winners' Manual 2016"
and that attachment include a new heading:
```
"Download The Queen's Awards for Enterprise Press Book 2016"
```
Then add a note which says "Please do not publicise the information in the press book
until 21 April as it is under embargo."

[Trello Story](https://trello.com/c/KkDCv7N3/322-qae2015-update-winners-resources-page)