### PR TITLE
[SECURITY UPGRADES] nokogiri to '1.8.1'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'enumerize', '~> 0.8'
 # PDF generation
 gem 'prawn'
 gem 'prawn-table'
-gem 'nokogiri', '~> 1.7'
+gem 'nokogiri', '~> 1.8.1'
 
 # Uploads
 gem 'carrierwave'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.2)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -317,8 +317,8 @@ GEM
     nilify_blanks (1.2.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
-    nokogiri (1.7.2)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     paper_trail (5.1.1)
       activerecord (>= 3.0, < 6.0)
@@ -593,7 +593,7 @@ DEPENDENCIES
   lograge
   newrelic_rpm
   nilify_blanks
-  nokogiri (~> 1.7)
+  nokogiri (~> 1.8.1)
   paper_trail (~> 5.1.0)
   pdf-inspector
   pg (~> 0.17)


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-20432?utm_source=slack

nokogiri (鋸) is an HTML, XML, SAX, and Reader parser, with the ability to search documents via XPath or CSS3 selectors.

Affected versions of the package are vulnerable to many vulnerabilities, including Arbitrary Code Execution and Denial of Service (DoS), and Sensitive Information Exposure. Nokogiri bundles the libxml2 library, which is vulnerable in versions below 2.9.5.

[TRELLO CARD](https://trello.com/c/A7Ur84aL/1929-qae17-tech-debt-new-vulnerability-in-gem-nokogiri-15)