### PR TITLE
Remove p tag from content when printing pdf

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/custom_questions/textarea.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/textarea.rb
@@ -2,7 +2,7 @@ module QaePdfForms::CustomQuestions::Textarea
 
   LIST_TAGS = ["ul", "ol"]
 
-  MAIN_CONTENT_BLOCKS = ["p"] + LIST_TAGS
+  MAIN_CONTENT_BLOCKS = LIST_TAGS + ["p"]
 
   SUPPORTED_TAGS = MAIN_CONTENT_BLOCKS + [
     "li", "a", "em", "strong", "text", "br"
@@ -308,7 +308,7 @@ module QaePdfForms::CustomQuestions::Textarea
           {"<" + t_name + ">" => {style: wysywyg_get_style(baby)}}
         when "a"
           "<u><link href=#{links_href(baby)}>"
-        when "text"
+        when "text", "p"
           baby.text
         else
           "<" + t_name + ">"


### PR DESCRIPTION
Related story:
  - https://trello.com/c/QUuOkCr5/673-qae18imp-as-a-applicant-assessor-i-dont-want-to-see-html-tags-on-the-pdf-forms-4