### PR TITLE
Prefill application background

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -219,6 +219,19 @@ class FormAnswer < ActiveRecord::Base
     end
   end
 
+  def application_background
+    case award_type
+    when "trade"
+      document["trade_goods_briefly"]
+    when "innovation"
+      document["innovation_desc_short"]
+    when "development"
+      document["development_management_approach_briefly"]
+    when "mobility"
+      document["mobility_desc_short"]
+    end
+  end
+
   def need_to_save_version?
     true
   end

--- a/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
@@ -10,10 +10,11 @@
         - else
           em.text-muted No comment has been added yet.
       .clear
-
     = f.input :application_background_section_desc,
               wrapper_html: { class: "form-group" },
-              input_html: { class: "form-control", rows: 10 },
+              input_html: { class: "form-control", 
+                            rows: 10, 
+                            value: f.object.application_background_section_desc.presence || resource.application_background },
               as: :text,
               label: false
 

--- a/spec/models/form_answer_spec.rb
+++ b/spec/models/form_answer_spec.rb
@@ -55,6 +55,32 @@ RSpec.describe FormAnswer, type: :model do
     end
   end
 
+  describe "#application_background" do
+    it "returns the trade_goods_briefly value if is type trade" do
+      document = {trade_goods_briefly: "International Trade"}
+      form = build(:form_answer, :trade, document: document)
+      expect(form.application_background).to eq("International Trade")
+    end
+
+    it "returns the trade_goods_briefly value if is type innovation" do
+      document = {innovation_desc_short: "Innovation"}
+      form = build(:form_answer, :innovation, document: document)
+      expect(form.application_background).to eq("Innovation")
+    end
+
+    it "returns the trade_goods_briefly value if is type development" do
+      document = {development_management_approach_briefly: "Development"}
+      form = build(:form_answer, :development, document: document)
+      expect(form.application_background).to eq("Development")
+    end
+
+    it "returns the trade_goods_briefly value if is type mobility" do
+      document = {mobility_desc_short: "Mobility"}
+      form = build(:form_answer, :mobility, document: document)
+      expect(form.application_background).to eq("Mobility")
+    end
+  end
+
   describe "#company_or_nominee_from_document" do
     subject { build(:form_answer, kind, document: doc) }
     let(:c_name) { "company name" }


### PR DESCRIPTION
This PR adds a new method to return the application background to the `FormAnswer` model, to be displayed in the assessment section, the application background.