### PR TITLE
Fixing alignment of file uploads

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -55,8 +55,7 @@ module QaePdfForms::General::DrawElements
     base_link_sceleton(
       attachment_path(attachment.file, true),
       attachment.original_filename.truncate(60),
-      description ? description : nil,
-      description_left_margin: 55)
+      description ? description : nil)
 
     move_down 5.mm
   end


### PR DESCRIPTION
Issue was that (according to code) in the past we included an image preview of the file on the left side of the attachment.

So I removed the margin left, aligning the uploads with the websites.