### PR TITLE
[WIP] Display audit log in admin area

### DIFF
--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -8,6 +8,7 @@ class Admin::FormAnswersController < Admin::BaseController
     :update_financials,
     :remove_audit_certificate
   ]
+  before_action :load_versions, only: :show
 
   skip_after_action :verify_authorized, only: [:awarded_trade_applications]
 
@@ -64,5 +65,9 @@ class Admin::FormAnswersController < Admin::BaseController
 
   def resource
     @form_answer ||= load_resource
+  end
+
+  def load_versions
+    @versions = FormAnswerVersionsDispatcher.new(@form_answer).versions
   end
 end

--- a/app/services/form_answer_versions_dispatcher.rb
+++ b/app/services/form_answer_versions_dispatcher.rb
@@ -1,0 +1,47 @@
+class FormAnswerVersionsDispatcher
+  def initialize(form_answer)
+    @form_answer = form_answer
+  end
+
+  def versions
+    @form_answer.versions.map do |version|
+      Version.new(version, whodunnit_hash)
+    end
+  end
+
+  private
+
+  def whodunnit_hash
+    @whodunnit_hash ||= begin
+      keys = @form_answer.versions.map(&:whodunnit).uniq.compact
+      Hash[keys.map { |key| [key, get_full_name(key)] }]
+    end
+  end
+
+  def get_full_name(whodunnit_key)
+    klass, id = whodunnit_key.split(":")
+    klass.capitalize.constantize.find(id).decorate.full_name
+  end
+
+  class Version
+    attr_reader :version, :whodunnit_hash
+
+    def initialize(version, whodunnit_hash)
+      @version = version
+      @whodunnit_hash = whodunnit_hash
+    end
+
+    def event
+      "#{version.event.capitalize}d"
+    end
+
+    def created_at
+      version.created_at.strftime("%d/%m/%Y at %H:%M")
+    end
+
+    def whodunnit
+      return "N/A" unless version.whodunnit
+      whodunnit_hash[version.whodunnit]
+    end
+  end
+end

--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -57,3 +57,13 @@
               = render "section_press_summary"
             - if show_palace_attendees_subsection?
               = render "section_palace_attendees"
+
+  .panel.panel-default.panel-parent
+    .panel-heading#logs-heading role="tab"
+      h4.panel-title
+        a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-logs" aria-expanded="true" aria-controls="section-logs"
+          ' Audit Log
+    #section-logs.section-application-info.panel-collapse.collapse role="tabpanel" aria-labelledby="logs-heading"
+      .panel-body
+        - @versions.reverse_each do |version|
+          p #{version.event} on #{version.created_at} by #{version.whodunnit}


### PR DESCRIPTION
This PR adds a section to see all the version a `FormAnswer` ( Application ) has.

We are using the versions that the gem `papertrail` creates, now is possible this is not the best solution because we will have a change/version everytime the record is updated.

We cannot display where is the change was made in the form because this information is stored in a `hstore` attribute called `document` so it will show all the old json vs the new one instead of only the changes. This is for the fields in the document.

For now we are displaying when the form answer was created and updated.

![logs](https://cloud.githubusercontent.com/assets/1143421/18336642/93a087f2-754e-11e6-9a3e-631a69e2994e.gif)


Any feedback will be appreciated.