### PR TITLE
Settings page copy/style changes

### DIFF
--- a/app/assets/stylesheets/admin/page-settings.scss
+++ b/app/assets/stylesheets/admin/page-settings.scss
@@ -29,7 +29,7 @@
   .form-value,
   .date-time-text {
     display: inline-block;
-    width: 35em;
+    width: 39em;
 
     @include screen-sm-max {
       display: inline;

--- a/app/assets/stylesheets/admin/page-settings.scss
+++ b/app/assets/stylesheets/admin/page-settings.scss
@@ -42,7 +42,11 @@
     margin-right: 10px;
   }
 
-  .deadline-help {
+  .email-notification-help {
+    margin-left: 10px;
+  }
+
+  .deadline-help, .email-notification-help {
     font-style: italic;
     display: inline-block;
     position: relative;

--- a/app/views/admin/settings/_email_notification.html.slim
+++ b/app/views/admin/settings/_email_notification.html.slim
@@ -4,8 +4,15 @@
 .panel-section id="email_notification_#{kind}"
   p
     = I18n.t("email_notification_headers.#{kind}")
+
+    span.email-notification-help
+      - if (help_message = t("email_notification_help_messages.#{kind}", default: "")).present?
+        span.glyphicon-info-sign.help-message
+          span.help-message-text
+            = help_message
+
   p
-    = link_to "View email example", "#", class: "link-email-example if-no-js-hide"
+  = link_to "View email example", "#", class: "link-email-example if-no-js-hide"
   .email-example.well
     = MailRenderer.new.public_send(kind)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,7 +159,7 @@ en:
     winners_notification: "WINNERS : Email notifying all winning business applicants of their success & requesting their confirmation of their Press Book entry."
     winners_reminder_to_submit:" WINNERS : Reminder to submit *palace reception attendee details* (for winning applicants who haven't submitted yet)."
     winners_head_of_organisation_notification: "WINNERS : Success email to the 'Head of Organisation' of the Business categories Winner."
-    buckingham_palace_invite: "WINNERS : Buckingham Palace Invite - to heads of winning organisations only"
+    buckingham_palace_invite: "WINNERS : Buckingham Palace Invite - to heads of winning organisations only."
     unsuccessful_notification: "UNSUCCESSFUL: Email notification to unsuccessful Business categories Registered Account holder."
     unsuccessful_ep_notification: "UNSUCCESSFUL: Email notification of unsuccessful QAEP nominations."
     shortlisted_notifier: "SHORTLISTED : Email notifying shortlisted applicants of their success, including Verification of Commercial Figures instructions."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,11 @@ en:
     buckingham_palace_reception_attendee_information_due_by: "Winners will not be able to submit attendees details after this date. This date will be pulled into the Buckingham Palace Invite email - to heads of winning organisations only."
     buckingham_palace_attendees_invite: "This date will be pulled into the email notifying all winning business applicants of their success, the email to the heads of organisations and the Buckingham Palace Invite email."
     audit_certificates: "Shortlisted applicants will have up until this date to submit their Verification of Commercial Figures. This date will be pulled into the email notifying shortlisted applicants of their success, and the reminder to submit Verification of Commercial Figures email."
-
+  email_notification_help_messages:
+    shortlisted_notifier: "Shortlisted stage start (date when we start displaying shortlisted/unsuccessful applications on the dashboard)"
+    winners_notification: "Winners stage start (date we start displaying winners on the dashboard)"
+    unsuccessful_notification: "Unsuccessful stage start (date we start displaying Unsuccessful apps on the dashboard)"
+    buckingham_palace_invite: "Palace invites stage start (allows users to add their Palace invite info)"
   email_notification_headers:
     submission_started_notification: "Notify users that applications for the new Award year are open"
     reminder_to_submit: Reminder to submit the applications (to all those who have started but not yet submitted applications).


### PR DESCRIPTION
- add help copy to some email notifications headers
- add full stop to winner's notification header copy
- make deadline date container wider so it fits in one line