### PR TITLE
[MANUAL SUBMISSION OF APPLICATION SCRIPT] corrects

### DIFF
--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -4,7 +4,10 @@ namespace :form_answers do
   task :force_submit, [:id] => [:environment] do |t, args|
     f = FormAnswer.find(args[:id])
     f.submitted = true
-    f.save
+    f.submitted_at = Time.current
+    f.save!
+    f.reload
+
     f.state_machine.submit(f.user)
     FormAnswerUserSubmissionService.new(f).perform
   end

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -1,5 +1,8 @@
 namespace :form_answers do
 
+  #
+  # bundle exec rake form_answers:force_submit[FORM_ANSWER_ID]
+  #
   desc "Force submit an application"
   task :force_submit, [:id] => [:environment] do |t, args|
     f = FormAnswer.find(args[:id])


### PR DESCRIPTION
[TRELLO STORY](https://trello.com/c/Ed0U7Y7D/1877-qae17-manually-submit-2-applications-even-though-they-have-dips-in-their-sales-which-makes-them-ineligible)