### PR TITLE
clean infected files

### DIFF
--- a/app/models/audit_certificate.rb
+++ b/app/models/audit_certificate.rb
@@ -1,7 +1,9 @@
 class AuditCertificate < ActiveRecord::Base
-
   mount_uploader :attachment, AuditCertificateUploader
   scan_file      :attachment
+
+  include ::InfectedFileCleaner
+  clean_after_scan :attachment
 
   begin :associations
     belongs_to :form_answer
@@ -12,6 +14,7 @@ class AuditCertificate < ActiveRecord::Base
     validates :form_answer_id, uniqueness: true,
                                presence: true
     validates :attachment, presence: true,
+                           on: :create,
                            file_size: {
                              maximum: 5.megabytes.to_i
                            }

--- a/app/models/concerns/infected_file_cleaner.rb
+++ b/app/models/concerns/infected_file_cleaner.rb
@@ -1,0 +1,26 @@
+module InfectedFileCleaner
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def clean_after_scan(*file_attr_names)
+      file_attr_names.each do |attr_name|
+        override_on_scan_callback(attr_name)
+      end
+    end
+
+    def override_on_scan_callback(file_attr_name)
+      class_eval <<-EVAL, __FILE__, __LINE__+1
+        def on_scan_#{file_attr_name}_with_cleanup(params)
+          on_scan_#{file_attr_name}_without_cleanup(params)
+
+          if #{file_attr_name}_scan_results == "infected"
+            public_send("remove_#{file_attr_name}!")
+            save!
+          end
+        end
+
+        alias_method_chain :on_scan_#{file_attr_name}, :cleanup
+      EVAL
+    end
+  end
+end

--- a/app/models/form_answer_attachment.rb
+++ b/app/models/form_answer_attachment.rb
@@ -1,10 +1,12 @@
 class FormAnswerAttachment < ActiveRecord::Base
-
   belongs_to :form_answer
   belongs_to :attachable, polymorphic: true
 
   mount_uploader :file, FormAnswerAttachmentUploader
   scan_file      :file
+
+  include ::InfectedFileCleaner
+  clean_after_scan :file
 
   scope :uploaded_by_user, -> { where attachable_type: "User" }
   scope :uploaded_not_by_user, -> { where.not(attachable_type: "User") }
@@ -26,6 +28,7 @@ class FormAnswerAttachment < ActiveRecord::Base
   begin :validations
     validates :form_answer_id, presence: true
     validates :file, presence: true,
+                     on: :create,
                      file_size: {
                        maximum: 5.megabytes.to_i
                      }

--- a/app/models/support_letter_attachment.rb
+++ b/app/models/support_letter_attachment.rb
@@ -2,6 +2,9 @@ class SupportLetterAttachment < ActiveRecord::Base
   mount_uploader :attachment, FormAnswerAttachmentUploader
   scan_file :attachment
 
+  include ::InfectedFileCleaner
+  clean_after_scan :attachment
+
   begin :associations
     belongs_to :user
     belongs_to :form_answer
@@ -11,6 +14,7 @@ class SupportLetterAttachment < ActiveRecord::Base
   begin :validations
     validates :form_answer, :user, presence: true
     validates :attachment, presence: true,
+                           on: :create,
                            file_size: {
                              maximum: 5.megabytes.to_i
                            }


### PR DESCRIPTION
When an uploaded file is scanned and detected as a virus it is removed from the server immediately, preventing other users from being able to download it and preventing it from being executed on the server itself.