### PR TITLE
Fixing double click to submit issue

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -285,7 +285,7 @@ jQuery ->
       e.stopPropagation()
 
       autosave ->
-        $(".qae-form").trigger("submit")
+        $(".steps-progress-content .step-current button[type='submit']").click()
 
   #
   # In case if was attempt to submit and validation errors are present


### PR DESCRIPTION
When clicking the submit button on the last page, two event handlers are
fired:

1) To check validations, and prevent submission
2) To see if any unsaved changes needed to be autosaved before
submitting

The second one, after autosaving, would trigger the form submit event
once again, this time bypassing the changes unsaved check and would
trigger the form to be submitted normally (no AJAX).

However, for some reason still unknown, the submission after the
autosave was being blocked.

I have tried removing the event handlers, but to no avail.
I saw that there were multiple submit buttons across the various
sections, and they were not disabled. I then thought that these could be
interfering in the submit handlers.

Triggering a click on the current step submit button works beautifully.