### PR TITLE
Making sortable table heading arrow always visible

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -924,14 +924,11 @@ table .ellipsis {
     background-position: right center;
     background-size: 10px 6px;
     color: $black;
+    background-image: image-url("icon-arrow-sort-down-grey.png");
+    text-decoration: none;
 
-    &:hover {
-      background-image: image-url("icon-arrow-sort-down-grey.png");
-      text-decoration: none;
-
-      @include is-retina {
-        background-image: image-url("icon-arrow-sort-down-grey@2.png");
-      }
+    @include is-retina {
+      background-image: image-url("icon-arrow-sort-down-grey@2.png");
     }
 
     &.ordered {


### PR DESCRIPTION
Before it was only visible on hover

![o9k2puorct](https://cloud.githubusercontent.com/assets/758001/24750156/40975650-1a9c-11e7-83dd-0643138d5f88.gif)
