### PR TITLE
Custom admin password score

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    bcrypt (3.1.9)
+    bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.3)
@@ -129,7 +129,7 @@ GEM
     decent_exposure (2.3.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (3.4.1)
+    devise (3.5.10)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -139,9 +139,9 @@ GEM
     devise-authy (1.6.0)
       authy
       devise
-    devise_zxcvbn (1.1.1)
+    devise_zxcvbn (2.1.1)
       devise
-      zxcvbn-ruby (>= 0.0.2)
+      zxcvbn-js (~> 4.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     dotenv (2.1.1)
@@ -392,7 +392,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
-    rake (11.1.2)
+    rake (11.2.2)
     redis (3.2.2)
     redis-actionpack (4.0.0)
       actionpack (~> 4)
@@ -413,8 +413,8 @@ GEM
     redis-store (1.1.4)
       redis (>= 2.2)
     request_store (1.3.1)
-    responders (2.1.0)
-      railties (>= 4.2.0, < 5)
+    responders (2.2.0)
+      railties (>= 4.2.0, < 5.1)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -521,7 +521,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.3)
+    warden (1.2.6)
       rack (>= 1.0)
     webmock (1.21.0)
       addressable (>= 2.3.6)
@@ -530,7 +530,8 @@ GEM
       rails (>= 3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    zxcvbn-ruby (0.0.3)
+    zxcvbn-js (4.2.0.1)
+      execjs
 
 PLATFORMS
   ruby

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -30,4 +30,10 @@ class Admin < ActiveRecord::Base
   def lead_or_assigned?(*)
     true
   end
+
+  private
+
+  def min_password_score
+    3
+  end
 end


### PR DESCRIPTION
#### What this PR does:

- Update devise_zxcvbn gem 
- Set zxcvbn's minimum password score for Admin model to 3

![password-strong](https://cloud.githubusercontent.com/assets/1143421/17338751/3893bf76-58ae-11e6-9f1a-83e2ce0de0ae.png)


#### Notes

I don't know how to create an admin user through the UI.. but I could test this in the rails console and it worked as expected.

To see this error message I had to delete the entries in the `config/locales/en.yml` file overriding the original message.