### PR TITLE
[Application View | PDF Blocks] added ability to turn on / off them

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ PROFILE_MODE=true
 ```
   rake users_import:import_from_csv FILEPATH="./spec/fixtures/users.csv"
 ```
+
+## Hide Application's PDF links anythere on Applicant view
+
+Uncomment following line in config/environments/production.rb:
+```
+Rails.configuration.hide_pdf_links = true
+```
+and all PDF blocks on Applicant's view would be automatically replaced with
+maintenance messages and PDF links would be hidden.

--- a/app/views/content_only/_current_applications.html.slim
+++ b/app/views/content_only/_current_applications.html.slim
@@ -23,7 +23,13 @@
             p
               - if award.submitted?
                 ' Submitted
-                = render "content_only/past_applications/download_pdf_link", award: award
+
+                - if Rails.configuration.try(:hide_pdf_links).present?
+                  br
+                  | Your application will be available to download from 17th of May
+                - else
+                  = render "content_only/past_applications/download_pdf_link", award: award
+
               - else
                 ' In progress
                 / TODO fix progress percentage

--- a/app/views/content_only/_pdf_link.html.slim
+++ b/app/views/content_only/_pdf_link.html.slim
@@ -1,0 +1,7 @@
+p
+  - if Rails.configuration.try(:hide_pdf_links).present?
+    | All applications must be completed online, but if you find it useful to have it in PDF format for planning purposes, downloadable PDF of the form will be available from 17th of May.
+  - else
+    ' For planning purposes you can
+    = link_to "download a blank PDF of the entire application form", users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true)
+    ' . However, all applications must be completed online.

--- a/app/views/content_only/award_info_development.html.slim
+++ b/app/views/content_only/award_info_development.html.slim
@@ -15,10 +15,8 @@ header.page-header.group.page-header-over-sidebar
             p The Queen’s Awards for Enterprise are highly competitive, and you will be assessed against other candidates.
 
             h2 Before you begin:
-            p
-              ' For planning purposes you can
-              = link_to "download a blank PDF of the entire application form", users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true)
-              ' . However, all applications must be completed online.
+
+            = render "content_only/pdf_link"
 
             - if @collaborators.any?
               br

--- a/app/views/content_only/award_info_innovation.html.slim
+++ b/app/views/content_only/award_info_innovation.html.slim
@@ -15,10 +15,8 @@ header.page-header.group.page-header-over-sidebar
             p The Queen’s Awards for Enterprise are highly competitive, and you will be assessed against other candidates.
 
             h2 Before you begin:
-            p
-              ' For planning purposes you can
-              = link_to "download a blank PDF of the entire application form", users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true)
-              ' . However, all applications must be completed online.
+
+            = render "content_only/pdf_link"
 
             - if @collaborators.any?
               br

--- a/app/views/content_only/award_info_trade.html.slim
+++ b/app/views/content_only/award_info_trade.html.slim
@@ -15,10 +15,8 @@ header.page-header.group.page-header-over-sidebar
             p The Queen’s Awards for Enterprise are highly competitive, and you will be assessed against other candidates.
 
             h2 Before you begin:
-            p
-              ' For planning purposes you can
-              = link_to "download a blank PDF of the entire application form", users_form_answer_path(@form_answer, format: :pdf, pdf_blank_mode: true)
-              ' . However, all applications must be completed online.
+
+            = render "content_only/pdf_link"
 
             - if @collaborators.any?
               br

--- a/app/views/qae_form/_pdf_link.html.slim
+++ b/app/views/qae_form/_pdf_link.html.slim
@@ -1,0 +1,6 @@
+- unless Rails.configuration.try(:hide_pdf_links).present?
+  = link_to users_form_answer_path(@form_answer, format: :pdf)
+    - if @form_answer.award_type == "promotion"
+      ' Download your nomination
+    - else
+      ' Download your application

--- a/app/views/qae_form/_step_submit.html.slim
+++ b/app/views/qae_form/_step_submit.html.slim
@@ -1,11 +1,7 @@
 .form-submit
   .form-download
     p
