### PR TITLE
Fixing Dockerfile in order to fix deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV AWS_SECRET_ACCESS_KEY dummy
 ENV CURL_CONNECT_TIMEOUT=0 CURL_TIMEOUT=0 GEM_PATH="$HOME/vendor/bundle/ruby/${RUBY_VERSION}:$GEM_PATH" LANG=${LANG:-en_US.UTF-8} PATH="$HOME/bin:$HOME/vendor/bundle/bin:$HOME/vendor/bundle/ruby/${RUBY_VERSION}/bin:$PATH" RACK_ENV=${RACK_ENV:-production} RAILS_ENV=${RAILS_ENV:-production} RAILS_SERVE_STATIC_FILES=${RAILS_SERVE_STATIC_FILES:-enabled} SECRET_KEY_BASE=${SECRET_KEY_BASE:-PLACEHOLDERSECRETBASEKEY}
 
 # Cache bundler
-COPY . /app
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
+COPY . /app
 RUN bundle install --without development test --jobs 4 && RAILS_ENV=production bundle exec rake assets:precompile


### PR DESCRIPTION
In recent versions of Docker redundant (or "empty") COPY statements
cause an issue when building images.

In this case, copying the whole "." folder to /app, and then copying
both Gemfile and Gemfile.lock again to that folder caused a state of "no
change", and these layers are skipped.

The solution from Convox team was to move the two COPY statements
related to Gemfiles above the whole folder copy in order to never have
an "empty" copy again.

P.S: I do believe we could remove those two COPY statements, but to make
the least amount of changes to fix, I'm gonna leave them there, just in
case...