### PR TITLE
[ADMIN SUBMITS APP MANUALLY] need to generate Hard Copy PDF too

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -158,6 +158,15 @@ class FormController < ApplicationController
           if submitted_was_changed
             @form_answer.state_machine.submit(current_user)
             FormAnswerUserSubmissionService.new(@form_answer).perform
+
+            if @form_answer.submission_ended?
+              #
+              # If submission period ended and Admin makes manual submission
+              # then we need to generate Hard Copy PDF file
+              # as it required for all submitted applications after submission deadline.
+              #
+              HardCopyPdfGenerators::FormDataWorker.perform_async(@form_answer.id)
+            end
           end
         end
 

--- a/app/tasks/manual_updaters/submit_application.rb
+++ b/app/tasks/manual_updaters/submit_application.rb
@@ -45,7 +45,7 @@ module ManualUpdaters
         HardCopyPdfGenerators::FormDataWorker.perform_async(form_answer.id)
 
         p ""
-        p "[MANUAL SUBMISSION | SUCCESS] DONE! Check it at https://www.queens-awards-enterprise.service.gov.uk/admin/form_answers/#{f.id}"
+        p "[MANUAL SUBMISSION | SUCCESS] DONE! Check it at https://www.queens-awards-enterprise.service.gov.uk/admin/form_answers/#{form_answer.id}"
         p ""
       else
         p ""


### PR DESCRIPTION
**NEW FEATURE**

If admin makes manual submission of application via Admin -> Application -> 'Edit Application'
Then we need to schedule Hard Copy PDF generation for this application
as it is required to have hard copy PDF for all submitted applications after deadline

[TRELLO STORY](https://trello.com/c/VMvWCIXt/1900-qae17-as-a-user-who-missed-the-submission-deadline-who-therefore-had-their-application-submitted-manually-by-bit-zesty-or-a-supe)