### PR TITLE
populate feedback with submitted primary appraisal

### DIFF
--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -36,6 +36,8 @@
             ' Feedback (for not recommended applications only)
             small.panel-subtitle-small
               | This will be sent  to the applicants to help improve their business and/or future award applications
+              br
+              | Note: this section is pre-populated with the Primary appraisal, so it can be eddited if necessary
             - if @form_answer.feedback_updated_by
               small
                 = @form_answer.feedback_updated_by

--- a/spec/services/assessment_submission_service_spec.rb
+++ b/spec/services/assessment_submission_service_spec.rb
@@ -48,6 +48,50 @@ describe AssessmentSubmissionService do
       expect(form_answer.reload.state).to eq("not_recommended")
     end
   end
+
+  context "feedback pre-population" do
+    let(:assessment) { form_answer.assessor_assignments.primary }
+
+    before do
+      assessment.assessor = assessor
+
+      assessment.document = {
+        overseas_earnings_growth_desc: "Good",
+        overseas_earnings_growth_rate: "positive",
+        commercial_success_desc: "Mild",
+        commercial_success_rate: "average",
+        strategy_desc: "Good",
+        strategy_rate: "positive",
+        corporate_social_responsibility_desc: "Bad",
+        corporate_social_responsibility_rate: "negative",
+        verdict_desc: "Mild",
+        verdict_rate: "average"
+      }
+
+      assessment.save!
+    end
+
+    it "pre-populates feedback" do
+      subject.perform
+
+      feedback = form_answer.feedback
+      expect(feedback).to be
+
+      expected_document = {
+        "overseas_earnings_growth_strength" => "Good",
+        "overseas_earnings_growth_weakness" => "",
+        "commercial_success_weakness" => "Mild",
+        "commercial_success_strength" => "",
+        "strategy_strength" => "Good",
+        "strategy_weakness" => "",
+        "corporate_social_responsibility_weakness" => "Bad",
+        "corporate_social_responsibility_strength" => "",
+        "overall_summary" => "Mild"
+      }
+
+      expect(feedback.document).to eq(expected_document)
+    end
+  end
 end
 
 def expect_to_submit


### PR DESCRIPTION
1) Only populate when the appraisals are confirmed/submitted by lead assessor
2) If they get unsubmitted, edited, resubmitted - then update the feedback accordignly
3) If RAG is G, populate Key Strength, else populate Information to strengthen the application
4) Overall verdict goes to Overall Summary
5) Add extra help copy to the section header