### PR TITLE
Taking case summary out of assessment section, and making it as well as the feedback section visible at all times

### DIFF
--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -1,5 +1,9 @@
 @import "mixins";
 
+.panel-subtitle-small {
+  margin-bottom: 5px;
+}
+
 .applications-filter {
   margin-bottom: 20px;
 

--- a/app/helpers/partials_visibility_helper.rb
+++ b/app/helpers/partials_visibility_helper.rb
@@ -12,8 +12,12 @@ module PartialsVisibilityHelper
     @form_answer.awarded? || @form_answer.recommended? || @form_answer.reserved?
   end
 
+  def show_case_summary_section?
+    admin_lead_or_primary?
+  end
+
   def show_feedback_section?
-    @form_answer.unsuccessful? && !@form_answer.promotion? &&
+    !@form_answer.promotion? &&
       admin_lead_or_primary?
   end
 

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -1,11 +1,13 @@
 - if visible_case_summaries(current_subject, resource)
   - visible_case_summaries(current_subject, resource).each do |assessment_obj|
     - assessment = assessment_obj.assessment
-    .panel.panel-default
+    .panel.panel-parent
       .panel-heading role="tab" id="case-summary-heading-#{assessment.position}"
         h4.panel-title
-          a data-toggle="collapse" data-parent="#panel-assessment" href="#section-case-summary-#{assessment.position}" aria-expanded="true" aria-controls="section-case-summary-#{assessment.position}"
-            = assessment_obj.title
+          a data-toggle="collapse" href="#section-case-summary-#{assessment.position}" aria-expanded="true" aria-controls="section-case-summary-#{assessment.position}"
+            ' Case Summary (for recommended or reserved applications only)
+            small.panel-subtitle-small
+              | This will be presented to the panel members and is used when making the final decision
             - if assessment.editable.present?
               small
                 = "Updated by #{assessment.editable.decorate.full_name} - #{format_date(assessment.updated_at)}"

--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -25,14 +25,18 @@
           = render "admin/form_answers/section_appraisal_form_primary"
           = render "admin/form_answers/section_appraisal_form_secondary"
           = render "section_appraisal_form_moderated"
-          = render "section_case_summary"
+
+  - if show_case_summary_section?
+    = render "section_case_summary"
 
   - if show_feedback_section?
     .panel.panel-default.panel-parent
       .panel-heading#feedback-heading role="tab"
         h4.panel-title
           a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-feedback" aria-expanded="true" aria-controls="section-feedback"
-            ' Feedback
+            ' Feedback (for not recommended applications only)
+            small.panel-subtitle-small
+              | This will be sent  to the applicants to help improve their business and/or future award applications
             - if @form_answer.feedback_updated_by
               small
                 = @form_answer.feedback_updated_by

--- a/app/views/assessor/form_answers/_submitted_view.html.slim
+++ b/app/views/assessor/form_answers/_submitted_view.html.slim
@@ -28,15 +28,21 @@
             = render "admin/form_answers/section_appraisal_form_secondary"
           - if show_section_appraisal_moderated?
             = render "admin/form_answers/section_appraisal_form_moderated"
-          - if show_section_case_summary?
-            = render "admin/form_answers/section_case_summary"
+
+  - if show_case_summary_section?
+    = render "admin/form_answers/section_case_summary"
 
   - if show_feedback_section?
     .panel.panel-default.panel-parent
       .panel-heading#feedback-heading role="tab"
         h4.panel-title
           a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-feedback" aria-expanded="true" aria-controls="section-feedback"
-            ' Feedback
+            ' Feedback (for not recommended applications only)
+            small.panel-subtitle-small
+              | This will be sent  to the applicants to help improve their business and/or future award applications
+            - if @form_answer.feedback_updated_by
+              small
+                = @form_answer.feedback_updated_by
       #section-feedback.section-application-info.panel-collapse.collapse role="tabpanel" aria-labelledby="feedback-heading"
         .panel-body
           = render "admin/feedbacks/section", form_answer: @form_answer


### PR DESCRIPTION
This PR does the following:

- Move case summary out of the Assessment header and into its own header
- Make the feedback header visible at all stages throughout the application process
- Add the new help copy for both case summary and feedback headers (ensure you still leave room for the "updated by:..." section

![feedback_and_case_summary](https://cloud.githubusercontent.com/assets/758001/18139643/b6799276-6f88-11e6-9a6b-d986c8583c5b.png)
