### PR TITLE
As an assessor, if I go into a PO assessment and then press ‘back to applications list’ the system takes me back to the SD applications list and not the PO applications list

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -6,7 +6,7 @@ class Admin < ActiveRecord::Base
 
   devise :authy_authenticatable, :database_authenticatable,
          :recoverable, :trackable, :validatable, :confirmable,
-         :zxcvbnable, :lockable, :timeoutable
+         :zxcvbnable, :lockable #, :timeoutable
 
   validates :first_name, :last_name, presence: true
 

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -6,7 +6,7 @@ class Admin < ActiveRecord::Base
 
   devise :authy_authenticatable, :database_authenticatable,
          :recoverable, :trackable, :validatable, :confirmable,
-         :zxcvbnable, :lockable #, :timeoutable
+         :zxcvbnable, :lockable, :timeoutable
 
   validates :first_name, :last_name, presence: true
 
@@ -42,17 +42,7 @@ class Admin < ActiveRecord::Base
   end
 
   def timeout_in
-    if Rails.env.development? ||
-       ENV['ASSET_HOST'].to_s == "dev.queens-awards-enterprise.service.gov.uk" ||
-       ENV['ASSET_HOST'].to_s == "assets2.queens-awards-enterprise.service.gov.uk"
-
-      # On dev and staging server for now we are gonna set 3 minutes for testing purposes
-      # Once mister Tom will test it - I will remove this case!
-
-      3.minutes
-    else
-      30.minutes
-    end
+    30.minutes
   end
 
   private

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -9,7 +9,7 @@ class Assessor < ActiveRecord::Base
 
   devise :database_authenticatable,
          :recoverable, :trackable, :validatable, :confirmable,
-         :zxcvbnable, :lockable #, :timeoutable
+         :zxcvbnable, :lockable, :timeoutable
 
   validates :first_name, :last_name, presence: true
   has_many :form_answer_attachments, as: :attachable
@@ -147,17 +147,7 @@ class Assessor < ActiveRecord::Base
   end
 
   def timeout_in
-    if Rails.env.development? ||
-       ENV['ASSET_HOST'].to_s == "dev.queens-awards-enterprise.service.gov.uk" ||
-       ENV['ASSET_HOST'].to_s == "assets2.queens-awards-enterprise.service.gov.uk"
-
-      # On dev and staging server for now we are gonna set 3 minutes for testing purposes
-      # Once mister Tom will test it - I will remove this case!
-
-      3.minutes
-    else
-      30.minutes
-    end
+    30.minutes
   end
 
   private

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -9,7 +9,7 @@ class Assessor < ActiveRecord::Base
 
   devise :database_authenticatable,
          :recoverable, :trackable, :validatable, :confirmable,
-         :zxcvbnable, :lockable, :timeoutable
+         :zxcvbnable, :lockable #, :timeoutable
 
   validates :first_name, :last_name, presence: true
   has_many :form_answer_attachments, as: :attachable

--- a/app/views/assessor/form_answers/show.html.slim
+++ b/app/views/assessor/form_answers/show.html.slim
@@ -1,7 +1,7 @@
 .row
   .col-xs-12
     .page-header.page-header-nav
-      = link_to "‹ Back to applications list", assessor_form_answers_path(search: params[:search], award_type: params[:award_type]), class: "btn btn-link btn-lg"
+      = link_to "‹ Back to applications list", assessor_form_answers_path(search: params[:search], award_type: @form_answer.award_type), class: "btn btn-link btn-lg"
       .apps-navigation
         - if !@form_paginator.first?
           = link_to "‹ Previous application", assessor_form_answer_path(@form_paginator.prev_entry, search: params[:search], award_type: params[:award_type]), class: "btn btn-link btn-lg link-prev"


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/0hfGrWlD/684-qae17-as-an-assessor-if-i-go-into-a-po-assessment-and-then-press-back-to-applications-list-the-system-takes-me-back-to-the-sd-ap)