### PR TITLE
Palace reception showing not completed

### DIFF
--- a/app/models/palace_invite.rb
+++ b/app/models/palace_invite.rb
@@ -3,7 +3,8 @@ class PalaceInvite < ActiveRecord::Base
 
   has_many :palace_attendees, dependent: :destroy, autosave: true
 
-  validates :form_answer, presence: true
+  validates :form_answer_id, presence: true,
+                             uniqueness: true
 
   before_create :set_token
 

--- a/app/models/reports/csv_helper.rb
+++ b/app/models/reports/csv_helper.rb
@@ -2,7 +2,7 @@ require "csv"
 
 module Reports::CSVHelper
   def build
-    csv_string = CSV.generate do |csv|
+    csv_string = CSV.generate(encoding: "UTF-8", force_quotes: true) do |csv|
       csv << headers
       @scope.each do |form_answer|
         form_answer = Reports::FormAnswer.new(form_answer)
@@ -16,7 +16,7 @@ module Reports::CSVHelper
   end
 
   def as_csv(rows)
-    CSV.generate do |csv|
+    CSV.generate(encoding: "UTF-8", force_quotes: true) do |csv|
       csv << headers
       rows.each do |row|
         csv << row


### PR DESCRIPTION
PR fixed 2 issues:

* [Palace Invites] should be unique for Form Answer model

* [CSV Reports] special characters in Form data bugfix
    
    If same into form data ';' symbol
    then this value would be splitted on multiple columns, instead of to be in one.
    
    For example:
    ```
    form.document["website_url"]
    => "www.babyliss.co.uk/curl-secret.html; www.babylisspro.co.uk/perfect-curl.html"
    ```
    will break CSV.

[Trello Story](https://trello.com/c/gvZP59d4/907-qae16imp-palace-reception-showing-not-completed