### PR TITLE
Update formatted trigger time decorator

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -6,7 +6,7 @@ class ApplicationDecorator < Draper::Decorator
   end
 
   def created_at_timestamp
-    object.created_at.strftime("%d%m%Y_%H%M")
+    object.created_at.strftime("%d%m%Y_%-l:%M%P")
   end
 
   def self.collection_decorator_class

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -248,6 +248,20 @@ class FormAnswerDecorator < ApplicationDecorator
     end
   end
 
+  def feedback_updated_by
+    feedback = object.feedback
+    if feedback && feedback.authorable.present?
+      "Updated by: #{feedback.authorable.decorate.full_name} - #{feedback.updated_at.strftime("%e %b %Y at %-l:%M%P")}"
+    end
+  end
+
+  def press_summary_updated_by
+    ps = object.press_summary
+    if ps.present? && ps.authorable.present?
+      "Updated by #{ps.authorable.decorate.full_name} - #{ps.updated_at.strftime("%e %b %Y at %-l:%M%P")}"
+    end
+  end
+
   def nominee_organisation
     document["organization_address_name"]
   end

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -243,7 +243,7 @@ class FormAnswerDecorator < ApplicationDecorator
   def last_state_updated_by
     transition = object.state_machine.last_transition
     if transition.present? && transition.transitable
-      time = transition.created_at.try(:strftime, "%e %b %Y at %H:%M")
+      time = transition.created_at.try(:strftime, "%e %b %Y at %-l:%M%P")
       "Updated by #{transition.transitable.decorate.full_name} - #{time}"
     end
   end

--- a/app/decorators/user_shared_decorator.rb
+++ b/app/decorators/user_shared_decorator.rb
@@ -8,10 +8,10 @@ module UserSharedDecorator
   end
 
   def formatted_last_sign_in_at_long
-    object.last_sign_in_at && object.last_sign_in_at.strftime("%e %b %Y at %H:%M")
+    object.last_sign_in_at && object.last_sign_in_at.strftime("%e %b %Y at %-l:%M%P")
   end
 
   def formatted_last_sign_in_at_short
-    object.last_sign_in_at && object.last_sign_in_at.strftime("%d/%m/%Y %H:%M")
+    object.last_sign_in_at && object.last_sign_in_at.strftime("%d/%m/%Y %-l:%M%P")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,7 +100,7 @@ module ApplicationHelper
   end
 
   def format_date(date)
-    date.strftime("%e %b %Y at %H:%M")
+    date.strftime("%e %b %Y at %-l:%M%P")
   end
 
   # Custom version of http://apidock.com/rails/v4.2.1/ActionView/Helpers/TextHelper/simple_format

--- a/app/helpers/form_answer_helper.rb
+++ b/app/helpers/form_answer_helper.rb
@@ -62,20 +62,6 @@ module FormAnswerHelper
     ([["United Kingdom", "GB"], ["United States", "US"]] + Country.all).uniq
   end
 
-  def feedback_updated_by(form_answer)
-    feedback = form_answer.feedback
-    if feedback && feedback.authorable.present?
-      "Updated by: #{feedback.authorable.decorate.full_name} - #{format_date(feedback.updated_at)}"
-    end
-  end
-
-  def press_summary_updated_by(form_answer)
-    ps = form_answer.press_summary
-    if ps.present? && ps.authorable.present?
-      "Updated by #{ps.authorable.decorate.full_name} - #{format_date(ps.updated_at)}"
-    end
-  end
-
   def assessors_collection_for_bulk
     assessors = Assessor.available_for(category_picker.current_award_type).map { |a| [a.full_name, a.id] }
     [["Not Assigned", "not assigned"]] + assessors

--- a/app/mailers/account_mailers/buckingham_palace_invite_mailer.rb
+++ b/app/mailers/account_mailers/buckingham_palace_invite_mailer.rb
@@ -8,7 +8,7 @@ class AccountMailers::BuckinghamPalaceInviteMailer < AccountMailers::BaseMailer
     @user = @form_answer.user.decorate
 
     @reception_date = AwardYear.buckingham_palace_reception_date
-    @reception_date = @reception_date.try(:strftime, "%A %d %B at %H:%M")
+    @reception_date = @reception_date.try(:strftime, "%A %d %B at %-l:%M%P")
 
     @palace_attendees_due = AwardYear.buckingham_palace_reception_attendee_information_due_by
     @palace_attendees_due = @palace_attendees_due.try(:strftime, "%A%e %B")

--- a/app/models/reports/admin_report.rb
+++ b/app/models/reports/admin_report.rb
@@ -45,7 +45,7 @@ class Reports::AdminReport
   end
 
   def pdf_filename
