### PR TITLE
Updating designs to match new designs by GDS

### DIFF
--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -94,11 +94,11 @@
     $ipad-height: 1024px;
 
     @mixin is-ios {
-      @media only screen and (min-device-width : $iphone-width) and (max-device-width : $iphone-old-height) and (orientation : landscape), 
-      only screen and (min-device-height : $iphone-width) and (max-device-height : $iphone-old-height) and (orientation : portrait), 
-      only screen and (min-device-width : $iphone-width) and (max-device-width : $iphone-height) and (orientation : landscape), 
-      only screen and (min-device-height : $iphone-width) and (max-device-height : $iphone-height) and (orientation : portrait), 
-      only screen and (min-device-width : $ipad-width) and (max-device-width : $ipad-height) and (orientation : landscape), 
+      @media only screen and (min-device-width : $iphone-width) and (max-device-width : $iphone-old-height) and (orientation : landscape),
+      only screen and (min-device-height : $iphone-width) and (max-device-height : $iphone-old-height) and (orientation : portrait),
+      only screen and (min-device-width : $iphone-width) and (max-device-width : $iphone-height) and (orientation : landscape),
+      only screen and (min-device-height : $iphone-width) and (max-device-height : $iphone-height) and (orientation : portrait),
+      only screen and (min-device-width : $ipad-width) and (max-device-width : $ipad-height) and (orientation : landscape),
       only screen and (min-device-height : $ipad-width) and (max-device-height : $ipad-height) and (orientation : portrait) {
         @content;
       }
@@ -165,4 +165,16 @@
       @media only screen and (-webkit-min-device-pixel-ratio: 2) {
         @content;
       }
+    }
+
+    @mixin border-radius($radius) {
+      -webkit-border-radius: $radius; // Chrome 4.0, Safari 3.1 to 4.0, Mobile Safari 3.2, Android Browser 2.1
+         -moz-border-radius: $radius; // Firefox 2.0 to 3.6
+              border-radius: $radius;
+    }
+
+    @mixin box-shadow($shadow) {
+      -webkit-box-shadow: $shadow; // Chrome 4.0 to 9.0, Safari 3.1 to 5.0, Mobile Safari 3.2 to 4.3, Android Browser 2.1 to 3.0
+         -moz-box-shadow: $shadow; // Firefox 3.5 to 3.6
+              box-shadow: $shadow;
     }

--- a/app/assets/stylesheets/admin/forms.scss
+++ b/app/assets/stylesheets/admin/forms.scss
@@ -1,0 +1,9 @@
+.selectable-group {
+  input[type='checkbox'],
+  input[type='radio'] {
+    margin-left: 0;
+    top: 15px;
+    left: 15px;
+    z-index: 999;
+  }
+}

--- a/app/assets/stylesheets/application-admin.scss
+++ b/app/assets/stylesheets/application-admin.scss
@@ -18,6 +18,7 @@ $button-colour: #00823b;
 @import "admin/toggle";
 @import "admin/layout";
 @import "admin/base";
+@import "admin/forms";
 @import "admin/header-footer";
 @import "admin/page-applications";
 @import "admin/page-users";

--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -333,6 +333,20 @@ input[type="file"] {
   margin-top: 0.2em;
 }
 
