### PR TITLE
Remove Times New Roman explicit calls on render

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/custom_questions/checkbox_seria.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/checkbox_seria.rb
@@ -10,9 +10,7 @@ module QaePdfForms::CustomQuestions::CheckboxSeria
 
     form_pdf.indent 7.mm do
       if title.present?
-        form_pdf.font("Times-Roman") do
-          form_pdf.render_text title, color: FormPdf::DEFAULT_ANSWER_COLOR
-        end
+        form_pdf.render_text title, color: FormPdf::DEFAULT_ANSWER_COLOR
       else
         checkbox_possible_ops.each do |key, value|
           question_option_box value

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/textarea.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/textarea.rb
@@ -238,10 +238,8 @@ module QaePdfForms::CustomQuestions::Textarea
   def print_pdf(line, lines_style)
     form_pdf.indent 7.mm do
       if line.present?
-        form_pdf.font("Times-Roman") do
-          form_pdf.text "#{line}", lines_style if lines_style.present?
-          form_pdf.move_down 2.mm
-        end
+        form_pdf.text "#{line}", lines_style if lines_style.present?
+        form_pdf.move_down 2.mm
       end
     end
   end

--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -71,19 +71,17 @@ module QaePdfForms::General::DrawElements
 
   def base_link_sceleton(url, filename, description=nil, ops = {})
     indent (ops[:description_left_margin] || 0) do
-      font("Times-Roman") do
-        formatted_text [{
-                          text: filename,
-                          link: url,
-                          styles: [:underline]
-                        }]
+      formatted_text [{
+                        text: filename,
+                        link: url,
+                        styles: [:underline]
+                      }]
 
-        move_down 3.mm
+      move_down 3.mm
 
-        if description.present?
-          text description,
-               color: FormPdf::DEFAULT_ANSWER_COLOR
-        end
+      if description.present?
+        text description,
+             color: FormPdf::DEFAULT_ANSWER_COLOR
       end
     end
   end
@@ -169,9 +167,7 @@ module QaePdfForms::General::DrawElements
   def render_standart_answer_block(title)
     if title.present?
       indent 7.mm do
-        font("Times-Roman") do
-          render_text title, color: FormPdf::DEFAULT_ANSWER_COLOR
-        end
+        render_text title, color: FormPdf::DEFAULT_ANSWER_COLOR
       end
     end
   end

--- a/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
@@ -415,11 +415,9 @@ class QaePdfForms::General::QuestionPointer
 
       if list_rows.present?
         form_pdf.indent 7.mm do
-          form_pdf.font("Times-Roman") do
-            list_rows.each do |award|
-              form_pdf.render_text "#{award[1]} - #{PREVIOUS_AWARDS[award[0].to_s]}",
-                                   color: FormPdf::DEFAULT_ANSWER_COLOR
-            end
+          list_rows.each do |award|
+            form_pdf.render_text "#{award[1]} - #{PREVIOUS_AWARDS[award[0].to_s]}",
+                                 color: FormPdf::DEFAULT_ANSWER_COLOR
           end
         end
       end
@@ -432,13 +430,11 @@ class QaePdfForms::General::QuestionPointer
 
       if list_rows.present?
         form_pdf.indent 7.mm do
-          form_pdf.font("Times-Roman") do
-            list_rows.each do |award|
-              outcome = question.outcomes.detect { |o| o.value == award[2] }.try(:text)
+          list_rows.each do |award|
+            outcome = question.outcomes.detect { |o| o.value == award[2] }.try(:text)
 
-              form_pdf.render_text "#{award[1]} - #{PREVIOUS_AWARDS[award[0].to_s]} - #{outcome}",
-                                   color: FormPdf::DEFAULT_ANSWER_COLOR
-            end
+            form_pdf.render_text "#{award[1]} - #{PREVIOUS_AWARDS[award[0].to_s]} - #{outcome}",
+                                 color: FormPdf::DEFAULT_ANSWER_COLOR
           end
         end
       end
@@ -627,11 +623,8 @@ class QaePdfForms::General::QuestionPointer
         render_info_about_conditional_parent
       end
     end
-
-    form_pdf.font("Times-Roman") do
-      form_pdf.render_text (q_visible? ? sub_answer : ""),
-                           color: FormPdf::DEFAULT_ANSWER_COLOR
-    end
+    form_pdf.render_text (q_visible? ? sub_answer : ""),
+                         color: FormPdf::DEFAULT_ANSWER_COLOR
   end
 
   def question_option_title


### PR DESCRIPTION
Related story:
 - https://trello.com/c/S9GtNcmf/766-qae18-as-an-assessor-i-want-the-answer-font-in-the-printed-pdf-application-forms-to-be-the-same-as-the-question-text-so-that-it