### PR TITLE
display previous wins in CS for an applicant from our data

### DIFF
--- a/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
@@ -55,19 +55,14 @@ module CaseSummaryPdfs::General::DataPointer
   end
 
   def current_awards
-    if current_awards_question.present?
-      answer = filled_answers[current_awards_question.key.to_s]
+    awarded_applications = form_answers.account.form_answers.winners.where.not(id: form_answer.id)
 
-      if answer.present?
-        res = answer.map do |item|
-          if item["category"].present? && item["year"].present? && (item["outcome"].nil? || item["outcome"] == "won")
-            "#{item["year"]} - #{PREVIOUS_AWARDS[item["category"].to_s]}"
-          end
-        end.compact
-
-        res.present? ? res.join(", ") : undefined_value
-      else
-        undefined_value
+    if awarded_applications.any?
+      wins = awarded_applications.map do |application|
+        "#{application.award_type_full_name} #{application.award_year.year}"
+      end
+      wins.each_slice(4).map do |wins_group|
+        wins_group.join(", ")
       end
     else
       undefined_value

--- a/app/pdf_generators/case_summary_pdfs/general/draw_elements.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/draw_elements.rb
@@ -83,7 +83,17 @@ module CaseSummaryPdfs::General::DrawElements
   end
 
   def render_current_awards(offset: 0)
-    pdf_doc.text_box "Current Awards: #{current_awards}",
-            header_text_properties.merge(width: 650.mm, at: [0.mm, y_coord('awards').mm + default_offset + offset])
+    current_awards.each_with_index do |awards_line, index|
+      if index == 0
+        pdf_doc.text_box "Current Awards: #{awards_line}",
+                         header_text_properties.merge(width: 650.mm, at: [0.mm, y_coord('awards').mm + default_offset + offset])
+      else
+        pdf_doc.text_box "#{awards_line}",
+                         header_text_properties.merge(width: 650.mm, at: [0.mm, y_coord('awards').mm + default_offset + offset - index * ONE_LINE_OFFSET])
+
+        pdf_doc.move_down ONE_LINE_OFFSET
+      end
+    end
+
   end
 end


### PR DESCRIPTION
https://trello.com/c/xh7aPOeE/1163-qaeimp-as-a-panel-member-i-want-to-see-past-awards-in-case-summary-so-that-i-know-if-they-won-before

Example of numerous awards fitting in CS:
![image](https://user-images.githubusercontent.com/332810/94134345-8899f100-fe6a-11ea-81f3-6598fc2ebb29.png)
