### PR TITLE
Clear missing cache on deadline update

### DIFF
--- a/app/models/deadline.rb
+++ b/app/models/deadline.rb
@@ -74,5 +74,6 @@ class Deadline < ActiveRecord::Base
     Rails.cache.clear("current_settings")
     Rails.cache.clear("current_award_year")
     Rails.cache.clear("#{kind.value}_deadline")
+    Rails.cache.clear("#{kind}_deadline_#{settings.award_year.year}")
   end
 end


### PR DESCRIPTION
Related story:
   - https://trello.com/c/2cSvhMdX/679-qae18imp-as-an-applicant-who-has-signed-in-after-the-submission-deadline-sometimes-the-award-winners-announcement-date-displays 