### PR TITLE
amend help copytext for multiple checkbox

### DIFF
--- a/app/forms/qae_2014_forms/international_trade/international_trade_step2.rb
+++ b/app/forms/qae_2014_forms/international_trade/international_trade_step2.rb
@@ -66,8 +66,11 @@ class QAE2014Forms
           words_max 15
         end
 
-        checkbox_seria :application_relate_to_header, "This entry relates to (please select all that apply):" do
+        checkbox_seria :application_relate_to_header, "This entry relates to:" do
           ref "B 2"
+          context %(
+            <p>Select all that apply.</p>
+          )
           check_options [
             ["products", "Products"],
             ["services", "Services"]


### PR DESCRIPTION
… on international trade form. so that this matches gov.uk styleguides