### PR TITLE
[ASSESOR] should be redirected to same award category on click on 'Back to applications'

### DIFF
--- a/app/views/assessor/form_answers/show.html.slim
+++ b/app/views/assessor/form_answers/show.html.slim
@@ -1,7 +1,7 @@
 .row
   .col-xs-12
     .page-header.page-header-nav
-      = link_to "‹ Back to applications list", assessor_form_answers_path(search: params[:search], award_type: params[:award_type]), class: "btn btn-link btn-lg"
+      = link_to "‹ Back to applications list", assessor_form_answers_path(search: params[:search], award_type: @form_answer.award_type), class: "btn btn-link btn-lg"
       .apps-navigation
         - if !@form_paginator.first?
           = link_to "‹ Previous application", assessor_form_answer_path(@form_paginator.prev_entry, search: params[:search], award_type: params[:award_type]), class: "btn btn-link btn-lg link-prev"


### PR DESCRIPTION
[TRELLO STORY](https://trello.com/c/0hfGrWlD/684-qae17-as-an-assessor-if-i-go-into-a-po-assessment-and-then-press-back-to-applications-list-the-system-takes-me-back-to-the-sd-ap)