### PR TITLE
[Admin - Entries Report] fixed missing 'Employees' values for Mobility form

### DIFF
--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -159,8 +159,8 @@ module Reports::DataPickers::FormDocumentPicker
           "5 plus" => "#{attr_name}_5of5"
         }
       },
-      "mobility" => { # CHECK: delete if not needed
-        "development_performance_years" => {
+      "mobility" => {
+        "programme_performance_years" => {
           "2 to 4" => "#{attr_name}_2of2",
           "5 plus" => "#{attr_name}_5of5"
         }


### PR DESCRIPTION
[TRELLO STORY](https://trello.com/c/qwyF33VY/1430-qae16imp-entries-report-promoting-opportunity-employee-numbers-field-not-populated)