### PR TITLE
Admins and Assessors: soft delete implementation

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -33,6 +33,13 @@ class Admin::AdminsController < Admin::UsersController
     respond_with :admin, @resource, location: admin_admins_path
   end
 
+  def destroy
+    authorize @resource, :destroy?
+    @resource.soft_delete!
+
+    respond_with :admin, @resource, location: admin_admins_path
+  end
+
   # NOTE: debug abilities for Admin - BEGIN
   def login_as_assessor
     authorize Admin, :index?

--- a/app/controllers/admin/assessors_controller.rb
+++ b/app/controllers/admin/assessors_controller.rb
@@ -36,7 +36,8 @@ class Admin::AssessorsController < Admin::UsersController
 
   def destroy
     authorize @resource, :destroy?
-    @resource.destroy
+    @resource.soft_delete!
+
     respond_with :admin, @resource, location: admin_assessors_path
   end
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -14,4 +14,15 @@ module AdminHelper
       ""
     end
   end
+
+  def comment_author(entry)
+    author = entry.author
+
+    if author.present?
+      base = author.email
+      base += " (deleted account)" if author.deleted?
+    else
+      "Author deleted"
+    end
+  end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -12,6 +12,8 @@ class Admin < ActiveRecord::Base
 
   has_many :form_answer_attachments, as: :attachable
 
+  default_scope { where(deleted: false) }
+
   pg_search_scope :basic_search,
                   against: [
                     :first_name,
@@ -29,6 +31,14 @@ class Admin < ActiveRecord::Base
 
   def lead_or_assigned?(*)
     true
+  end
+
+  def active_for_authentication?
+    super && !deleted?
+  end
+
+  def soft_delete!
+    update_column(:deleted, true)
   end
 
   private

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -42,6 +42,8 @@ class Assessor < ActiveRecord::Base
                     }
                   }
 
+  default_scope { where(deleted: false) }
+
   scope :by_email, -> { order(:email) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
 
@@ -51,6 +53,10 @@ class Assessor < ActiveRecord::Base
         where("#{award_category}_role" => role)
       }
     end
+  end
+
+  def active_for_authentication?
+    super && !deleted?
   end
 
   def self.roles
@@ -134,6 +140,10 @@ class Assessor < ActiveRecord::Base
 
   def secondary?(form_answer)
     form_answer.assessor_assignments.secondary.assessor_id == id
+  end
+
+  def soft_delete!
+    update_column(:deleted, true)
   end
 
   private

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,6 +15,10 @@ class Comment < ActiveRecord::Base
     authorable == subject
   end
 
+  def author
+    authorable_type.constantize.unscoped.where(id: authorable_id).first
+  end
+
   def self.admin
     where(section: 0).order(created_at: :desc)
   end

--- a/app/views/admin/form_answers/_comment.html.slim
+++ b/app/views/admin/form_answers/_comment.html.slim
@@ -14,7 +14,8 @@
 
   .comment-header
     h3
-      = comment.authorable.present? ? comment.author_email : "Author deleted"
+      = comment_author(comment)
+
       span.pull-right.if-no-js-hide
         - if comment.author?(current_subject)
           = link_to "#", class: "link-delete-comment"

--- a/app/views/admin/form_answers/_comment_read_only.html.slim
+++ b/app/views/admin/form_answers/_comment_read_only.html.slim
@@ -1,7 +1,7 @@
 .comment class="#{'comment-flagged' if comment_read_only.flagged?}"
   .comment-header
     h3
-      = comment.authorable.present? ? comment.author_email : "Author deleted"
+      = comment_author(comment_read_only)
 
   .comment-content
     = qae_simple_format comment_read_only.body

--- a/db/migrate/20161021111201_add_deleted_to_assessors.rb
+++ b/db/migrate/20161021111201_add_deleted_to_assessors.rb
@@ -1,0 +1,5 @@
+class AddDeletedToAssessors < ActiveRecord::Migration
+  def change
+    add_column :assessors, :deleted, :boolean, default: :false
+  end
+end

--- a/db/migrate/20161021140457_add_deleted_to_admins.rb
+++ b/db/migrate/20161021140457_add_deleted_to_admins.rb
@@ -1,0 +1,5 @@
+class AddDeletedToAdmins < ActiveRecord::Migration
+  def change
+    add_column :admins, :deleted, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -107,7 +107,8 @@ CREATE TABLE admins (
     failed_attempts integer DEFAULT 0 NOT NULL,
     unlock_token character varying,
     locked_at timestamp without time zone,
-    superadmin boolean DEFAULT false
+    superadmin boolean DEFAULT false,
+    deleted boolean DEFAULT false
 );
 
 
@@ -3935,4 +3936,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160804175527');
 INSERT INTO schema_migrations (version) VALUES ('20160906174550');
 
 INSERT INTO schema_migrations (version) VALUES ('20161021111201');
+
+INSERT INTO schema_migrations (version) VALUES ('20161021140457');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -237,7 +237,8 @@ CREATE TABLE assessors (
     unlock_token character varying,
     locked_at timestamp without time zone,
     company character varying,
-    mobility_role character varying
+    mobility_role character varying,
+    deleted boolean DEFAULT false
 );
 
 
@@ -3932,4 +3933,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160804175513');
 INSERT INTO schema_migrations (version) VALUES ('20160804175527');
 
 INSERT INTO schema_migrations (version) VALUES ('20160906174550');
+
+INSERT INTO schema_migrations (version) VALUES ('20161021111201');
 


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/V1MZtZ7I/543-qae16imp-cloudflare-error-message-caused-by-viewing-old-applications-that-have-comments-from-assessors-who-have-since-been-delet) 