### PR TITLE
Security: Timing Attack affecting rack-protection gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ gem 'vigilion-rails', '~> 1.0.5'
 gem "sidekiq", "~> 4.1.1"
 gem "sidekiq-cron", "~> 0.4.2"
 gem 'sinatra', require: nil
+gem "rack-protection", "1.5.5" # Sinatra's dependency
 
 # Redis
 gem 'redis-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -684,6 +684,7 @@ DEPENDENCIES
   pusher
   quiet_assets
   rack-mini-profiler (>= 0.10.1)
+  rack-protection (= 1.5.5)
   rack-ssl-enforcer
   rails (= 4.2.10)
   rails-html-sanitizer (~> 1.0.4)


### PR DESCRIPTION
- Upgrade `rack-protection` gem version to fix timing attack
vulnerability issue.
- Currently, I have upgraded the version to "1.5.5" as this also fixes the same issue.

https://trello.com/c/CbleNB3C/712-qae18-security-timing-attack-affecting-rack-protection-gem