### PR TITLE
don't filter user applications by state on post submission partial

### DIFF
--- a/app/models/form_answer_transition.rb
+++ b/app/models/form_answer_transition.rb
@@ -1,15 +1,6 @@
 class FormAnswerTransition < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordTransition
 
-  POSSIBLE_STATES_BEFORE_SHORTLISED_STAGE = [
-    "assessment_in_progress",
-    "submitted",
-    "not_submitted",
-    "application_in_progress",
-    "reserved",
-    "recommended"
-  ]
-
   belongs_to :form_answer, inverse_of: :form_answer_transitions
 
   def transitable

--- a/app/views/content_only/post_submission/_submitted.html.slim
+++ b/app/views/content_only/post_submission/_submitted.html.slim
@@ -1,19 +1,17 @@
-- applications = FormAnswerDecorator.decorate_collection(award_applications.where(state: FormAnswerTransition::POSSIBLE_STATES_BEFORE_SHORTLISED_STAGE))
-- if applications.present?
-  - applications.each do |award|
-    .container-split.award-list
-      .content-left
-        h3
-          = award.application_name
-          small
-            = award.award_type_full_name
-            '  Award
-      .content-right.content-offset-24
-        p
-          ' Your
-          - link_name = award.promotion? ? "nomination" : "application"
-          => link_to link_name, edit_form_url(award.id)
-          / ' is currently being assessed.
-      .clear
-  br
-  br
+- applications = FormAnswerDecorator.decorate_collection(award_applications)
+- applications.each do |award|
+  .container-split.award-list
+    .content-left
+      h3
+        = award.application_name
+        small
+          = award.award_type_full_name
+          '  Award
+    .content-right.content-offset-24
+      p
+        ' Your
+        - link_name = award.promotion? ? "nomination" : "application"
+        => link_to link_name, edit_form_url(award.id)
+    .clear
+br
+br


### PR DESCRIPTION
https://trello.com/c/ivgpEKD5/1227-qae16imp-after-submission-deadline-applicants-should-still-be-able-to-view-their-application