### PR TITLE
fix 500 error in form paginator

### DIFF
--- a/app/value_objects/form_paginator.rb
+++ b/app/value_objects/form_paginator.rb
@@ -42,11 +42,11 @@ class FormPaginator
   end
 
   def first?
-    position == 0
+    !position || position == 0
   end
 
   def last?
-    position == ids.count - 1
+    !position || position == ids.count - 1
   end
 
   private


### PR DESCRIPTION
when form answer no longer meets the search requirements position can become nil

https://sentry.io/bit-zesty-client-apps/qae/issues/170196249/