### PR TITLE
[CSP Report UI] fix of 'InvalidAuthenticityToken' issue

### DIFF
--- a/app/controllers/csp_report_uri_controller.rb
+++ b/app/controllers/csp_report_uri_controller.rb
@@ -4,6 +4,8 @@ class CspReportUriController < ApplicationController
   # http://content-security-policy.com/
   # Content Security Policy settings are set config/initializers/secure_headers.rb
 
+  protect_from_forgery except: [:report]
+
   def report
     render status: :ok
   end


### PR DESCRIPTION
```
I, [2016-04-29T15:24:44.339120 #1973]  INFO -- : Processing by CspReportUriController#report as */*
W, [2016-04-29T15:24:44.339611 #1973]  WARN -- : Can't verify CSRF token authenticity
I, [2016-04-29T15:24:44.340012 #1973]  INFO -- : Completed 422 Unprocessable Entity in 1ms (ActiveRecord: 0.0ms)
I, [2016-04-29T15:24:44.340670 #1973]  INFO -- : ** [Raven] User excluded error: #<ActionController::InvalidAuthenticityToken: ActionController::InvalidAuthenticityToken>
F, [2016-04-29T15:24:44.342385 #1973] FATAL -- :
ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken):
  actionpack (4.2.5.2) lib/action_controller/metal/request_forgery_protection.rb:181:in `handle_unverified_request'
  actionpack (4.2.5.2) lib/action_controller/metal/request_forgery_protection.rb:209:in `handle_unverified_request'
  devise (3.4.1) lib/devise/controllers/helpers.rb:251:in `handle_unverified_request'
  actionpack (4.2.5.2) lib/action_controller/metal/request_forgery_protection.rb:204:in `verify_authenticity_token'
```

[Help Scout Topic](https://secure.helpscout.net/conversation/197477704/897/?folderId=621869)
[AWS Alarm](https://console.aws.amazon.com/cloudwatch/home?region=eu-west-1#s=Alarms&alarm=awselb-ProductionLoadBalancer-High-Average-Latency)