### PR TITLE
ease the restrictions for assessors

### DIFF
--- a/app/models/assessor_assignment.rb
+++ b/app/models/assessor_assignment.rb
@@ -75,6 +75,11 @@ class AssessorAssignment < ApplicationRecord
 
   def visible_for?(subject)
     return true if owner_or_administrative?(subject)
+    # Adds ability to view assessments of past applications
+    if subject.is_a?(Assessor) && form_answer.award_year.year < AwardYear.current.year
+      return true
+    end
+
     # regular assessors flow
     assessments = Array(self)
     assessments << form_answer.assessor_assignments.secondary if primary?
@@ -83,6 +88,7 @@ class AssessorAssignment < ApplicationRecord
     if assessments.all?(&:submitted?)
       return assessments.any? { |a| a.assessor_id == subject.id }
     end
+
     false
   end
 

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -112,10 +112,10 @@ class FormAnswerPolicy < ApplicationPolicy
   end
 
   def can_download_original_pdf_of_application_before_deadline?
-    can_update_by_admin_lead_and_primary_assessors? &&
-    record.submitted? &&
-    record.submission_ended? &&
-    record.pdf_version.present?
+    (can_update_by_admin_lead_and_primary_assessors? || assessor?) &&
+      record.submitted? &&
+      record.submission_ended? &&
+      record.pdf_version.present?
   end
 
   def can_add_collaborators_to_application?

--- a/spec/models/assessor_assignment_spec.rb
+++ b/spec/models/assessor_assignment_spec.rb
@@ -128,6 +128,29 @@ describe AssessorAssignment do
         expect(moderated.visible_for?(lead)).to eq(true)
       end
     end
+
+    context "for previous award year" do
+      let(:previous_award_year) { AwardYear.for_year(AwardYear.current.year - 1).first_or_create }
+      let(:lead) {create(:assessor, :lead_for_all)}
+
+      it "moderated form is not visible" do
+        form_answer.award_year = previous_award_year
+        form_answer.save!
+
+        moderated = form_answer.assessor_assignments.moderated
+        expect(moderated.visible_for?(assessor1)).to eq(true)
+        expect(moderated.visible_for?(assessor2)).to eq(true)
+        expect(moderated.visible_for?(lead)).to eq(true)
+
+        expect(primary.visible_for?(assessor1)).to eq(true)
+        expect(primary.visible_for?(assessor2)).to eq(true)
+        expect(primary.visible_for?(lead)).to eq(true)
+
+        expect(secondary.visible_for?(assessor1)).to eq(true)
+        expect(secondary.visible_for?(assessor2)).to eq(true)
+        expect(secondary.visible_for?(lead)).to eq(true)
+      end
+    end
   end
 
   context "moderated assessment" do


### PR DESCRIPTION
so they can compare the progress of the applicant compared to previous years

https://trello.com/c/xh7aPOeE/1163-qaeimp-as-a-panel-member-i-want-to-see-past-awards-in-case-summary-so-that-i-know-if-they-won-before