### PR TITLE
update inline the name of the person who submits press book notes

### DIFF
--- a/app/controllers/concerns/press_summary_mixin.rb
+++ b/app/controllers/concerns/press_summary_mixin.rb
@@ -91,7 +91,7 @@ module PressSummaryMixin
 
       format.js do
         if @press_summary.valid?
-          render json: { errors: [] }
+          render "shared/press_summaries/create"
         else
           render status: :unprocessable_entity,
                  json: { errors: @press_summary.errors.full_messages }

--- a/app/views/admin/form_answers/_section_press_summary.html.slim
+++ b/app/views/admin/form_answers/_section_press_summary.html.slim
@@ -3,8 +3,8 @@
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-winners" href="#section-press-summary" aria-expanded="true" aria-controls="section-press-summary"
         ' Press Book Notes
-        - if @form_answer.press_summary_updated_by
-          small
+        small.updated-by
+          - if @form_answer.press_summary_updated_by
             = @form_answer.press_summary_updated_by
   #section-press-summary.section-press-summary.panel-collapse.collapse role="tabpanel" aria-labelledby="press-summary-heading"
     .panel-body

--- a/app/views/shared/press_summaries/create.js.erb
+++ b/app/views/shared/press_summaries/create.js.erb
@@ -1,0 +1,1 @@
+$("#press-summary-heading .updated-by").html("<%= @form_answer.press_summary_updated_by %>");


### PR DESCRIPTION
currently the user needs to refresh the page in order to see the UI change. This commit updates the name in the UI using javascript i.e. inline after the user submits the form

![image002](https://cloud.githubusercontent.com/assets/1407000/17059809/92154120-4fec-11e6-9069-8becfdb313c5.jpg)
