### PR TITLE
Updating sign up checkbox to use new styling as to aid users to click it

### DIFF
--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -51,10 +51,6 @@ ul.question-context,
     position: relative;
   }
 
-  &.control-label {
-    padding-left: $gutter-two-thirds;
-  }
-
   .checkbox {
     position: absolute;
     top: 0;

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -76,7 +76,8 @@
           .form-inputs
             .question
               .question-body
-                = f.input :agreed_with_privacy_policy, as: :boolean, label: "I have read and accept the #{link_to 'terms and conditions of the privacy statement', privacy_path, target: '_blank'}".html_safe
+                label.selectable
+                  = f.input :agreed_with_privacy_policy, as: :boolean, label: "I have read and accept the #{link_to 'terms and conditions of the privacy statement', privacy_path, target: '_blank'}".html_safe
 
           .form-actions
             = f.button :submit, "Create account", class: "button large"


### PR DESCRIPTION
Updated sign up checkbox to use new styling from GDS.

From this:
![screen_shot_2017-04-25_at_17 11 26](https://cloud.githubusercontent.com/assets/758001/25429588/e8e4a23c-2a4f-11e7-8f35-30a4e921aded.png)


To this:
![screen shot 2017-04-25 at 13 32 56](https://cloud.githubusercontent.com/assets/758001/25429550/c2f8b68a-2a4f-11e7-9365-50d0fbde9ecf.png)
