### PR TITLE
[Hotfix] Case summaries for lead assessors

### DIFF
--- a/app/controllers/assessor/reports_controller.rb
+++ b/app/controllers/assessor/reports_controller.rb
@@ -14,6 +14,18 @@ class Assessor::ReportsController < Assessor::BaseController
       format.csv do
         send_data resource.as_csv, type: "text/csv"
       end
+
+      format.pdf do
+        pdf = Reports::AdminReport.new(params[:id], @award_year, params).as_pdf
+
+        if pdf[:hard_copy].blank? || Rails.env.development?
+          send_data pdf.data,
+                    filename: pdf.filename,
+                    type: "application/pdf"
+        else
+          redirect_to pdf.data
+        end
+      end
     end
   end
 

--- a/app/views/assessor/reports/_assessors_progress.html.slim
+++ b/app/views/assessor/reports/_assessors_progress.html.slim
@@ -1,17 +1,12 @@
 .well
   h2
-    ' Assessor's Progress Report
+    ' Assessor's Progress Reports
   ul.list-unstyled.list-actions
     - FormAnswer::AWARD_TYPE_FULL_NAMES.select { |key, value| current_assessor.lead_roles.include?(key) }.each do |key, value|
       - file_name = value.gsub(" ", "-").downcase
       - year = "#{(@award_year.year - 1).to_s[2..-1]}-#{@award_year.year.to_s[2..-1]}"
       li
-        .pull-right
-          = link_to assessor_report_path("assessors-progress-#{file_name}-#{year}", category: key, format: :csv, year: @award_year.year)
-            span.glyphicon.glyphicon-download-alt
-            span.visible-lg.visible-md
-              ' Download
         = link_to assessor_report_path("assessors-progress-#{file_name}-#{year}", category: key, format: :csv, year: @award_year.year), class: "action-title"
-          span.glyphicon.glyphicon-file
+          span.glyphicon.glyphicon-download
           = value
   .clear

--- a/app/views/assessor/reports/_case_status_report.html.slim
+++ b/app/views/assessor/reports/_case_status_report.html.slim
@@ -2,12 +2,7 @@
   h2
   ul.list-unstyled.list-actions
     li
-      .pull-right
-        = link_to assessor_report_path("cases-status", format: :csv, year: @award_year.year) do
-          span.glyphicon.glyphicon-download-alt
-          span.visible-lg.visible-md
-            ' Download
       = link_to assessor_report_path("cases-status", format: :csv, year: @award_year.year), class: "action-title" do
-        span.glyphicon.glyphicon-file
+        span.glyphicon.glyphicon-download
         | Case status report
   .clear

--- a/app/views/assessor/reports/_case_summaries.html.slim
+++ b/app/views/assessor/reports/_case_summaries.html.slim
@@ -4,12 +4,8 @@
   ul.list-unstyled.list-actions
     - FormAnswer::AWARD_TYPE_FULL_NAMES.select { |key, value| current_assessor.lead_roles.include?(key) }.each do |key, value|
       li
-        .pull-right
-          = link_to assessor_report_path("case_summaries", category: key, format: :pdf, year: @award_year.year), target: admin_conditional_aggregated_pdf_link_target(@award_year, 'case_summary')
-            span.glyphicon.glyphicon-download-alt
-            span.visible-lg.visible-md
-              ' Download
         = link_to assessor_report_path("case_summaries", category: key, format: :pdf, year: @award_year.year), class: "action-title", target: admin_conditional_aggregated_pdf_link_target(@award_year, 'case_summary')
-          span.glyphicon.glyphicon-file
+          span.glyphicon.glyphicon-download
+          span.visible-lg.visible-md
           = value
   .clear

--- a/app/views/assessor/reports/_case_summaries.html.slim
+++ b/app/views/assessor/reports/_case_summaries.html.slim
@@ -1,0 +1,15 @@
+.well
+  h2
+    ' Case Summaries
+  ul.list-unstyled.list-actions
+    - FormAnswer::AWARD_TYPE_FULL_NAMES.select { |key, value| current_assessor.lead_roles.include?(key) }.each do |key, value|
+      li
+        .pull-right
+          = link_to assessor_report_path("case_summaries", category: key, format: :pdf, year: @award_year.year), target: admin_conditional_aggregated_pdf_link_target(@award_year, 'case_summary')
+            span.glyphicon.glyphicon-download-alt
+            span.visible-lg.visible-md
+              ' Download
+        = link_to assessor_report_path("case_summaries", category: key, format: :pdf, year: @award_year.year), class: "action-title", target: admin_conditional_aggregated_pdf_link_target(@award_year, 'case_summary')
+          span.glyphicon.glyphicon-file
+          = value
+  .clear

--- a/app/views/assessor/reports/index.html.slim
+++ b/app/views/assessor/reports/index.html.slim
@@ -7,3 +7,4 @@ br
     - if policy(:report).show?
       = render "assessor/reports/case_status_report"
       = render "assessor/reports/assessors_progress"
+      = render "assessor/reports/case_summaries"


### PR DESCRIPTION
This is a hotfix to allow the lead assessors download the case summaries

It also updates the views.


![reports](https://cloud.githubusercontent.com/assets/1143421/18141552/8e90c170-6f7f-11e6-98b6-9611614e3988.gif)
