### PR TITLE
Fix formatting of feedback form sections in QAE admin dashboard

### DIFF
--- a/app/views/admin/feedbacks/_feedback_fields.html.slim
+++ b/app/views/admin/feedbacks/_feedback_fields.html.slim
@@ -4,14 +4,20 @@ strong = feedback_field_value[:label]
     label.form-label
       | Key strength
   .form-value.no-js-update
-    p = feedback.public_send("#{feedback_field}_strength").presence || content_tag(:i, "No feedback has been added yet")
+    - if feedback.public_send("#{feedback_field}_strength").present?
+      p = qae_simple_format(feedback.public_send("#{feedback_field}_strength"))
+    - else
+      p = content_tag(:i, "No feedback has been added yet")
   .input.form-group
     = f.input "#{feedback_field}_strength", as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{form_answer.id}-#{f.object.id}-#{feedback_field}-strength" }, label: false
   .clear
 
   label.form-label Information to strengthen the application
   .form-value.no-js-update
-    p = feedback.public_send("#{feedback_field}_weakness").presence || content_tag(:i, "No feedback has been added yet")
+    - if feedback.public_send("#{feedback_field}_weakness").present?
+      p = qae_simple_format(feedback.public_send("#{feedback_field}_weakness"))
+    - else
+      p = content_tag(:i, "No feedback has been added yet")
   .input.form-group
     = f.input "#{feedback_field}_weakness", as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{form_answer.id}-#{f.object.id}-#{feedback_field}-weakness" }, label: false
   .clear

--- a/app/views/admin/feedbacks/_feedback_fields.html.slim
+++ b/app/views/admin/feedbacks/_feedback_fields.html.slim
@@ -1,32 +1,34 @@
-strong = feedback_field_value[:label]
-.form-group class=feedback_field
-  - unless feedback.form_answer.development?
-    label.form-label
-      | Key strength
-  .form-value.no-js-update
-    - if feedback.public_send("#{feedback_field}_strength").present?
-      p = qae_simple_format(feedback.public_send("#{feedback_field}_strength"))
-    - else
-      p = content_tag(:i, "No feedback has been added yet")
-  .input.form-group
-    = f.input "#{feedback_field}_strength", as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{form_answer.id}-#{f.object.id}-#{feedback_field}-strength" }, label: false
-  .clear
+.form-group
+  .form-container
+    strong = feedback_field_value[:label]
+    .form-group class=feedback_field
+      - unless feedback.form_answer.development?
+        label.form-label
+          | Key strength
+      .form-value.no-js-update
+        - if feedback.public_send("#{feedback_field}_strength").present?
+          p = qae_simple_format(feedback.public_send("#{feedback_field}_strength"))
+        - else
+          p = content_tag(:i, "No feedback has been added yet")
+      .input.form-group
+        = f.input "#{feedback_field}_strength", as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{form_answer.id}-#{f.object.id}-#{feedback_field}-strength" }, label: false
+      .clear
 
-  label.form-label Information to strengthen the application
-  .form-value.no-js-update
-    - if feedback.public_send("#{feedback_field}_weakness").present?
-      p = qae_simple_format(feedback.public_send("#{feedback_field}_weakness"))
-    - else
-      p = content_tag(:i, "No feedback has been added yet")
-  .input.form-group
-    = f.input "#{feedback_field}_weakness", as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{form_answer.id}-#{f.object.id}-#{feedback_field}-weakness" }, label: false
-  .clear
+      label.form-label Information to strengthen the application
+      .form-value.no-js-update
+        - if feedback.public_send("#{feedback_field}_weakness").present?
+          p = qae_simple_format(feedback.public_send("#{feedback_field}_weakness"))
+        - else
+          p = content_tag(:i, "No feedback has been added yet")
+      .input.form-group
+        = f.input "#{feedback_field}_weakness", as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{form_answer.id}-#{f.object.id}-#{feedback_field}-weakness" }, label: false
+      .clear
 
-  - if policy(feedback).update?
-    = link_to "#", class: "form-edit-link pull-right" do
-      span.glyphicon.glyphicon-pencil
-      ' Edit
-    .form-actions.text-right
-      = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
-      = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
-.clear
+      - if policy(feedback).update?
+        = link_to "#", class: "form-edit-link pull-right" do
+          span.glyphicon.glyphicon-pencil
+          ' Edit
+        .form-actions.text-right
+          = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
+          = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
+    .clear

