### PR TITLE
[PDF GENERATION] fixed bug with deadlines displaying in PDF with HTML tags

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -166,7 +166,7 @@ module QaePdfForms::General::DrawElements
 
   def render_text(title, ops = {})
     default_bottom_margin
-    text title, ops
+    text title, ops.merge!({inline_format: true})
   end
 
   def render_table(table_lines)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5beta2
--- Dumped by pg_dump version 9.5beta2
+-- Dumped from database version 9.5.6
+-- Dumped by pg_dump version 9.5.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
```
There is some more HTML tags showing on PDF - Question F4.1 <strong>
```

[TRELLO CARD](https://trello.com/c/3OCMPeXD/596-qae17imp-as-an-applicant-i-would-like-to-be-able-to-add-formating-to-my-application)