### PR TITLE
Fixing autosave bug in non-editable form

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -428,6 +428,10 @@ jQuery ->
       #
       autosave_enabled = false
 
+    # Assessor viewing form, autosave should be disabled
+    if $(".page-read-only-form").length > 0
+      autosave_enabled = false
+
     if autosave_enabled
       save_form_data(callback)
     #TODO: indicators, error handlers?


### PR DESCRIPTION
When assessors were going through the application, whenever they changed
steps, the autosave functionality was being called, and when that
happens and FAILS, the behaviour implemented is to refresh the page.

The fix was to simply check if the page was in read-only mode, and use
the same autosave disabling mechanism as when there's multiple
collaborators.

PS: it was believed this issue was only happening on IE, but it actually affects all browsers, as it's an issue of autosave being called, when it shouldn't