### PR TITLE
Innovation form tweaks

### DIFF
--- a/app/forms/qae_2014_forms/innovation/innovation_step1.rb
+++ b/app/forms/qae_2014_forms/innovation/innovation_step1.rb
@@ -154,8 +154,29 @@ class QAE2014Forms
           words_max 300
         end
 
-        options :innovation_any_contributors, "Did any external organisation(s) or individual(s) contribute to your innovation?" do
+        options :innovation_joint_contributors, "Is this application part of a joint entry with any of the contributing organisation(s)?" do
           ref "A 8"
+          required
+          context %(
+            <p>
+              If two or more organisations made a significant contribution to the product,
+              service or business model then you should make a joint entry.
+              Each organisation should submit separate, cross-referenced, entry forms.
+            </p>
+          )
+          yes_no
+        end
+
+        textarea :innovation_contributors, "Please enter their name(s)" do
+          classes "sub-question"
+          sub_ref "A 8.1"
+          conditional :innovation_joint_contributors, :yes
+          rows 2
+          words_max 100
+        end
+
+        options :innovation_any_contributors, "Did any external organisation(s) or individual(s) contribute to your innovation?" do
+          ref "A 9"
           required
           # context %(
           #   <p>
@@ -170,10 +191,10 @@ class QAE2014Forms
 
         options :innovation_contributors_aware, "Are they aware that you're applying for this award?" do
           classes "sub-question"
-          sub_ref "A 8.1"
+          sub_ref "A 9.1"
           required
           conditional :innovation_any_contributors, :yes
-          conditional :innovation_joint_contributors, :no
+          # conditional :innovation_joint_contributors, :no
           option :yes, "Yes, they are all aware"
           option :no, "No, they are not all aware"
         end
@@ -185,7 +206,7 @@ class QAE2014Forms
                     )
           conditional :innovation_any_contributors, :yes
           conditional :innovation_contributors_aware, :no
-          conditional :innovation_joint_contributors, :no
+          # conditional :innovation_joint_contributors, :no
         end
 
         header :innovation_contributors_aware_header_some, "" do
@@ -200,46 +221,21 @@ class QAE2014Forms
 
         textarea :innovation_contributors_why_organisations, "Explain why external organisations or individuals that contributed to your innovation are not all aware of this applications" do
           classes "sub-question"
-          sub_ref "A 8.2"
+          sub_ref "A 9.2"
           required
           conditional :innovation_contributors_aware, :no
           rows 3
           words_max 200
         end
 
-        options :innovation_joint_contributors, "Is this application part of a joint entry with any of the contributing organisation(s)?" do
-          classes "sub-question"
-          sub_ref "A 8.3"
-          required
-          context %(
-            <p>
-              If two or more organisations made a significant contribution to the product,
-              service or business model then you should make a joint entry.
-              Each organisation should submit separate, cross-referenced, entry forms.
-            </p>
-          )
-          conditional :innovation_any_contributors, :yes
-          yes_no
-        end
-
-        textarea :innovation_contributors, "Please enter their name(s)" do
-          classes "sub-question"
-          sub_ref "A 8.4"
-          required
-          conditional :innovation_any_contributors, :yes
-          conditional :innovation_joint_contributors, :yes
-          rows 2
-          words_max 100
-        end
-
         options :innovation_under_license, "Is your innovation under licence from another organisation?" do
-          ref "A 9"
+          ref "A 10"
           yes_no
         end
 
         textarea :innovation_license_terms, "Briefly describe the licensing arrangement." do
           classes "sub-question"
-          sub_ref "A 9.1"
+          sub_ref "A 10.1"
           required
           conditional :innovation_under_license, :yes
           rows 5
@@ -248,7 +244,7 @@ class QAE2014Forms
 
         address :organization_address, "Principal address of your organisation" do
           required
-          ref "A 10"
+          ref "A 11"
           sub_fields([
             { building: "Building" },
             { street: "Street" },
@@ -261,41 +257,41 @@ class QAE2014Forms
 
         text :org_telephone, "Main telephone number" do
           required
-          ref "A 11"
+          ref "A 12"
           style "small"
         end
 
         text :website_url, "Website Address" do
-          ref "A 12"
+          ref "A 13"
           style "large"
           form_hint "e.g. www.example.com"
         end
 
         sic_code_dropdown :sic_code, "SIC code" do
           required
-          ref "A 13"
+          ref "A 14"
         end
 
         options :has_parent_company, "Do you have a parent or a holding company?" do
-          ref "A 14"
+          ref "A 15"
           yes_no
           required
         end
 
         text :parent_company, "Name of immediate parent company" do
-          sub_ref "A 14.1"
+          sub_ref "A 15.1"
           classes "sub-question"
           conditional :has_parent_company, "yes"
         end
 
         country :parent_company_country, "Country of immediate parent company" do
-          sub_ref "A 14.2"
+          sub_ref "A 15.2"
           classes "regular-question"
           conditional :has_parent_company, "yes"
         end
 
         options :parent_ultimate_control, "Does your immediate parent company have ultimate control?" do
-          sub_ref "A 14.3"
+          sub_ref "A 15.3"
           classes "sub-question"
           conditional :has_parent_company, "yes"
           yes_no
@@ -303,20 +299,20 @@ class QAE2014Forms
 
         text :ultimate_control_company, "Name of organisation with ultimate control" do
           classes "regular-question"
-          sub_ref "A 13.4"
+          sub_ref "A 15.4"
           conditional :parent_ultimate_control, :no
           conditional :has_parent_company, "yes"
         end
 
         country :ultimate_control_company_country, "Country of organisation with ultimate control" do
           classes "regular-question"
-          sub_ref "A 13.5"
+          sub_ref "A 15.5"
           conditional :parent_ultimate_control, :no
           conditional :has_parent_company, "yes"
         end
 
         upload :org_chart, "Upload an organisational chart (optional)." do
-          ref "A 15"
+          ref "A 16"
           context %(
             <p>You can submit files in all common formats, as long as they're less than 5mb each.</p>
                     )

--- a/app/forms/qae_2014_forms/innovation/innovation_step3.rb
+++ b/app/forms/qae_2014_forms/innovation/innovation_step3.rb
@@ -156,9 +156,10 @@ class QAE2014Forms
         end
 
         # UK sales = turnover - exports
-        turnover_exports_calculation :uk_sales, "UK Sales" do
+        turnover_exports_calculation :uk_sales, "Of which UK sales" do
           classes "sub-question"
           sub_ref "C 4.3"
+          context %(<p>This number is automatically calculated using your total turnover and export figures</p>)
           label ->(y) { "Financial year #{y}" }
           by_year_condition :innovation_performance_years, "2 to 4", 2
           by_year_condition :innovation_performance_years, "5 plus", 5


### PR DESCRIPTION
#### What this PR does:

A8 CHANGES:

A8.3 -> A8 Is this application part of a joint - if yes, show new A8.1
A8.4 -> A8.1 Please enter their name(s)


A8 -> A9 Did any external organisation(s) - if yes, show new A9.1
A8.1 -> A9.1 Are they aware that you're - if yes, show new A9.2
A8.2 -> A9.2 Explain why external organisations

Renumber following numbers +1


![a8](https://cloud.githubusercontent.com/assets/1143421/14868762/f34173f6-0c94-11e6-888c-3ce05de02b34.gif)

C4.3 Change title copy from "UK Sales" to "Of which UK sales"; ADD help text: "This number is automatically calculated using your total turnover and export figures"


![uk-sales](https://cloud.githubusercontent.com/assets/1143421/14868766/f63f878c-0c94-11e6-958d-5bd6fc4604ac.png)
