### PR TITLE
Update formatted trigger time decorator

### DIFF
--- a/app/decorators/trigger_at_decorator.rb
+++ b/app/decorators/trigger_at_decorator.rb
@@ -7,8 +7,8 @@ module TriggerAtDecorator
 
     trigger_on = object.trigger_at.strftime("%-d %b %Y")
     trigger_at = object.trigger_at.strftime("%-l:%M%P")
-    trigger_at = "midnight" if object.trigger_at == object.trigger_at.midnight
-    trigger_at = "midday" if object.trigger_at == object.trigger_at.midday
+    trigger_at = "midnight" if midnight?
+    trigger_at = "midday" if midday?
 
     h.content_tag(:strong, trigger_on) + " at #{trigger_at}".html_safe
   end
@@ -26,5 +26,15 @@ module TriggerAtDecorator
     str_format = str_format + " %Y" if format.present? && format == "with_year"
 
     object.trigger_at.strftime(str_format)
+  end
+
+  private
+
+  def midday?
+    object.trigger_at == object.trigger_at.midday
+  end
+
+  def midnight?
+    object.trigger_at == object.trigger_at.midnight
   end
 end

--- a/app/decorators/trigger_at_decorator.rb
+++ b/app/decorators/trigger_at_decorator.rb
@@ -6,7 +6,9 @@ module TriggerAtDecorator
     return PLACEHOLDER unless object.trigger_at
 
     trigger_on = object.trigger_at.strftime("%-d %b %Y")
-    trigger_at = object.trigger_at.strftime("%k:%M")
+    trigger_at = object.trigger_at.strftime("%-l:%M%P")
+    trigger_at = "midnight" if object.trigger_at == object.trigger_at.midnight
+    trigger_at = "midday" if object.trigger_at == object.trigger_at.midday
 
     h.content_tag(:strong, trigger_on) + " at #{trigger_at}".html_safe
   end

--- a/app/views/content_only/_dashboard_pre_submission.html.slim
+++ b/app/views/content_only/_dashboard_pre_submission.html.slim
@@ -22,10 +22,10 @@
 
           / = render "apply_to_promotion_award_block"
 
-  .related-positioning.related-positioning-no-header
-    .related-container.hidden
-      .related#related
-        - if submission_deadline && submission_deadline.trigger_at
+  - if submission_deadline && submission_deadline.trigger_at
+    .related-positioning.related-positioning-no-header
+      .related-container
+        .related#related
           .highlighted-event
             p
               ' Submission deadline

--- a/spec/decorators/trigger_at_decorator_spec.rb
+++ b/spec/decorators/trigger_at_decorator_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe TriggerAtDecorator do
+
+  let(:date) { DateTime.new(2015,2,6,8,30) }
+
+  before do
+    award_year = instance_double("AwardYear", year: 2017, settings: nil)
+    allow(AwardYear).to receive(:current).and_return(award_year)
+  end
+
+  describe "#formatted_trigger_time" do
+    it "Returns a placeholder if trigger_at is nil" do
+      deadline = build_stubbed(:deadline, trigger_at: nil).decorate
+      expect(deadline.formatted_trigger_time).to eq("<strong>-- --- 2017</strong> at --:--")
+    end
+
+    it "Returns expected format" do
+      deadline = build_stubbed(:deadline, trigger_at: date).decorate
+      expect(deadline.formatted_trigger_time).to eq("<strong>6 Feb 2015</strong> at 8:30am")
+    end
+
+    it "Returns midnight if time is 00:00" do
+      deadline = build_stubbed(:deadline, trigger_at: date.midnight).decorate
+      expect(deadline.formatted_trigger_time).to eq("<strong>6 Feb 2015</strong> at midnight")
+    end
+
+    it "Returns midday if time is 12:00" do
+      deadline = build_stubbed(:deadline, trigger_at: date.midday).decorate
+      expect(deadline.formatted_trigger_time).to eq("<strong>6 Feb 2015</strong> at midday")
+    end
+  end
+end


### PR DESCRIPTION
#### What this PR does:

Updates the format of the date in different parts of the app.

- Dashboard green box

![green-box](https://cloud.githubusercontent.com/assets/1143421/14925985/9aeed834-0e0f-11e6-8d89-b76eeb0a9c5d.png)

- Apply page (before eligibility questionnaire)

![apply-before](https://cloud.githubusercontent.com/assets/1143421/14926014/b6ddf886-0e0f-11e6-871f-14a5e904f43f.png)

- Application info page.

![application-info](https://cloud.githubusercontent.com/assets/1143421/14926044/d638795e-0e0f-11e6-9499-dc32223e8090.png)

- Section F - before submit button

![section-f](https://cloud.githubusercontent.com/assets/1143421/14926064/f14a9bdc-0e0f-11e6-856f-037b8466c808.png)

- Confirmation of submission page 

![confirmation](https://cloud.githubusercontent.com/assets/1143421/14926099/19c527ee-0e10-11e6-9e95-2740c4326813.png)

#### Notes:

There are other parts of the application that will show the time in other format, because they are not covered by this decorator, however this is out of the scope of this card.