### PR TITLE
do not show QAEP’s role for assessor in form

### DIFF
--- a/app/views/admin/assessors/_form.html.slim
+++ b/app/views/admin/assessors/_form.html.slim
@@ -130,17 +130,6 @@
                 collection: Assessor.roles,
                 include_blank: false,
                 label: false
-  .row
-    .col-md-2.col-sm-3
-      = f.label :promotion_role, FormAnswerDecorator::AWARD_TITLES["Enterprise Promotion"]
-    .col-md-2.col-sm-3
-      = f.input :promotion_role,
-                wrapper_html: { class: "form-group" },
-                input_html: { class: "form-control"},
-                as: :select,
-                collection: Assessor.roles,
-                include_blank: false,
-                label: false
 
   br
   .row


### PR DESCRIPTION
as we’re getting rid of references to QAEP

trello card https://trello.com/c/z04S3uff/18-qae16soc-dev-clean-up-code-related-to-old-forms-4