### PR TITLE
Popup to confirm changes when changing deadlines

### DIFF
--- a/app/assets/javascripts/admin/settings.js.coffee
+++ b/app/assets/javascripts/admin/settings.js.coffee
@@ -1,9 +1,90 @@
 # require jquery-ui
+
+class DeadlineForm
+  constructor: (el) ->
+    @form = el
+    @hasChanged = false
+    @init()
+
+  init: ->
+    @createModal()
+    @gatherInitialValues()
+    @bindEvents()
+
+  createModal: ->
+    html = """
+<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-body">
+        <p>
+          This could change the current status of the application and affect all users.
+        </p>
+        <p>
+          Are you sure you want to change the date?
+        </p>
+
+        <br />
+
+        <p>
+          <button type="button" class="btn btn-primary confirm-date-change">Yes, change the date</button>
+          <button type="button" class="btn btn-link" data-dismiss="modal">Cancel</button>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+    """
+
+    @modal = $(html)
+
+  gatherInitialValues: ->
+    @date = @form.find("input.datepicker").val()
+    @time = @form.find("input.timepicker").val()
+
+  bindEvents: ->
+    @form.find("input.datepicker").on "change", (e) =>
+      if e.target.value != @date and @date
+        @hasChanged = true
+
+    @form.find("input.timepicker").on "change", (e) =>
+      if e.target.value != @time and @time
+        @hasChanged = true
+
+    @form.on "click", ".btn-submit", (e) =>
+      if @hasChanged
+        e.preventDefault()
+
+        @showConfirmationModal()
+      else
+        @form.submit()
+
+    @modal.on "click", ".confirm-date-change", (e) =>
+      e.preventDefault()
+
+      @modal.modal("hide")
+
+      @form.submit()
+
+    @form.on "ajax:saved", =>
+      @reset()
+
+  showConfirmationModal: ->
+    @modal.modal("show")
+
+  reset: ->
+    @hasChanged = false
+    @gatherInitialValues()
+
+
 jQuery ->
   if (settingsWrapper = ($ "#admin-settings-parent")).length
     ($ ".deadline-form").addClass("hidden")
     ($ ".notification-edit-form, .notification-form").addClass("hidden")
     ($ ".email-example").addClass("hidden")
+
+    ($ "form.edit_deadline").each ->
+      new DeadlineForm($(@))
 
     settingsWrapper.on "click", ".edit-deadline", (e) ->
       e.preventDefault()

--- a/app/views/admin/deadlines/update.js.erb
+++ b/app/views/admin/deadlines/update.js.erb
@@ -1,6 +1,7 @@
 wrapper = $("#deadline-" + "<%= @deadline.id %>");
 
 <% if @deadline.valid? %>
+  $("form.edit_deadline", wrapper).trigger("ajax:saved");
   $(".form-value", wrapper).removeClass("hidden");
   $(".deadline-form", wrapper).addClass("hidden");
   $(".edit-deadline", wrapper).removeClass("hidden");

--- a/app/views/admin/settings/_deadline_form.html.slim
+++ b/app/views/admin/settings/_deadline_form.html.slim
@@ -14,7 +14,7 @@
                   input_html: { id: '' }
       .control-action
         = link_to "Cancel", "#", class: "btn btn-default btn-cancel if-no-js-hide"
-        = f.submit "Save", class: "btn btn-primary btn-submit"
+        input type="button" value="Save" class="btn btn-primary btn-submit"
       .clear
 
   = link_to "Edit", "#", class: "edit-deadline if-no-js-hide"


### PR DESCRIPTION
In the settings page, now whenever a form is "submitted", we prevent it from submitting if dates have changed and display a modal to confirm the changes.

![mant8vpadf](https://cloud.githubusercontent.com/assets/758001/23404408/964930d0-fd93-11e6-9f34-776a01bd7aa0.gif)
