### PR TITLE
[Eligibility] fixing of issue with changing answer

### DIFF
--- a/app/controllers/form_award_eligibilities_controller.rb
+++ b/app/controllers/form_award_eligibilities_controller.rb
@@ -56,7 +56,9 @@ class FormAwardEligibilitiesController < ApplicationController
         @eligibility.pass!
       end
 
-      if params[:skipped] == "false"
+      check_passed_award_eligibility_after_changing_answer!
+
+      if params[:skipped] == "false" || !@award_eligibility.valid?
         set_steps_and_eligibilities
         setup_wizard
 
@@ -112,6 +114,21 @@ class FormAwardEligibilitiesController < ApplicationController
     else
       @eligibility = @award_eligibility
       self.steps = @award_eligibility.questions
+    end
+  end
+
+  def check_passed_award_eligibility_after_changing_answer!
+    if @basic_eligibility.passed? && @award_eligibility.passed?
+      # Check validations which are not depends on current_step
+      # if case if Eligibility was already marked as #passed
+      # We need it in case if user changed answer after passing of validation
+      #
+      @award_eligibility.current_step = nil
+
+      # Mark eligibility as not passed in case if answer was changed
+      # and now eligibility is not valid!
+      #
+      @award_eligibility.update_column(:passed, false) if !@award_eligibility.valid?
     end
   end
 

--- a/app/models/eligibility/trade.rb
+++ b/app/models/eligibility/trade.rb
@@ -2,10 +2,25 @@
 class Eligibility::Trade < Eligibility
   AWARD_NAME = 'International Trade'
 
+  validates :current_holder_of_qae_for_trade,
+            presence: true,
+            if: proc {
+              account.basic_eligibility.try(:current_holder) == "yes" && (
+                current_step == :current_holder_of_qae_for_trade ||
+                current_step.blank?
+              )
+            }
+
   validates :qae_for_trade_award_year,
             presence: true,
             not_winner_in_last_year: true,
-            if: proc { current_holder_of_qae_for_trade? && current_step == :qae_for_trade_award_year }
+            if: proc {
+              account.basic_eligibility.try(:current_holder) == "yes" &&
+              current_holder_of_qae_for_trade? && (
+                current_step == :qae_for_trade_award_year ||
+                current_step.blank?
+              )
+            }
 
   property :sales_above_100_000_pounds,
             values: %w[yes no skip],

--- a/spec/controllers/form_controller_spec.rb
+++ b/spec/controllers/form_controller_spec.rb
@@ -108,6 +108,11 @@ describe FormController do
       end
 
       it "does nothing there was no award" do
+        el = account.basic_eligibility
+        el.update!(
+          current_holder: "no"
+        )
+
         trade_el = form_answer.trade_eligibility
         trade_el.update!(
           sales_above_100_000_pounds: "yes",


### PR DESCRIPTION
For example:

If I changing "Are you a current holder of a Queen's Award for International Trade?" from 'No' to 'Yes'
Then question "In which year did you receive the award?" should be required
but this conditional question is not displayed.

[Trello Story](https://trello.com/c/NWWfPlr0/887-qae16imp-investigate-issue-with-eligibility-changing-answer)