### PR TITLE
Fixing date format on year dates questions

### DIFF
--- a/app/form_pointers/financial_table.rb
+++ b/app/form_pointers/financial_table.rb
@@ -41,21 +41,13 @@ module FinancialTable
       corrected_result << if entry.size == 6 && (index + 1) != res.size
         year = last_year - (res.size - (index + 1))
         entry += year.to_s
-        fix_day_month_format(entry)
+        entry
       else
-        fix_day_month_format(entry)
+        entry
       end
     end
 
-    corrected_result
-  end
-
-  def fix_day_month_format(date)
-    parts = date.split("/")
-    day = parts[0].rjust(2, "0")
-    month = parts[1].rjust(2, "0")
-
-    "#{day}/#{month}/#{parts[2]}"
+    corrected_result.map { |string_date| Date.parse(string_date).strftime("%d/%m/%Y") }
   end
 
   def financial_table_pointer_headers

--- a/app/form_pointers/financial_table.rb
+++ b/app/form_pointers/financial_table.rb
@@ -41,13 +41,21 @@ module FinancialTable
       corrected_result << if entry.size == 6 && (index + 1) != res.size
         year = last_year - (res.size - (index + 1))
         entry += year.to_s
-        entry
+        fix_day_month_format(entry)
       else
-        entry
+        fix_day_month_format(entry)
       end
     end
 
     corrected_result
+  end
+
+  def fix_day_month_format(date)
+    parts = date.split("/")
+    day = parts[0].rjust(2, "0")
+    month = parts[1].rjust(2, "0")
+
+    "#{day}/#{month}/#{parts[2]}"
   end
 
   def financial_table_pointer_headers


### PR DESCRIPTION
The en dates per year questions don't validate if user is typing "05". So on PDFs the dates end up being not "padded".

This PR addresses that by padding the day and month of these dates.