### PR TITLE
Winners resources between award years should still display

### DIFF
--- a/app/controllers/content_only_controller.rb
+++ b/app/controllers/content_only_controller.rb
@@ -44,7 +44,7 @@ class ContentOnlyController < ApplicationController
     current_account.form_answers.submitted.past.group_by(&:award_year)
   end
 
-  expose(:winners_award_year) do
+  expose(:target_award_year) do
     if params[:award_year_id].present?
       AwardYear.find(params[:award_year_id])
     else
@@ -70,14 +70,14 @@ class ContentOnlyController < ApplicationController
   def award_winners_section
     @user_award_forms_submitted = user_award_forms.submitted
 
-    render "content_only/award_winners_section/#{winners_award_year.year}"
+    render "content_only/award_winners_section/#{target_award_year.year}"
   end
 
   private
 
   def user_award_forms
     current_account.form_answers
-                   .where(award_year: AwardYear.current)
+                   .where(award_year: target_award_year)
                    .order("award_type")
   end
 

--- a/app/views/content_only/award_winners_section/2016.html.slim
+++ b/app/views/content_only/award_winners_section/2016.html.slim
@@ -28,7 +28,7 @@ div
           p
             ' Please do not publicise the information in the press book until
             strong
-              => deadline_for("buckingham_palace_attendees_details", "%d %B")
+              => application_deadline_for_year(target_award_year, :buckingham_palace_attendees_details, "%d %B")
             ' as it is under embargo.
 
           p


### PR DESCRIPTION
1) Winners Resources - fixed issue with deadline
2) Winners Resources - fixed issue with past year

[Trello Story](https://trello.com/c/VvWaHI1n/790-qae16imp-winners-resources-between-award-years-should-still-display)