### PR TITLE
🐛 Fix paragraph formatting for feedback text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,7 +119,7 @@ module ApplicationHelper
     if paragraphs.present?
       paragraphs.map! { |paragraph|
         raw(paragraph)
-      }.join("\n\n").html_safe
+      }.join("<br/><br/>").html_safe
     end
   end
 


### PR DESCRIPTION
As part of assessing a QAE award application, QAE assessors leave
feedback through a WYSWIYG editor in their browser. This is stored as
regular text with normal control characters such as `\n` for
line-breaks. Unfortunately, regular control characters are ignored by
HTML, meaning we need to do a little work to ensure text is properly
formatted when rendered in our views.

This commit fixes our `qae_simple_format` helper so that paragraphs are
separated using HTML line breaks, `<br/>`, rather than `\n` control
characters, which are ignored by HTML.

<img width="778" alt="Screenshot 2020-10-09 at 13 49 24" src="https://user-images.githubusercontent.com/1914715/95584899-54136100-0a36-11eb-9c33-a4201ebb284a.png">
<img width="768" alt="Screenshot 2020-10-09 at 13 49 46" src="https://user-images.githubusercontent.com/1914715/95584905-57a6e800-0a36-11eb-9515-af0f23210e9d.png">
