### PR TITLE
Remove deadline box pre submission start

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -41,6 +41,11 @@ class Settings < ActiveRecord::Base
       end
     end
 
+    def after_current_submission_deadline_start?
+      deadline = current_submission_start_deadline.trigger_at
+      DateTime.now >= deadline if deadline
+    end
+
     def after_current_audit_certificates_deadline?
       deadline = current_audit_certificates_deadline.trigger_at
       DateTime.now >= deadline if deadline

--- a/app/views/content_only/dashboard.html.slim
+++ b/app/views/content_only/dashboard.html.slim
@@ -13,7 +13,7 @@ header.page-header.group
 - if Settings.after_current_submission_deadline?
   .dashboard-post-submission
     = render "dashboard_post_submission"
-- else
+- elsif Settings.after_current_submission_deadline_start?
   .dashboard-pre-submission
     = render "dashboard_pre_submission"
 

--- a/app/views/content_only/dashboard.html.slim
+++ b/app/views/content_only/dashboard.html.slim
@@ -5,10 +5,11 @@
 - elsif Settings.current_registrations_open_on?
   = render "content_only/info_messages/registrations_open_on"
 
-header.page-header.group
-  div
-    h1
-      ' Applications
+- if Settings.after_current_submission_deadline_start? || past_applications.present?
+  header.page-header.group
+    div
+      h1
+        ' Applications
 
 - if Settings.after_current_submission_deadline?
   .dashboard-post-submission

--- a/spec/features/users/post_submission_dashboard_spec.rb
+++ b/spec/features/users/post_submission_dashboard_spec.rb
@@ -3,6 +3,7 @@ include Warden::Test::Helpers
 
 describe  "User sees the post submission dashboard" do
   let(:user) { create(:user, :completed_profile) }
+  let!(:settings) { create(:settings, :submission_deadlines, award_year_id: AwardYear.current.id) }
   let!(:form_answer) { create(:form_answer, :with_audit_certificate, user: user) }
 
   before do
@@ -16,7 +17,8 @@ describe  "User sees the post submission dashboard" do
       expect(page).to have_content"Edit application"
       expect(page).to have_content("Current Applications")
 
-      settings = create(:settings, :expired_submission_deadlines)
+      settings.destroy
+      settings = create(:settings, :expired_submission_deadlines, award_year_id: AwardYear.current.id)
       form_answer.update_column(:state, "reserved")
 
       visit dashboard_path


### PR DESCRIPTION
This PR improves the dashboard when submissions haven't started yet by:

- Hiding applications title if submissions haven't started and past applications are not present
- Hiding sidebar box displaying submissions deadline if submissions haven't started

![screen shot 2018-05-07 at 10 51 34](https://user-images.githubusercontent.com/758001/39705555-28b9c866-51e5-11e8-818d-c56b16587432.png)
![screen shot 2018-05-07 at 10 51 50](https://user-images.githubusercontent.com/758001/39705556-28de7832-51e5-11e8-963f-65d5c50a779f.png)
![screen shot 2018-05-07 at 10 52 05](https://user-images.githubusercontent.com/758001/39705557-290324e8-51e5-11e8-903c-860d51e4ee6f.png)