-      = link_to users_form_answer_path(@form_answer, format: :pdf)
-        - if @form_answer.award_type == "promotion"
-          ' Download your nomination
-        - else
-          ' Download your application
+      = render "qae_form/pdf_link"
 
   - if submit.notice
     br

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -33,9 +33,14 @@
                      ' #{step_letters[step.index]}.
                    = step.short_title.html_safe
 
-    li.divider
-    li.step-past.step-download
-      = render "qae_form/pdf_link"
+    - unless Rails.configuration.try(:hide_pdf_links).present?
+      li.divider
+      li.step-past.step-download
+        = link_to users_form_answer_path(@form_answer, format: :pdf)
+          - if @form_answer.award_type == "promotion"
+            ' Download your nomination
+          - else
+            ' Download your application
 
     li.divider
     li.sidebar-helpline

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -35,11 +35,7 @@
 
     li.divider
     li.step-past.step-download
-      = link_to users_form_answer_path(@form_answer, format: :pdf)
-        - if @form_answer.award_type == "promotion"
-          ' Download your nomination
-        - else
-          ' Download your application
+      = render "qae_form/pdf_link"
 
     li.divider
     li.sidebar-helpline

--- a/app/views/qae_form/confirm.html.slim
+++ b/app/views/qae_form/confirm.html.slim
@@ -35,12 +35,7 @@ header.page-header.group.page-header-wider
       .inner
         .form-download
           p
-            = link_to users_form_answer_path(@form_answer, format: :pdf)
-              ' Download a PDF of your
-              - if @form_answer.promotion?
-                ' nomination
-              - else
-                ' application
+            = render "qae_form/pdf_link"
 
         .application-notice.help-notice
           p

--- a/config/environments/bzstaging.rb
+++ b/config/environments/bzstaging.rb
@@ -86,4 +86,14 @@ Rails.application.configure do
 
   # configure the devise email layout
   config.to_prepare { Devise::Mailer.layout "mailer" }
+
+  #
+  # Usefull env var allows you to hide any PDF links on Applicant's view
+  # for example in case if you are changing smth in PDF generators
+  # and it's on development mode!
+  #
+  # Uncomment line below to hide PDF links:
+  #
+  # Rails.configuration.hide_pdf_links = true
+  #
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,4 +40,14 @@ Rails.application.configure do
 
   # configure the devise email layout
   config.to_prepare { Devise::Mailer.layout "mailer" }
+
+  #
+  # Usefull env var allows you to hide any PDF links on Applicant's view
+  # for example in case if you are changing smth in PDF generators
+  # and it's on development mode!
+  #
+  # Uncomment line below to hide PDF links:
+  #
+  # Rails.configuration.hide_pdf_links = true
+  #
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,4 +86,14 @@ Rails.application.configure do
 
   # configure the devise email layout
   config.to_prepare { Devise::Mailer.layout "mailer" }
+
+  #
+  # Usefull env var allows you to hide any PDF links on Applicant's view
+  # for example in case if you are changing smth in PDF generators
+  # and it's on development mode!
+  #
+  # Uncomment line below to hide PDF links:
+  #
+  Rails.configuration.hide_pdf_links = true
+  #
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -82,4 +82,14 @@ Rails.application.configure do
 
   # configure the devise email layout
   config.to_prepare { Devise::Mailer.layout "mailer" }
+
+  #
+  # Usefull env var allows you to hide any PDF links on Applicant's view
+  # for example in case if you are changing smth in PDF generators
+  # and it's on development mode!
+  #
+  # Uncomment line below to hide PDF links:
+  #
+  # Rails.configuration.hide_pdf_links = true
+  #
 end


### PR DESCRIPTION
Uncomment following line in config/environments/production.rb:

```
Rails.configuration.hide_pdf_links = true
```

and all PDF blocks on Applicant's view would be automatically replaced with
maintenance messages and PDF links would be hidden.

[Trello Story](https://trello.com/c/1dZP2eCP/914-remove-hiding-of-pdfs-in-live-site)