### PR TITLE
Modify year-end dates only for empty values

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -148,9 +148,11 @@ jQuery ->
 
     # Auto fill the year for previous years
     $(".js-financial-year-changed-dates .js-fy-entries").each ->
-      parent_fy = $(this).parent().find(".js-fy-entries")
-      this_fy_year = fy_year - (parent_fy.size() - parent_fy.index($(this)) - 1)
-      $(this).find("input.js-fy-year").val(this_fy_year)
+      if $(this).find("input.js-fy-year").val() == ""
+        parent_fy = $(this).parent().find(".js-fy-entries")
+        this_year = fy_year - (parent_fy.size() - parent_fy.index($(this)) - 1)
+        $(this).find("input.js-fy-year").val(this_year)
+
     fy_latest_changed_input.find("input").attr("disabled", "disabled")
     $(".js-financial-year-changed-dates").attr("data-year", fy_year)
 


### PR DESCRIPTION
#### What this PR does:

Modify the year end dates values only for those fields which are empty

Before of this change the script modified the previous value entered by the user.


![years](https://cloud.githubusercontent.com/assets/1143421/18021597/3e048e64-6bae-11e6-98ca-af8c668447b4.gif)
