### PR TITLE
    [FORM ANSWER ATTACHMENTS] corrected displaying of virus scanner check message

### DIFF
--- a/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
+++ b/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
@@ -17,7 +17,7 @@
       = link_to [namespace_name, form_answer_attachment.form_answer,form_answer_attachment], target: "_blank", class: "action-title"
         span.glyphicon.glyphicon-file
         = form_answer_attachment.decorate.display_name
-    - elsif form_answer_attachment.pending? || form_answer_attachment.scanning?
+    - elsif %w(pending scanning).include?(form_answer_attachment.file_scan_results.to_s)
       span.glyphicon.glyphicon-file
       = "Scanning of '#{form_answer_attachment.decorate.display_name}' file"
     - else

--- a/app/views/admin/form_answer_attachments/_support_letter.html.slim
+++ b/app/views/admin/form_answer_attachments/_support_letter.html.slim
@@ -7,7 +7,7 @@ li.form_answer_attachment
                 target: "_blank", class: "action-title"
         span.glyphicon.glyphicon-file
         = sl_attachment.original_filename
-    - elsif sl_attachment.pending? || sl_attachment.scanning?
+    - elsif %w(pending scanning).include?(sl_attachment.attachment_scan_results.to_s)
       span.glyphicon.glyphicon-file
       = "Scanning of '#{sl_attachment.original_filename}' file"
     - else


### PR DESCRIPTION
Current version of `virus_scanner` doesn't have enum `pending?` and `scanning?` helpers.

So gonna check via:
```
%w(pending scanning).include?(file_status)
```
[TRELLO STORY](https://trello.com/c/plV8rVuB/1888-qae17-attach-a-file-to-littlepods-application-and-investigate-why-it-is-failing-vigilion-scanning-on-upload)