### PR TITLE
Remove destroy dependency to form_answers on users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ActiveRecord::Base
   validates_with AdvancedEmailValidator, unless: "Rails.env.test? || Rails.env.development?"
 
   begin :associations
-    has_many :form_answers, dependent: :destroy
+    has_many :form_answers
     has_many :feedbacks, through: :form_answers,
                          class_name: "Feedback",
                          source: :feedback


### PR DESCRIPTION
Related story:
 - https://trello.com/c/Q0tPPmWq/710-qae18imp-as-an-admin-when-i-delete-an-applicant-user-from-the-system-i-dont-want-the-associated-application-form-deleted-so-that