--- a/app/views/admin/feedbacks/_overall_feedback_field.html.slim
+++ b/app/views/admin/feedbacks/_overall_feedback_field.html.slim
@@ -1,7 +1,10 @@
 strong Overall Summary
 .form-group
   .form-value.no-js-update
-    p = feedback.overall_summary.presence || content_tag(:i, "No feedback has been added yet")
+    - if feedback.overall_summary.present?
+      p = qae_simple_format(feedback.overall_summary)
+    - else
+      p = content_tag(:i, "No feedback has been added yet")
   .input.form-group
     = f.input :overall_summary, as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-overall_summary" }, label: false
   .clear

--- a/app/views/admin/feedbacks/_overall_feedback_field.html.slim
+++ b/app/views/admin/feedbacks/_overall_feedback_field.html.slim
@@ -1,19 +1,20 @@
-strong Overall Summary
 .form-group
-  .form-value.no-js-update
-    - if feedback.overall_summary.present?
-      p = qae_simple_format(feedback.overall_summary)
-    - else
-      p = content_tag(:i, "No feedback has been added yet")
-  .input.form-group
-    = f.input :overall_summary, as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-overall_summary" }, label: false
-  .clear
+  .form-container
+    strong Overall Summary
+    .form-value.no-js-update
+      - if feedback.overall_summary.present?
+        p = qae_simple_format(feedback.overall_summary)
+      - else
+        p = content_tag(:i, "No feedback has been added yet")
+    .input.form-group
+      = f.input :overall_summary, as: :text, input_html: { class: 'form-control js-char-count', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-overall_summary" }, label: false
+    .clear
 
-  - if policy(feedback).update?
-    = link_to "#", class: "form-edit-link pull-right" do
-      span.glyphicon.glyphicon-pencil
-      ' Edit
-    .form-actions.text-right
-      = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
-      = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
-.clear
+    - if policy(feedback).update?
+      = link_to "#", class: "form-edit-link pull-right" do
+        span.glyphicon.glyphicon-pencil
+        ' Edit
+      .form-actions.text-right
+        = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
+        = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right"
+    .clear

--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -37,7 +37,7 @@
             small.panel-subtitle-small
               | This will be sent  to the applicants to help improve their business and/or future award applications
               br
-              | Note: this section is pre-populated with the Primary appraisal, so it can be eddited if necessary
+              | Note: this section is pre-populated with the Primary appraisal, so it can be edited if necessary
             - if @form_answer.feedback_updated_by
               small
                 = @form_answer.feedback_updated_by

--- a/app/views/assessor/form_answers/_submitted_view.html.slim
+++ b/app/views/assessor/form_answers/_submitted_view.html.slim
@@ -40,7 +40,7 @@
             small.panel-subtitle-small
               | This will be sent  to the applicants to help improve their business and/or future award applications
               br
-              | Note: this section is pre-populated with the Primary appraisal, so it can be eddited if necessary
+              | Note: this section is pre-populated with the Primary appraisal, so it can be edited if necessary
             - if @form_answer.feedback_updated_by
               small
                 = @form_answer.feedback_updated_by


### PR DESCRIPTION
This PR fixes a handful of UI bugs that I've spotted whilst working on the feedback section of the QAE admin dashboard

1. Makes use of the existing `qae_simple_format` helper to correctly replace `\n` control characters with HTML `<br/>` tags, allowing text to render as paragraphs on screen.
1. Add missing `form-group` and `form-container` divs around feedback sections, ensuring they render within a grey box like all other input sections in the admin dashboard.
1. Fix a typo, `Edited` rather than `Editted`.

Each change is introduced as its own commit with a meaningful description of the change.

https://trello.com/c/MQOGvtRP

**BEFORE**
<img width="860" alt="Screenshot 2020-10-13 at 13 05 30" src="https://user-images.githubusercontent.com/1914715/95858337-d95b8600-0d54-11eb-9221-e8e65e212ecf.png">

**AFTER**
<img width="795" alt="Screenshot 2020-10-13 at 13 05 47" src="https://user-images.githubusercontent.com/1914715/95858349-dc567680-0d54-11eb-88bc-c47a5df814e1.png">
