### PR TITLE
Reduce password score from 3 to 2

### DIFF
--- a/app/assets/javascripts/frontend/password-strength-indicator.js
+++ b/app/assets/javascripts/frontend/password-strength-indicator.js
@@ -106,7 +106,7 @@ $(function() {
       password_confirmation_guidance: $('#password-confirmation-guidance'),
       email_field: $emailField,
 
-      strong_passphrase_boundary: 3,
+      strong_passphrase_boundary: 2,
       min_password_length: $passwordField.data('min-password-length'),
 
       update_indicator: function(guidance, strengthScore) {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -205,5 +205,5 @@ Devise.setup do |config|
   # config.authy_remember_device = 1.month
 
   # default devise_zxcvbn minimum password score
-  config.min_password_score = 3
+  config.min_password_score = 2
 end


### PR DESCRIPTION
#### What this PR does:

Reduce the password complexity requirement of the zxcvbn library from 3 to 2.

#### Notes

The `password-strength-indicator.js` has room for improvements, but this is out of the scope of this PR.