### PR TITLE
[ADMIN] If comment author is deleted - it breaks application page

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -24,7 +24,11 @@ module AdminHelper
 
       base
     else
-      "Author deleted"
+      "Written by author who is no longer active"
     end
+  end
+
+  def message_author_name(author)
+    author.present? ? author.decorate.full_name : 'author who is no longer active'
   end
 end

--- a/app/views/admin/form_answers/_comment.html.slim
+++ b/app/views/admin/form_answers/_comment.html.slim
@@ -1,4 +1,4 @@
-.form-container.comment.show-comment class="#{'comment-flagged' if comment.flagged?}" data-signature="Updated by #{comment.author.decorate.full_name} - #{l(comment.created_at, format: :date_at_time)}"
+.form-container.comment.show-comment class="#{'comment-flagged' if comment.flagged?}" data-signature="Updated by #{message_author_name(comment.author)} - #{l(comment.created_at, format: :date_at_time)}"
   .overlay-delete
     .overlay-content
       - if comment.author?(current_subject)

--- a/app/views/admin/form_answers/_section_admin_comments.html.slim
+++ b/app/views/admin/form_answers/_section_admin_comments.html.slim
@@ -13,7 +13,7 @@
           span.signature
             - if @form_answer.comments.admin.any?
               - last_comment = @form_answer.comments.admin.first
-              = "Updated by #{last_comment.author.decorate.full_name} - #{l(last_comment.created_at, format: :date_at_time)}"
+              = "Updated by #{message_author_name(last_comment.author)} - #{l(last_comment.created_at, format: :date_at_time)}"
 
   #section-admin-comments.section-admin-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="admin-comments-heading"
     .panel-body

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -10,7 +10,7 @@
               | This will be presented to the panel members and is used when making the final decision
             - if assessment.editable.present?
               small
-                = "Updated by #{assessment.editable.decorate.full_name} - #{format_date(assessment.updated_at)}"
+                = "Updated by #{message_author_name(assessment.editable)} - #{format_date(assessment.updated_at)}"
       .panel-collapse.collapse role="tabpanel" aria-labelledby="case-summary-heading-#{assessment.position}" id="section-case-summary-#{assessment.position}" class="section-case-summary-#{assessment.position}"
 
         .panel-body

--- a/app/views/admin/form_answers/_section_critical_comments.html.slim
+++ b/app/views/admin/form_answers/_section_critical_comments.html.slim
@@ -13,7 +13,7 @@
           span.signature
             - if @form_answer.comments.critical.any?
               - last_comment = @form_answer.comments.critical.first
-              = "Updated by #{last_comment.author.decorate.full_name} - #{l(last_comment.created_at, format: :date_at_time)}"
+              = "Updated by #{message_author_name(last_comment.author)} - #{l(last_comment.created_at, format: :date_at_time)}"
 
   #section-critical-comments.section-critical-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="critical-comments-heading"
     .panel-body


### PR DESCRIPTION
Investigation of Sentry issues below showed that there is a problem with displaying comments of users who are now removed from the system

-  https://sentry.io/bit-zesty-client-apps/qae/issues/357946878, -
- https://sentry.io/bit-zesty-client-apps/qae/issues/357946610

Solution: Add a condition on view of comments list. If author is removed and we no longer have his name, display as per annotated screenshot:
-  "author who is no longer active" instead of author name
- "Written by author who is no longer active"

[TRELLO CARD](https://trello.com/c/Xj5S2f8r/693-qae17-issue-with-rendering-comments-of-removed-users)