+.selectable-confirm-wrapper {
+  padding: 1em;
+  border-radius: 5px;
+  background-color: #D5E8F3;
+  border: 1px solid  #CBCBCB;
+
+  &:after {
+    content: " ";
+    display: table;
+    clear: both;
+    zoom: 1;
+  }
+}
+
 .question-block h2 {
   margin-bottom: 0.6em;
 
@@ -385,7 +399,7 @@ input[type="file"] {
         padding: 19px;
         padding-left: 45px;
         background-color: #D5E8F3;
-        border-width: solid 1px #CBCBCB;
+        border: 1px solid  #CBCBCB;
         border-radius: 4px;
 
         input[type="checkbox"] {
@@ -405,18 +419,18 @@ input[type="file"] {
     }
   }
 
-  span.selectable {
-    padding: 0;
-
-    .lte-ie7 & {
-      width: 85%;
-    }
-
-    label {
-      display: block;
-      padding: 18px 30px 15px 45px;
-    }
-  }
+  // span.selectable {
+  //   padding: 0;
+  //
+  //   .lte-ie7 & {
+  //     width: 85%;
+  //   }
+  //
+  //   label {
+  //     display: block;
+  //     padding: 18px 30px 15px 45px;
+  //   }
+  // }
 
   input,
   select,

--- a/app/assets/stylesheets/helpers/_beta-label.scss
+++ b/app/assets/stylesheets/helpers/_beta-label.scss
@@ -1,3 +1,7 @@
 .phase-banner {
   @include phase-banner(beta);
+
+  .phase-tag {
+    background-color: $govuk-blue;
+  }
 }

--- a/app/assets/stylesheets/helpers/_buttons.scss
+++ b/app/assets/stylesheets/helpers/_buttons.scss
@@ -8,6 +8,11 @@
 /* buttons! */
 .button{
   @include button;
+  font-size: 19px;
+
+  @include media-down(mobile) {
+    font-size: 16px;
+  }
 }
 
 .button,
@@ -75,7 +80,7 @@
 /* get started buttons */
 .get-started {
   margin:1.5em 0 0 0;
-  
+
   .destination {
     @include core-14;
     color: $text-colour;
@@ -100,7 +105,7 @@ input{
     min-width: 8em;
     margin: 0 0.5em;
     padding: 0.25em;
-  
+
     @include ie-lte(7) {
       width:8em;
     }
@@ -119,4 +124,3 @@ input{
     }
   }
 }
-

--- a/app/assets/stylesheets/helpers/_selectable.scss
+++ b/app/assets/stylesheets/helpers/_selectable.scss
@@ -10,54 +10,121 @@ span.selectable {
   clear: left;
   position: relative;
 
-  background: $panel-colour;
-  border: 1px solid $panel-colour;
-  padding: (18px $gutter $gutter-half $gutter*1.5);
-  margin-top: 10px;
-  margin-bottom: 10px;
-
-  cursor: pointer; // Encourage clicking on block labels
+  padding: 0 0 0 38px;
+  margin-bottom: $gutter-one-third;
 
   @include media(tablet) {
     float: left;
-    margin-top: 5px;
-    margin-bottom: 5px;
   }
 
-  &:hover {
-    border-color: $black;
-  }
-
-  // Position checkbox within label, to allow text to wrap
+  // Absolutely position inputs within label, to allow text to wrap
   input {
     position: absolute;
-    top: 18px;
-    left: $gutter-half;
     cursor: pointer;
+    left: 0;
+    top: -7px;
+    width: 38px;
+    height: 38px;
+    z-index: 1;
+
+    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
+    @if ($is-ie == false) or ($ie-version == 9) {
+      top: 0;
+      margin: 0;
+      opacity: 0 !important;
+    }
   }
 
-  // Use inline, to sit block labels next to each other
-  .inline & {
-    clear: none;
-    margin-right: $gutter-half;
+  label {
+    cursor: pointer;
+    padding: 8px $gutter-one-third 9px 12px;
+    display: block;
+
+    // remove 300ms pause on mobile
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+
+    @include media(tablet) {
+      float: left;
+      padding-top: 7px;
+      padding-bottom: 7px;
+    }
   }
 
-  // Only if JavaScript is enabled
-  .js-enabled & {
-    // Remove focus styles from radio and checkbox inputs
-    input:focus {
-      outline: none;
-    }
+  [type=radio] + label::before {
+    content: "";
+    border: 2px solid;
+    background: transparent;
+    width: 30px;
+    height: 30px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    @include border-radius(50%);
+  }
 
-    // Add selected state to block labels
-    &.selected {
-      background: $white;
-      border-color: $black;
-    }
+  [type=radio] + label::after {
+    content: "";
+    border: 8px solid;
+    width: 0;
+    height: 0;
+    position: absolute;
+    top: 9px;
+    left: 9px;
+    @include border-radius(50%);
+    @include opacity(0);
+  }
 
-    // Add focus styles to block labels
-    &.focused {
-      outline: 3px solid $yellow;
-    }
+  [type=checkbox] + label::before {
+    content: "";
+    border: 2px solid;
+    background: transparent;
+    width: 30px;
+    height: 30px;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  [type=checkbox] + label::after {
+    content: "";
+    border: solid;
+    border-width: 0 0 4px 4px;
+    background: transparent;
+    width: 14px;
+    height: 6px;
+    position: absolute;
+    top: 10px;
+    left: 8px;
+    -moz-transform: rotate(-45deg); // Firefox 15 compatibility
+    -o-transform: rotate(-45deg); // Opera 12.0 compatibility
+    -webkit-transform: rotate(-45deg); // Safari 8 compatibility
+    -ms-transform: rotate(-45deg); // IE9 compatibility
+    transform: rotate(-45deg);
+    @include opacity(0);
+  }
+
+  // Focused state
+  [type=radio]:focus + label::before {
+    @include box-shadow(0 0 0 4px $focus-colour);
+  }
+
+  [type=checkbox]:focus + label::before {
+    @include box-shadow(0 0 0 3px $focus-colour);
+  }
+
+  // Selected state
+  input:checked + label::after {
+    @include opacity(1);
+  }
+
+  // Disabled state
+  input:disabled + label {
+    @include opacity(0.5);
+  }
+
+  &:last-child,
+  &:last-of-type {
+    margin-bottom: 0;
   }
 }

--- a/app/assets/stylesheets/helpers/_selectable.scss
+++ b/app/assets/stylesheets/helpers/_selectable.scss
@@ -58,7 +58,7 @@ span.selectable {
     width: 30px;
     height: 30px;
     position: absolute;
-    top: 0;
+    top: -2px;
     left: 0;
     @include border-radius(50%);
   }
@@ -69,7 +69,7 @@ span.selectable {
     width: 0;
     height: 0;
     position: absolute;
-    top: 9px;
+    top: 7px;
     left: 9px;
     @include border-radius(50%);
     @include opacity(0);
@@ -82,7 +82,7 @@ span.selectable {
     width: 30px;
     height: 30px;
     position: absolute;
-    top: 0;
+    top: -2px;
     left: 0;
   }
 
@@ -94,7 +94,7 @@ span.selectable {
     width: 14px;
     height: 6px;
     position: absolute;
-    top: 10px;
+    top: 8px;
     left: 8px;
     -moz-transform: rotate(-45deg); // Firefox 15 compatibility
     -o-transform: rotate(-45deg); // Opera 12.0 compatibility

--- a/app/assets/stylesheets/qae.scss
+++ b/app/assets/stylesheets/qae.scss
@@ -2,6 +2,7 @@
 @import "grid_layout";
 @import "conditionals";
 @import "colours";
+@import "styleguide/palette";
 @import "css3";
 @import "typography";
 @import "device-pixels";

--- a/app/assets/stylesheets/styleguide/_palette.scss
+++ b/app/assets/stylesheets/styleguide/_palette.scss
@@ -1,0 +1,77 @@
+// Brand colours
+$govuk-blue: #005ea5;
+$mainstream-brand: $govuk-blue;
+
+// Standard palette, colours
+$purple: #2e358b;
+$purple-50: #9799c4;
+$purple-25: #d5d6e7;
+$mauve: #6f72af;
+$mauve-50: #b7b9d7;
+$mauve-25: #e2e2ef;
+$fuschia: #912b88;
+$fuschia-50: #c994c3;
+$fuschia-25: #e9d4e6;
+$pink: #d53880;
+$pink-50: #eb9bbe;
+$pink-25: #f6d7e5;
+$baby-pink: #f499be;
+$baby-pink-50: #faccdf;
+$baby-pink-25: #fdebf2;
+$red: #b10e1e;
+$red-50: #d9888c;
+$red-25: #efcfd1;
+$mellow-red: #df3034;
+$mellow-red-50: #ef9998;
+$mellow-red-25: #f9d6d6;
+$orange: #f47738;
+$orange-50: #fabb96;
+$orange-25: #fde4d4;
+$brown: #b58840;
+$brown-50: #dac39c;
+$brown-25: #f0e7d7;
+$yellow: #ffbf47;
+$yellow-50: #ffdf94;
+$yellow-25: #fff2d3;
+$grass-green: #85994b;
+$grass-green-50: #c2cca3;
+$grass-green-25: #e7ebda;
+$green: #006435;
+$green-50: #7fb299;
+$green-25: #cce0d6;
+$turquoise: #28a197;
+$turquoise-50: #95d0cb;
+$turquoise-25: #d5ecea;
+$light-blue: #2b8cc4;
+$light-blue-50: #96c6e2;
+$light-blue-25: #d5e8f3;
+
+// Standard palette, greys
+$black: #0b0c0c;
+$grey-1: #6f777b;
+$grey-2: #bfc1c3;
+$grey-3: #dee0e2;
+$grey-4: #f8f8f8;
+$white: #fff;
+
+// Semantic colour names
+$link-colour: $govuk-blue;
+$link-active-colour: $light-blue;
+$link-hover-colour: $light-blue;
+$link-visited-colour: #4c2c92;
+$button-colour: #00823b;
+$focus-colour: $yellow;
+$text-colour: $black;             // Standard text colour
+$secondary-text-colour: $grey-1;  // Section headers, help text etc.
+$border-colour: $grey-2;          // Borders, seperators, rules, keylines etc.
+$panel-colour: $grey-3;           // Related links panel, page footer etc.
+$canvas-colour: $grey-4;          // Page background
+$highlight-colour: $grey-4;       // Table stripes etc.
+$page-colour: $white;             // The page
+$discovery-colour: $govuk-blue;   // Discovery badges and banners
+$alpha-colour: $govuk-blue;       // Alpha badges and banners
+$beta-colour: $govuk-blue;        // Beta badges and banners
+$live-colour: $grass-green;       // Live badges and banners
+$banner-text-colour: #000;        // Text colour for Alpha & Beta banners
+$error-colour: $red;              // Error text and border colour
+$error-background: #fef7f7;       // Error background colour

--- a/app/views/accounts/_form_contact_settings.html.slim
+++ b/app/views/accounts/_form_contact_settings.html.slim
@@ -1,7 +1,7 @@
 fieldset
-  = f.input :subscribed_to_emails, label: "I am happy to be contacted about Queen's Awards for Enterprise issues not related to my application (e.g. acting as a case study, newsletters, other info).", label_html: { class: "selectable" }, wrapper_class: "selectable-group"
+  = f.input :subscribed_to_emails, checkbox: true, label: "I am happy to be contacted about Queen's Awards for Enterprise issues not related to my application (e.g. acting as a case study, newsletters, other info).", wrapper_class: "selectable", wrapper_tag: :label
 
-  = f.input :agree_being_contacted_by_department_of_business, label: "I am happy to be contacted by the Department for Business, Energy and Industrial Strategy.", label_html: { class: "selectable" }, wrapper_class: "selectable-group"
+  = f.input :agree_being_contacted_by_department_of_business, label: "I am happy to be contacted by the Department for Business, Energy and Industrial Strategy.", wrapper_class: "selectable", wrapper_tag: :label
 
 /fieldset
   h3

--- a/app/views/qae_form/_checkbox_seria_question.html.slim
+++ b/app/views/qae_form/_checkbox_seria_question.html.slim
@@ -7,4 +7,6 @@ input name="form[#{question.key}][array]" value="true" type="hidden"
 
   label.selectable.qae-form-checkbox-seria-question-item
     input.js-trigger-autosave type="checkbox" id=question.input_name(suffix: "type_#{placement}") name="#{question.input_name}[#{placement}][type]" value="#{check_option[0]}" checked=('checked' if value_selected) *possible_read_only_ops
-    = check_option[1]
+    
+    label for=question.input_name(suffix: "type_#{placement}")
+      = check_option[1]

--- a/app/views/qae_form/_confirm_question.html.slim
+++ b/app/views/qae_form/_confirm_question.html.slim
@@ -1,6 +1,8 @@
-label.selectable.selectable-confirm
-  input.js-trigger-autosave type="checkbox" name=question.input_name checked=!!question.input_value *possible_read_only_ops
-  - if question.key == :shortlisted_case_confirmation
-    == interpolate_deadlines question.text
-  - elsif question.text
-    == question.text
+.selectable-confirm-wrapper
+  label.selectable
+    input.js-trigger-autosave type="checkbox" name=question.input_name id="q_#{question.key}" checked=!!question.input_value *possible_read_only_ops
+    label for="q_#{question.key}"
+      - if question.key == :shortlisted_case_confirmation
+        == interpolate_deadlines question.text
+      - elsif question.text
+        == question.text

--- a/app/views/qae_form/_options_question.html.slim
+++ b/app/views/qae_form/_options_question.html.slim
@@ -1,4 +1,5 @@
 - for answer in question.options do
   label.selectable
     input.js-trigger-autosave type="radio" name=question.input_name value=answer.value checked=(answer.value.to_s == (question.input_value || '').to_s || (question.input_value.blank? && question.default_option.to_s == answer.value.to_s)) *possible_read_only_ops
-    = answer.text
+    label
+      = answer.text

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -48,6 +48,11 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: :span, class: :hint }
   end
 
+  config.wrappers :checkbox do |b|
+    b.use :input
+    b.use :label
+  end
+
   # The default wrapper to be used by the FormBuilder.
   config.default_wrapper = :default
 
@@ -55,7 +60,7 @@ SimpleForm.setup do |config|
   # Defaults to :nested for bootstrap config.
   #   inline: input + label
   #   nested: label > input
-  config.boolean_style = :nested
+  config.boolean_style = :inline
 
   # Default class for buttons
   config.button_class = 'button'
@@ -126,7 +131,7 @@ SimpleForm.setup do |config|
 
   # Custom wrappers for input types. This should be a hash containing an input
   # type as key and the wrapper that will be used for all inputs with specified type.
-  # config.wrapper_mappings = { string: :prepend }
+  config.wrapper_mappings = { boolean: :checkbox }
 
   # Default priority for time_zone inputs.
   # config.time_zone_priority = nil

--- a/spec/features/users/eligibility_form_fulfillment_spec.rb
+++ b/spec/features/users/eligibility_form_fulfillment_spec.rb
@@ -108,7 +108,7 @@ def form_choice(labels)
   label_ids = Array(labels)
 
   label_ids.each do |label_id|
-    l = all(".question-body .selectable label").detect do |label|
+    l = all(".question-body .selectable").detect do |label|
       if label_id.is_a?(String)
         label.text == label_id
       elsif label_id.is_a?(Regexp)


### PR DESCRIPTION
- Updated alpha/beta colors
- Updated checkboxes and radio buttons throughout USER flows.
- Due to changing Simple Form markup style, admin and assessors had to
tweak styling in order to make the checkboxes look the same as before
- Changed buttons to have default button size of 19px, thus fixing the issue on the new collaborators page, where the button was on 14px.

The change in the markup of Simple Form is due to the fact that we were
using the nested style, which puts the checkboxes and radio buttons
inside a label along with the accompanying text.

But to make the checkboxes/radio buttons as GDS designed, they need to
be before a label with the text inside. Therefore, affecting the default
config, affected admin and assessor screens, making the checkboxes look
outside the containers.

NOTE: had to make checkboxes and radio buttons smaller than GDS' because we have a smaller font in place, so the inputs would look disproportionally big.

![screen shot 2017-04-10 at 08 46 41](https://cloud.githubusercontent.com/assets/758001/24860298/54e7c80c-1dca-11e7-91e0-440147b518e8.png)
![screen shot 2017-04-10 at 08 46 46](https://cloud.githubusercontent.com/assets/758001/24860300/54e9bd42-1dca-11e7-829b-b4a7db65843f.png)
![screen shot 2017-04-10 at 08 46 58](https://cloud.githubusercontent.com/assets/758001/24860299/54e90a00-1dca-11e7-8b7d-ea8adaff8da6.png)
