### PR TITLE
[PDF FORM] add submission end deadline block to top and bottom of PDF doc

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -109,6 +109,11 @@ class Settings < ActiveRecord::Base
         current.email_notifications.not_awarded.first.try(:trigger_at)
       end
     end
+
+    def submission_deadline_title
+      formatted_datetime = current_submission_deadline.strftime("%d %b %Y at %H:%M%P")
+      "Submission deadline: #{formatted_datetime}"
+    end
   end
 
   def winners_email_notification

--- a/app/pdf_generators/form_pdf.rb
+++ b/app/pdf_generators/form_pdf.rb
@@ -59,5 +59,7 @@ class FormPdf < Prawn::Document
                                             form_pdf: self,
                                             step: step).render!
     end
+
+    render_submission_deadline_block(32)
   end
 end

--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -97,12 +97,24 @@ module QaePdfForms::General::DrawElements
       render_company_name unless pdf_blank_mode.present?
     end
 
-    move_down 15.mm
-
     if !form_answer.urn.present? || pdf_blank_mode
+      move_down 6.mm
       render_intro_text
+      move_down 2.mm
+    end
 
-      move_down 15.mm
+    render_submission_deadline_block
+
+    move_down 7.mm
+  end
+
+  def render_submission_deadline_block(indent_value=0)
+    title = Settings.submission_deadline_title
+
+    if title.present?
+      indent indent_value.mm do
+        render_text(title, style: :bold)
+      end
     end
   end
 


### PR DESCRIPTION
**1) Added submission end deadline information block to the top of first page**

![top_deadline_block](https://user-images.githubusercontent.com/358508/28884700-9e548d86-77bb-11e7-853b-15a8b7026696.png)

**2) And to the last page right after final question**

![bottom_deadline_block](https://user-images.githubusercontent.com/358508/28884715-aec44dfa-77bb-11e7-8b1e-344e15920423.png)

[TRELLO CARD](https://trello.com/c/cgiXFRWS/532-qae17imp-as-an-applicant-i-want-the-submission-deadline-to-be-more-prominent-so-that-it-is-easier-to-find-out-when-the-deadline)