### PR TITLE
[ELIGIBILITY] fixed display conditions for 'Continue' button

### DIFF
--- a/app/views/account_mailers/reminder_to_submit_mailer/notify.html.slim
+++ b/app/views/account_mailers/reminder_to_submit_mailer/notify.html.slim
@@ -2,7 +2,10 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Dear Queen’s Award applicant,
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' This is a reminder that there are less than 2 weeks left to submit your application for a Queen’s Award for Enterprise before the deadline at noon on Friday 1 September 2017.
+  =<> "This is a reminder that there are less than"
+  span style="color: red;"
+    | 48hrs
+  =<> "left to submit your application for a Queen’s Award for Enterprise before the deadline at noon on Friday 1 September 2017."
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' Whether you excel in international trade, have a great innovative product or service, or are running an impressive social mobility or sustainable development programme, these Awards are a unique way to recognise your achievements.

--- a/app/views/account_mailers/reminder_to_submit_mailer/notify.text.slim
+++ b/app/views/account_mailers/reminder_to_submit_mailer/notify.text.slim
@@ -1,6 +1,6 @@
 ' Dear Queen’s Award applicant,
 
-' This is a reminder that there are less than 2 weeks left to submit your application for a Queen’s Award for Enterprise before the deadline at noon on Friday 1 September 2017.
+' This is a reminder that there are less than 48hrs left to submit your application for a Queen’s Award for Enterprise before the deadline at noon on Friday 1 September 2017.
 
 ' Whether you excel in international trade, have a great innovative product or service, or are running an impressive social mobility or sustainable development programme, these Awards are a unique way to recognise your achievements.
 

--- a/app/views/form_award_eligibilities/show.html.slim
+++ b/app/views/form_award_eligibilities/show.html.slim
@@ -67,10 +67,10 @@ header.page-header.group.page-header-over-sidebar
         = render "previous_answers"
 
         - if (!step || step.to_s == "wicked_finish")
-          .eligibility-continue-button
-            = link_to "Continue", [:award_info, @form_answer.award_type, form_id: @form_answer.id], class: "button medium"
-
-          - unless @form_answer.eligible?
+          - if @form_answer.eligible?
+            .eligibility-continue-button
+              = link_to "Continue", [:award_info, @form_answer.award_type, form_id: @form_answer.id], class: "button medium"
+          - else
             footer
               nav.pagination.no-border role="navigation" aria-label="Pagination"
                 ul.group


### PR DESCRIPTION
 'Continue' button should be displayed if application eligible only
    
[TRELLO STORY](https://trello.com/c/Y0fjuuAO/1852-qae17-error-rate-needs-investigating-as-it-is-5)