### PR TITLE
Add extended applications scope for assessors to see previous apps within their category

### DIFF
--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -45,7 +45,7 @@ class Assessor::FormAnswersController < Assessor::BaseController
   private
 
   def resource
-    @form_answer ||= current_assessor.applications_scope.find(params[:id]).decorate
+    @form_answer ||= current_assessor.extended_applications_scope.find(params[:id]).decorate
   end
 
   def category_picker

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -95,6 +95,19 @@ class Assessor < ApplicationRecord
     ", c, [0, 1], id, "withdrawn")
   end
 
+  # we're using extended scope on the resource page
+  # to allow assessors to cross check progresss
+  # with account's other applications
+  # they were not assigned to
+  def extended_applications_scope
+    c = assigned_categories_as(%w(lead regular))
+
+    out = FormAnswer.where("
+      form_answers.award_type in (?)
+      AND form_answers.state NOT IN (?)
+    ", c, "withdrawn")
+  end
+
   def full_name
     "#{first_name} #{last_name}".strip
   end


### PR DESCRIPTION
https://trello.com/c/2Zd4eeVf/1162-qae0920-support-email-re-permissions-for-assessors-to-view-past-applications