### PR TITLE
Hiding go back button on collaborators page when coming from an application/form

### DIFF
--- a/app/views/account/collaborators/index.html.slim
+++ b/app/views/account/collaborators/index.html.slim
@@ -39,7 +39,7 @@ header.page-header.group.page-header-over-sidebar
             footer
               nav.pagination.no-border role="navigation" aria-label="Pagination"
                 ul.group
-                  - if current_user.completed_registration
+                  - unless params.has_key? :form_id
                     li.previous.previous-alternate
                       = link_to contact_settings_account_path, rel: "prev", title: "Navigate to previous part" do
                         span class="pagination-label"


### PR DESCRIPTION
This PR removed the "Go back" button on the collaborators page when user comes from a form

![go_back](https://cloud.githubusercontent.com/assets/758001/16460007/ab24ce7c-3dfb-11e6-831c-8aa1594b6bc9.png)
