### PR TITLE
Add set_paper_trail_whodunnit before filter to application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   ensure_security_headers if ENV["ENSURE_SECURITY_HEADERS"]
 
   before_filter :configure_permitted_parameters, if: :devise_controller?
+  before_filter :set_paper_trail_whodunnit
 
   self.responder = AppResponder
   respond_to :html


### PR DESCRIPTION
From warning message:

PaperTrail no longer adds the set_paper_trail_whodunnit before_filter
for you. Please add this before_filter to your ApplicationController to
continue recording whodunnit.

Please check the `set_paper_trail_whodunnit` code:

https://github.com/airblade/paper_trail/blob/5cf96bd9ada41c1620fc8754326ca2cc56a9e394/lib/paper_trail/frameworks/rails/controller.rb