### PR TITLE
[MANUAL SUBMISSION OF APPLICATION] make it universal and easy to use

### DIFF
--- a/app/models/urn_builder.rb
+++ b/app/models/urn_builder.rb
@@ -11,6 +11,10 @@ class UrnBuilder
     return unless fa.submitted?
     return unless fa.award_type
 
+    fa.urn = generate_urn
+  end
+
+  def generate_urn
     sequence_attr = "urn_seq_promotion_#{award_year.year}" if fa.promotion?
     sequence_attr ||= "urn_seq_#{award_year.year}"
 
@@ -26,6 +30,6 @@ class UrnBuilder
     }[fa.award_type]
     generated_urn += "#{award_year.year.to_s[2..-1]}#{suffix}"
 
-    fa.urn = generated_urn
+    generated_urn
   end
 end

--- a/app/tasks/manual_updaters/submit_application.rb
+++ b/app/tasks/manual_updaters/submit_application.rb
@@ -1,0 +1,57 @@
+#
+# Manual Submission of FormAnswer
+#
+# Use:
+#
+# ::ManualUpdaters::SubmitApplication.new(form_answer).run!
+#
+
+module ManualUpdaters
+  class SubmitApplication
+
+    attr_accessor :form_answer
+
+    def initialize(form_answer)
+      @form_answer = form_answer
+    end
+
+    def run!
+      # STEP 1: Set submitted fields
+      #
+      form_answer.update_column(:submitted, true)
+      form_answer.update_column(:submitted_at, Time.current)
+
+      # STEP 2: Assign URN
+      #
+      generated_urn = UrnBuilder.new(form_answer).generate_urn
+
+      if generated_urn.present?
+        # STEP 3: If URN generate successfuly, THEN:
+
+        # save URN
+        #
+        form_answer.update_column(:urn, generated_urn)
+
+        # trigger state
+        #
+        form_answer.state_machine.submit(form_answer.user)
+
+        # notify user about successful submission
+        #
+        FormAnswerUserSubmissionService.new(form_answer).perform
+
+        # generate hard copy PDF file
+        #
+        HardCopyPdfGenerators::FormDataWorker.perform_async(form_answer.id)
+
+        p ""
+        p "[MANUAL SUBMISSION | SUCCESS] DONE! Check it at https://www.queens-awards-enterprise.service.gov.uk/admin/form_answers/#{f.id}"
+        p ""
+      else
+        p ""
+        p "[MANUAL SUBMISSION | ERROR] seems URN is not generated! Please, check why!"
+        p ""
+      end
+    end
+  end
+end

--- a/lib/tasks/form_answers.rake
+++ b/lib/tasks/form_answers.rake
@@ -5,14 +5,8 @@ namespace :form_answers do
   #
   desc "Force submit an application"
   task :force_submit, [:id] => [:environment] do |t, args|
-    f = FormAnswer.find(args[:id])
-    f.submitted = true
-    f.submitted_at = Time.current
-    f.save!
-    f.reload
-
-    f.state_machine.submit(f.user)
-    FormAnswerUserSubmissionService.new(f).perform
+    form_answer = FormAnswer.find(args[:id])
+    ::ManualUpdaters::SubmitApplication.new(form_answer).run!
   end
 
   desc "Populate submitted_at"


### PR DESCRIPTION
**WHAT DOES THIS PR:**

1) Moving all manual submission stuff into separated class

2) Rewritten `.save` to using `.update_column` as most apps we are submitting manually are having some NOT valid answers.
So that now we can submit any application.

3) As set_urn require form to have all answers to be valid - we corrected `UrnBuilder` to allow generate URN even if application is invalid by moving URN generation to separated method

3) Adds hard copy PDF generation to manual submission flow as it is required thing for submitted apps

[TREELO STORY](https://trello.com/c/VMvWCIXt/1900-qae17-as-a-user-who-missed-the-submission-deadline-who-therefore-had-their-application-submitted-manually-by-bit-zesty-or-a-supe)