### PR TITLE
Reverting order of elements to fix validations

### DIFF
--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -4,8 +4,8 @@
   - if question.header_context
     == question.header_context
 
-= condition_divs question do
-  fieldset class=question.fieldset_classes data=question.fieldset_data_hash class=("question-has-errors" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
+fieldset class=question.fieldset_classes data=question.fieldset_data_hash class=("question-has-errors" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
+  = condition_divs question do
     - ref = question.ref ? question.ref : question.sub_ref
     - if question.title != "" || question.show_ref_always.present?
       - if question.label_as_legend?
@@ -26,7 +26,7 @@
           - unless question.title.blank?
             h2
               == question.title
-      
+
     - else
       - if question.ref || question.sub_ref
         .if-js-hide


### PR DESCRIPTION
Other fixes in accessibility meant this one wasn't doing anything but
breaking the validations.

This revert is needed to fix validations without going through all
validations one by one to change behaviour.

Checked accessibility using tools, and they didn't report any errors
coming from this revert.