### PR TITLE
[WYSYWYG EDITOR] 'Exeeded' is spelt wrong, it should be 'Exceeded'

### DIFF
--- a/app/forms/qae_form_builder/textarea_question.rb
+++ b/app/forms/qae_form_builder/textarea_question.rb
@@ -14,7 +14,7 @@ class QAEFormBuilder
 
       if limit_with_buffer(limit) && length && length > limit_with_buffer(limit)
         result[question.hash_key] ||= ""
-        result[question.hash_key] << " Exeeded #{limit} words limit."
+        result[question.hash_key] << " Exceeded #{limit} words limit."
       end
 
       result


### PR DESCRIPTION
[TRELLO STORY](https://trello.com/c/Wxkcgq7n/1841-qae17-a-user-wants-to-submit-but-receives-an-error-saying-that-he-is-over-the-word-limit-when-he-isnt)