-    pdf_timestamp = Time.zone.now.strftime("%e_%b_%Y_at_%H:%M")
+    pdf_timestamp = Time.zone.now.strftime("%e_%b_%Y_at_%-l:%M%P")
     "#{::FormAnswer::AWARD_TYPE_FULL_NAMES[params[:category]]}_award_#{id}_#{pdf_timestamp}.pdf"
   end
 end

--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -148,7 +148,7 @@ class MailRenderer
     reception_date = DateTime.new(Date.current.year, 7, 14, 18, 00) if reception_date.blank?
 
     assigns[:reception_date] = reception_date.strftime(
-      "%A %d %B at %H:%M"
+      "%A %d %B at %-l:%M%P"
     )
 
     palace_attendees_due = AwardYear.buckingham_palace_reception_attendee_information_due_by

--- a/app/views/admin/form_answers/_section_press_summary.html.slim
+++ b/app/views/admin/form_answers/_section_press_summary.html.slim
@@ -3,9 +3,9 @@
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-winners" href="#section-press-summary" aria-expanded="true" aria-controls="section-press-summary"
         ' Press Book Notes
-        - if press_summary_updated_by(@form_answer).present?
+        - if @form_answer.press_summary_updated_by
           small
-            = press_summary_updated_by(@form_answer)
+            = @form_answer.press_summary_updated_by
   #section-press-summary.section-press-summary.panel-collapse.collapse role="tabpanel" aria-labelledby="press-summary-heading"
     .panel-body
       = render "admin/press_summaries/section", form_answer: @form_answer

--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -33,9 +33,9 @@
         h4.panel-title
           a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-feedback" aria-expanded="true" aria-controls="section-feedback"
             ' Feedback
-            - if feedback_updated_by(@form_answer).present?
+            - if @form_answer.feedback_updated_by
               small
-                = feedback_updated_by(@form_answer)
+                = @form_answer.feedback_updated_by
       #section-feedback.section-application-info.panel-collapse.collapse role="tabpanel" aria-labelledby="feedback-heading"
         .panel-body
           = render "admin/feedbacks/section", form_answer: @form_answer

--- a/app/views/admin/users_feedbacks/show.html.slim
+++ b/app/views/admin/users_feedbacks/show.html.slim
@@ -25,7 +25,7 @@
             - @feedbacks.each do |feedback|
               tr
                 td
-                  = feedback.created_at.strftime("%d/%m/%Y %H:%M")
+                  = feedback.created_at.strftime("%d/%m/%Y %-l:%M%P")
                 td
                   span.feedback-stars alt=feedback.rating.text title=feedback.rating.text
                     - feedback.rating.value.times do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,7 +84,7 @@ en:
 
   time:
     formats:
-      date_at_time: "%d/%m/%Y at %H:%M"
+      date_at_time: "%d/%m/%Y at %-l:%M%P"
       govuk_time: "%-I:%M%P"
       govuk_date_short: "%-I:%M%P, %-e %b %Y"
       govuk_date: "%-I:%M%P, %-e %B %Y"

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe ApplicationDecorator do
+
+  let(:date) { DateTime.new(2015,2,6,8,30) }
+
+  describe "#created_at" do
+    it "Returns the expected format" do
+      user = build_stubbed(:user, created_at: date).decorate
+      expect(user.created_at).to eq("Feb_06_2015")
+    end
+  end
+
+  describe "#created_at_timestamp" do
+    it "Returns the expected format" do
+      user = build_stubbed(:user, created_at: date).decorate
+      expect(user.created_at_timestamp).to eq("06022015_8:30am")
+    end
+  end
+end

--- a/spec/decorators/form_answer_decorator_spec.rb
+++ b/spec/decorators/form_answer_decorator_spec.rb
@@ -1,6 +1,18 @@
 require "rails_helper"
 
 describe FormAnswerDecorator do
+
+  describe "#last_state_updated_by" do
+    it "Returns the person and time of who made the last transition" do
+
+      Timecop.freeze(DateTime.new(2015, 2, 6, 8, 30)) do
+        form_answer = create(:form_answer).decorate
+        form_answer.state_machine.submit(form_answer.user)
+        expect(form_answer.last_state_updated_by).to eq("Updated by John Doe -  6 Feb 2015 at 8:30am")
+      end
+    end
+  end
+
   describe "#average_growth_for" do
     subject { described_class.new form_answer }
     let(:form_answer) { build(:form_answer, sic_code: sic_code.code) }

--- a/spec/decorators/form_answer_decorator_spec.rb
+++ b/spec/decorators/form_answer_decorator_spec.rb
@@ -2,16 +2,7 @@ require "rails_helper"
 
 describe FormAnswerDecorator do
 
