### PR TITLE
increase user timeout limit to 24h to avoid data being lost

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -141,7 +141,7 @@ class User < ActiveRecord::Base
   end
 
   def timeout_in
-    30.minutes
+    24.hours
   end
 
   private


### PR DESCRIPTION
when user is considered inactive for 30 minutes