### PR TITLE
[MANUAL FROM HARD COPY PDF GENERATION] need to use latest document

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -165,7 +165,7 @@ class FormController < ApplicationController
               # then we need to generate Hard Copy PDF file
               # as it required for all submitted applications after submission deadline.
               #
-              HardCopyPdfGenerators::FormDataWorker.perform_async(@form_answer.id)
+              HardCopyPdfGenerators::FormDataWorker.perform_async(@form_answer.id, true)
             end
           end
         end

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -315,6 +315,10 @@ class FormAnswer < ActiveRecord::Base
     HardCopyGenerators::FormDataGenerator.new(self).run
   end
 
+  def generate_pdf_version_from_latest_doc!
+    HardCopyGenerators::FormDataGenerator.new(self, true).run
+  end
+
   def generate_case_summary_hard_copy_pdf!
     HardCopyGenerators::CaseSummaryGenerator.new(self).run
   end

--- a/app/pdf_generators/hard_copy_generators/base.rb
+++ b/app/pdf_generators/hard_copy_generators/base.rb
@@ -4,10 +4,12 @@ class HardCopyGenerators::Base
               :pdf,
               :tempfile_name,
               :timestamp,
-              :tmpfile
+              :tmpfile,
+              :use_latest_version
 
-  def initialize(form_answer)
+  def initialize(form_answer, use_latest_version=false)
     @form_answer = form_answer
+    @use_latest_version = use_latest_version
     @timestamp = Time.zone.now.strftime('%d_%b_%Y_%H_%M')
 
     set_pdf!

--- a/app/pdf_generators/hard_copy_generators/form_data_generator.rb
+++ b/app/pdf_generators/hard_copy_generators/form_data_generator.rb
@@ -7,8 +7,13 @@
 
 class HardCopyGenerators::FormDataGenerator < HardCopyGenerators::Base
   def set_pdf!
-    @pdf = form_answer.original_form_answer
-                      .decorate
+    form_record = if use_latest_version.present?
+      form_answer
+    else
+      form_answer.original_form_answer
+    end
+
+    @pdf = form_record.decorate
                       .pdf_generator
   end
 

--- a/app/pdf_generators/hard_copy_generators/form_data_generator.rb
+++ b/app/pdf_generators/hard_copy_generators/form_data_generator.rb
@@ -7,7 +7,7 @@
 
 class HardCopyGenerators::FormDataGenerator < HardCopyGenerators::Base
   def set_pdf!
-    form_record = if use_latest_version.present?
+    form_record = if use_latest_version
       form_answer
     else
       form_answer.original_form_answer

--- a/app/tasks/manual_updaters/submit_application.rb
+++ b/app/tasks/manual_updaters/submit_application.rb
@@ -42,7 +42,7 @@ module ManualUpdaters
 
         # generate hard copy PDF file
         #
-        HardCopyPdfGenerators::FormDataWorker.perform_async(form_answer.id)
+        HardCopyPdfGenerators::FormDataWorker.perform_async(form_answer.id, true)
 
         p ""
         p "[MANUAL SUBMISSION | SUCCESS] DONE! Check it at https://www.queens-awards-enterprise.service.gov.uk/admin/form_answers/#{form_answer.id}"

--- a/app/workers/hard_copy_pdf_generators/form_data_worker.rb
+++ b/app/workers/hard_copy_pdf_generators/form_data_worker.rb
@@ -1,7 +1,12 @@
 class HardCopyPdfGenerators::FormDataWorker  < HardCopyPdfGenerators::BaseWorker
 
-  def perform(form_answer_id)
+  def perform(form_answer_id, generate_from_latest_doc=false)
     form_answer = FormAnswer.find(form_answer_id)
-    form_answer.generate_pdf_version!
+
+    if generate_from_latest_doc.present?
+      form_answer.generate_pdf_version_from_latest_doc!
+    else
+      form_answer.generate_pdf_version!
+    end
   end
 end

--- a/app/workers/hard_copy_pdf_generators/form_data_worker.rb
+++ b/app/workers/hard_copy_pdf_generators/form_data_worker.rb
@@ -3,7 +3,7 @@ class HardCopyPdfGenerators::FormDataWorker  < HardCopyPdfGenerators::BaseWorker
   def perform(form_answer_id, generate_from_latest_doc=false)
     form_answer = FormAnswer.find(form_answer_id)
 
-    if generate_from_latest_doc.present?
+    if generate_from_latest_doc
       form_answer.generate_pdf_version_from_latest_doc!
     else
       form_answer.generate_pdf_version!


### PR DESCRIPTION
**NOW WE HAVE ISSUE:**

Now if Admin manually submits application after deadline OR
developer does manual submissing via rake script, THEN:

System generates hard copy PDF based on version of `document`
at the moment before submission end deadline.

It is wrong, because applications which Admin OR
developer submits manually after deadline can be corrected
after submission end deadline too!

**WHAT DOES THIS PR?**

1) We extended `HardCopyPdfGenerators::FormDataWorker` sidekiq worker to
   handle `generate_from_latest_doc` option, so that now we can use it for both cases:

   - generation of hard copy PDF from version of document before submission end deadline

   - and generate PDF from latest version at the moment of manul submission by Admin or Developer

2) Corrected manual submission class

3) Corrected using of `HardCopyPdfGenerators::FormDataWorker` in FormController in submission block

[TRELLO STORY](https://trello.com/c/KdWqEj8V/687-qae17-as-a-user-who-missed-the-submission-deadline-who-therefore-had-their-application-submitted-manually-by-bit-zesty-or-a-supe)