-  describe "#last_state_updated_by" do
-    it "Returns the person and time of who made the last transition" do
-
-      Timecop.freeze(DateTime.new(2015, 2, 6, 8, 30)) do
-        form_answer = create(:form_answer).decorate
-        form_answer.state_machine.submit(form_answer.user)
-        expect(form_answer.last_state_updated_by).to eq("Updated by John Doe -  6 Feb 2015 at 8:30am")
-      end
-    end
-  end
+  let(:user) { build_stubbed(:user, first_name: "John", last_name: "Doe") }
 
   describe "#average_growth_for" do
     subject { described_class.new form_answer }
@@ -29,6 +20,35 @@ describe FormAnswerDecorator do
       let(:sic_code) { double(code: nil) }
       it "returns nil" do
         expect(subject.average_growth_for(year)).to be_nil
+      end
+    end
+  end
+
+  describe "#last_state_updated_by" do
+    it "Returns the person and time of who made the last transition" do
+
+      Timecop.freeze(DateTime.new(2015, 2, 6, 8, 30)) do
+        form_answer = create(:form_answer).decorate
+        form_answer.state_machine.submit(form_answer.user)
+        expect(form_answer.last_state_updated_by).to eq("Updated by John Doe -  6 Feb 2015 at 8:30am")
+      end
+    end
+  end
+
+  describe "#feedback_updated_by" do
+    it "Returns the person and time of who made the feedback" do
+      Timecop.freeze(DateTime.new(2015, 2, 6, 8, 30)) do
+        form_answer = create(:feedback, authorable: user).form_answer.decorate
+        expect(form_answer.feedback_updated_by).to eq("Updated by: John Doe -  6 Feb 2015 at 8:30am")
+      end
+    end
+  end
+
+  describe "#press_summary" do
+    it "Returns the person and time of who made the last transition" do
+      Timecop.freeze(DateTime.new(2015, 2, 6, 8, 30)) do
+        form_answer = create(:press_summary, authorable: user).form_answer.decorate
+        expect(form_answer.press_summary_updated_by).to eq("Updated by John Doe -  6 Feb 2015 at 8:30am")
       end
     end
   end

--- a/spec/decorators/user_shared_decorator_spec.rb
+++ b/spec/decorators/user_shared_decorator_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe UserSharedDecorator do
+
+  let(:user) do
+    build_stubbed(:user, first_name: "John",
+                         last_name: "Doe",
+                         last_sign_in_at: DateTime.new(2015,2,6,8,30)).decorate
+  end
+
+  describe "#full_name" do
+    it "Returns the first_name and last_name concatenated if present" do
+      expect(user.full_name).to eq("John Doe")
+    end
+
+    it "Returns Anonymous if first_name is not present" do
+      user.first_name = nil
+      expect(user.full_name).to eq("Anonymous")
+    end
+  end
+
+  describe "#formatted_last_sign_in_at_long" do
+    it "Returns the expected format" do
+      expect(user.formatted_last_sign_in_at_long).to eq(" 6 Feb 2015 at 8:30am")
+    end
+  end
+
+  describe "#formatted_last_sign_in_at_short" do
+    it "Returns the expected format" do
+      expect(user.formatted_last_sign_in_at_short).to eq("06/02/2015 8:30am")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,6 @@ SimpleCov.start CodeClimate::TestReporter.configuration.profile
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'capybara/rspec'
-require 'database_cleaner'
 require 'shoulda/matchers'
 require "capybara-screenshot/rspec"
 require "webmock/rspec"
@@ -40,13 +39,6 @@ RSpec.configure do |config|
   config.order = "random"
 
   config.before :each do
-    if Capybara.current_driver == :rack_test
-      DatabaseCleaner.strategy = :transaction
-    else
-      DatabaseCleaner.strategy = :truncation
-    end
-    DatabaseCleaner.start
-
     stub_request(:post, /virus.scanner/).
       to_return(status: 200, body: { id: "de401fdf-08b0-44a8-810b-20794c5c98c7" }.to_json)
 
@@ -60,11 +52,6 @@ RSpec.configure do |config|
 
     AwardYear.current
   end
-
-  config.after do
-    DatabaseCleaner.clean
-  end
-
   config.infer_spec_type_from_file_location!
 end
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
#### What this PR does:

- More updates to time format.
From `%H:%M` to `%-l:%M%P`    Ex: `14:08` becomes `2:08pm`
- Move helpers methods to a Decorator class.
- Swap strategy for database_cleaner

#### Notes

>The documentation says:

>For the SQL libraries the fastest option will be to use :transaction as transactions are simply rolled back. If you can use this strategy you should.

We can set the truncation strategy only for js tests since capybara will run in another thread and will not share the connection to rollback a transaction.