### PR TITLE
[FORM ANSWER ATTACHMENTS] corrected displaying of virus scanner check message

### DIFF
--- a/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
+++ b/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
@@ -17,6 +17,9 @@
       = link_to [namespace_name, form_answer_attachment.form_answer,form_answer_attachment], target: "_blank", class: "action-title"
         span.glyphicon.glyphicon-file
         = form_answer_attachment.decorate.display_name
+    - elsif form_answer_attachment.pending? || form_answer_attachment.scanning?
+      span.glyphicon.glyphicon-file
+      = "Scanning of '#{form_answer_attachment.decorate.display_name}' file"
     - else
       span.glyphicon.glyphicon-file
       = "Not passed virus scanner check (#{form_answer_attachment.decorate.display_name})"

--- a/app/views/admin/form_answer_attachments/_support_letter.html.slim
+++ b/app/views/admin/form_answer_attachments/_support_letter.html.slim
@@ -1,13 +1,18 @@
 li.form_answer_attachment
   - if support_letter.support_letter_attachment.present?
-    - if support_letter.support_letter_attachment.clean?
+    - sl_attachment = support_letter.support_letter_attachment
+
+    - if sl_attachment.clean?
       = link_to [namespace_name, support_letter.form_answer, support_letter],
                 target: "_blank", class: "action-title"
         span.glyphicon.glyphicon-file
-        = support_letter.support_letter_attachment.original_filename
+        = sl_attachment.original_filename
+    - elsif sl_attachment.pending? || sl_attachment.scanning?
+      span.glyphicon.glyphicon-file
+      = "Scanning of '#{sl_attachment.original_filename}' file"
     - else
       span.glyphicon.glyphicon-file
-      = "Not passed virus scanner check (#{support_letter.support_letter_attachment.original_filename})"
+      = "Not passed virus scanner check (#{sl_attachment.original_filename})"
   - else
     = link_to [namespace_name, support_letter.form_answer, support_letter],
               target: "_blank",


### PR DESCRIPTION
**WE HAVE ISSUE NOW:**

Once Admin or Assessor uploads attachment to application via `Attach document` Then
We are displaying `Not passed virus scanner check` message.
This message is bit confusing.

**WHAT THIS PR DOES?**

We are adding advanced check on views.
So that if file is in `pending` or `scanning` status, THEN:
we are displaying `Scanning of #{filename} file` message.

[TRELLO STORY](https://trello.com/c/plV8rVuB/1888-qae17-attach-a-file-to-littlepods-application-and-investigate-why-it-is-failing-vigilion-scanning-on-upload)