### PR TITLE
♻️ Remove AJAX from submission of appraisal form

### DIFF
--- a/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
@@ -1,9 +1,7 @@
 - if policy(assessment).can_be_submitted? || policy(assessment).can_be_re_submitted?
   = form_tag(url_for([namespace_name, :assessment_submissions]),
-            remote: true,
             authenticity_token: true,
-            class: "submit-assessment",
-            "data-type" => "json")
+            class: "submit-assessment")
 
     = hidden_field_tag :assessment_id, assessment.id
 

--- a/spec/features/assessor/appraisal_form_submission_spec.rb
+++ b/spec/features/assessor/appraisal_form_submission_spec.rb
@@ -27,7 +27,6 @@ describe "Assessor submits appraisal form", %(
       within "#section-appraisal-form-primary" do
         click_button "Submit appraisal"
       end
-      expect(page).to have_selector(".feedback-holder", text: "Assessment submitted")
       expect(form_answer.assessor_assignments.primary).to be_submitted
     end
   end


### PR DESCRIPTION
We recently received some feedback from the QAE team about
"intermittent" or "random" behaviour copying assessor comments from the
appraisal form into the "feedback" section of the page. We suspect one
source of confusion could be our use of AJAX to `POST` the appraisal
form to the server, which updates the persisted `feedback` in the
back-end, but won't re-render the feedback in the DOM. To the user, it
now seems that something is amiss as the submitting appraisal form
(seemingly) hasn't been pulled into the feedback section, as they
expect.

This PR updates the appraisal form to submit using regular HTTP,
rather than AJAX, meaning the DOM will reload in the user's browser.
Allowing the DOM to reload will trigger a re-rendering of the feedback
section, ensuring the submitted appraisal notes are now visible to the
user in the feedback section.

https://trello.com/c/MQOGvtRP/1181-qaeimp-case-summary-primary-assessor-feedback-not-consistently-pulled-through-ex-qa0606-21i