### PR TITLE
Fix 'Assessment in progress' status for assessor users.

### DIFF
--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -446,7 +446,7 @@ class FormAnswerDecorator < ApplicationDecorator
 
   def dashboard_status(user_type = "")
     if object.submitted?
-      if user_type.downcase == "admin" && object.state == "assessment_in_progress"
+      if user_type.casecmp("admin").zero? && object.state == "assessment_in_progress"
         assessment_in_progress_status
       else
         state_text
@@ -460,10 +460,10 @@ class FormAnswerDecorator < ApplicationDecorator
 
   def assessment_in_progress_status
     if object.assessors.any?
-      object.assessors.pluck(:first_name, :last_name).map { |first_name, last_name| "#{first_name} #{last_name}" }.join(", ")
+      names_list = object.assessors.pluck(:first_name, :last_name)
+      names_list.map { |first_name, last_name| "#{first_name} #{last_name}" }.join(", ")
     else
       ASSESSORS_NOT_ASSIGNED
     end
   end
-
 end

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -444,14 +444,10 @@ class FormAnswerDecorator < ApplicationDecorator
     object.assessor_assignments.secondary.submitted?
   end
 
-  def dashboard_status
+  def dashboard_status(user_type = "")
     if object.submitted?
-      if object.state == "assessment_in_progress"
-        if object.assessors.any?
-          object.assessors.pluck(:first_name, :last_name).map { |first_name, last_name| "#{first_name} #{last_name}" }.join(", ")
-        else
-          ASSESSORS_NOT_ASSIGNED
-        end
+      if user_type.downcase == "admin" && object.state == "assessment_in_progress"
+        assessment_in_progress_status
       else
         state_text
       end
@@ -459,4 +455,15 @@ class FormAnswerDecorator < ApplicationDecorator
       progress_text
     end
   end
+
+  private
+
+  def assessment_in_progress_status
+    if object.assessors.any?
+      object.assessors.pluck(:first_name, :last_name).map { |first_name, last_name| "#{first_name} #{last_name}" }.join(", ")
+    else
+      ASSESSORS_NOT_ASSIGNED
+    end
+  end
+
 end

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -17,7 +17,7 @@
         - else
           span.urn-not-generated Not yet generated
     td = obj.award_type_short_name
-    td = obj.dashboard_status
+    td = obj.dashboard_status(current_admin.class.name)
     td = obj.sic_code
     td
       - app_comments = application_comments(obj.comments_count)

--- a/spec/decorators/form_answer_decorator_spec.rb
+++ b/spec/decorators/form_answer_decorator_spec.rb
@@ -95,12 +95,12 @@ describe FormAnswerDecorator do
       expect(described_class.new(form_answer).dashboard_status).to eq("Application in progress...11%")
     end
 
-    it "warns that assessors are not assigned if assessment is in progress and assessors are not assigned yet" do
+    it "warns that assessors are not assigned if assessment is in progress and assessors are not assigned yet for admin section" do
       form_answer = create(:form_answer, :trade, :submitted, state: "assessment_in_progress")
-      expect(described_class.new(form_answer).dashboard_status).to eq("Assessors are not assigned")
+      expect(described_class.new(form_answer).dashboard_status("admin")).to eq("Assessors are not assigned")
     end
 
-    it "returns assessors' names if assessment is in progress and assessors are assigned" do
+    it "returns assessors' names if assessment is in progress and assessors are assigned for admin section" do
       assessor1 = create(:assessor, :regular_for_all, first_name: "Jon", last_name: "Snow")
       assessor2 = create(:assessor, :regular_for_all, first_name: "Ramsay", last_name: "Snow")
 
@@ -114,7 +114,29 @@ describe FormAnswerDecorator do
       primary.save
       secondary.save
 
-      expect(described_class.new(form_answer).dashboard_status).to eq("Jon Snow, Ramsay Snow")
+      expect(described_class.new(form_answer).dashboard_status("admin")).to eq("Jon Snow, Ramsay Snow")
+    end
+
+    it "warns that assessors are not assigned if assessment is in progress and assessors are not assigned yet for assessor section" do
+      form_answer = create(:form_answer, :trade, :submitted, state: "assessment_in_progress")
+      expect(described_class.new(form_answer).dashboard_status).to eq("Assessment in progress")
+    end
+
+    it "returns assessors' names if assessment is in progress and assessors are assigned for assessor section" do
+      assessor1 = create(:assessor, :regular_for_all, first_name: "Jon", last_name: "Snow")
+      assessor2 = create(:assessor, :regular_for_all, first_name: "Ramsay", last_name: "Snow")
+
+      form_answer = create(:form_answer, :trade, :submitted, state: "assessment_in_progress")
+
+      primary = form_answer.assessor_assignments.primary
+      secondary = form_answer.assessor_assignments.secondary
+
+      primary.assessor = assessor1
+      secondary.assessor = assessor2
+      primary.save
+      secondary.save
+
+      expect(described_class.new(form_answer).dashboard_status).to eq("Assessment in progress")
     end
 
     it "returns application state after assessment is ended" do


### PR DESCRIPTION
https://trello.com/c/m2ACbJbE/685-qae18imp-as-an-assessor-when-assessment-is-in-progress-i-want-the-status-field-to-display-assessment-in-progress-rather-than-the