### PR TITLE
hide user links for both admin and assessor

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -56,18 +56,17 @@
         nav#proposition-menu
           a#proposition-name href="/"
             ' Queen's Awards for Enterprise
-          - if current_admin || current_user || current_assessor
+          - if current_user && !current_admin && !current_assessor
             ul#proposition-links
-              - if !current_admin && current_user.try(:completed_registration)
+              - if current_user.try(:completed_registration)
                 li
                   = link_to "Applications", dashboard_path
                 li
                   = link_to "Account details", correspondent_details_account_path
                 li
                   = link_to "Collaborators", account_collaborators_path
-                - unless current_admin
-                  li
-                    = link_to "Sign out", destroy_user_session_path, method: :delete
+              li
+                = link_to "Sign out", destroy_user_session_path, method: :delete
 
 - content_for :inside_header do
   - if landing_page?


### PR DESCRIPTION
display sign out link for user even if registration is not completed

https://trello.com/c/ukSESHae/539-qae17imp-as-an-admin-assessor-i-don-t-want-to-be-able-to-see-or-interact-with-the-main-menu-ctas-when-i-view-a-user-s-applicatio