### PR TITLE
Fixing sidebar overflowing main section

### DIFF
--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -672,9 +672,11 @@ header.page-header aside .inner {
   margin: 0;
   margin-left: 272px;
   padding-right: 32px;
+  min-height: 1020px;
 
   @media (max-width: 990px) {
     margin-left: 0;
+    min-height: 0;
   }
 
   @media (max-width: 640px) {


### PR DESCRIPTION
This PR adds a minimum height to main section of forms, so that smaller sections like the E section, when no document/link is added, the sidebar doesn't overflow into the footer

![screen_shot_2017-09-04_at_13 35 41](https://user-images.githubusercontent.com/758001/31717007-0cb25042-b3e9-11e7-8b7f-476068052280.png)

to

![fixed_sidebar](https://user-images.githubusercontent.com/758001/31717008-0f85012a-b3e9-11e7-9940-f2ce5dca7a8d.png)
