### PR TITLE
hide user links for admins

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -58,18 +58,16 @@
             ' Queen's Awards for Enterprise
           - if current_admin || current_user || current_assessor
             ul#proposition-links
-              - if current_admin || current_user.try(:completed_registration)
+              - if !current_admin && current_user.try(:completed_registration)
                 li
                   = link_to "Applications", dashboard_path
                 li
                   = link_to "Account details", correspondent_details_account_path
                 li
                   = link_to "Collaborators", account_collaborators_path
-              li
-                - if current_admin
-                  = link_to "Sign out", destroy_admin_session_path, method: :delete
-                - else
-                  = link_to "Sign out", destroy_user_session_path, method: :delete
+                - unless current_admin
+                  li
+                    = link_to "Sign out", destroy_user_session_path, method: :delete
 
 - content_for :inside_header do
   - if landing_page?


### PR DESCRIPTION
As an Admin/Assessor I don't want to be able to see or interact with the main menu CTAs when I view a user's application online, so I don't accidentally try and access a user's account when I am trying to access my own account