### PR TITLE
In Section A of all forms, SIC codes - make the default option "Selec…

### DIFF
--- a/app/views/qae_form/_select2_dropdown_question.html.slim
+++ b/app/views/qae_form/_select2_dropdown_question.html.slim
@@ -1,4 +1,7 @@
 select.js-trigger-autosave.select2.sic_code-selector name=question.input_name *possible_read_only_ops id="q_#{question.key}"
+  - if defined?(placeholder)
+    option value=""
+      = placeholder
   - question.options.each do |option|
     option value="#{option.value}" selected=((question.input_value || '').to_s == option.value.to_s)
       = option.text

--- a/app/views/qae_form/_sic_code_dropdown_question.html.slim
+++ b/app/views/qae_form/_sic_code_dropdown_question.html.slim
@@ -1,1 +1,1 @@
-= render "qae_form/select2_dropdown_question", question: question
+= render "qae_form/select2_dropdown_question", question: question, placeholder: "Select SIC code"


### PR DESCRIPTION
…t SIC code"

[Trello Story](https://trello.com/c/ScuCGBeg/886-qae16imp-in-section-a-of-all-forms-sic-codes-make-the-default-option-select-sic-code)