### PR TITLE
More Event Auditing Improvements For QAE

### DIFF
--- a/app/controllers/admin/audit_logs_controller.rb
+++ b/app/controllers/admin/audit_logs_controller.rb
@@ -1,6 +1,6 @@
 class Admin::AuditLogsController < Admin::BaseController
   def index
     authorize :audit_log, :index?
-    @audit_logs = AuditLog.all.order(id: :desc).page(params[:page])
+    @audit_logs = AuditLog.data_export.order(id: :desc).page(params[:page])
   end
 end

--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -38,6 +38,11 @@ class Admin::FormAnswersController < Admin::BaseController
                       .page(params[:page])
   end
 
+  def show
+    super
+    @audit_logs = FormAnswerAuditor.new(@form_answer).get_logs
+  end
+
   def edit
     authorize resource
     sign_in(@form_answer.user, scope: :user, skip_session_limitable: true)

--- a/app/controllers/admin/palace_attendees_controller.rb
+++ b/app/controllers/admin/palace_attendees_controller.rb
@@ -1,3 +1,4 @@
 class Admin::PalaceAttendeesController < Admin::BaseController
+  after_action :log_event, only: [:create, :update, :destroy]
   include PalaceAttendeesMixin
 end

--- a/app/controllers/admin/press_summaries_controller.rb
+++ b/app/controllers/admin/press_summaries_controller.rb
@@ -1,3 +1,4 @@
 class Admin::PressSummariesController < Admin::BaseController
+  after_action :log_event, only: [:update, :signoff]
   include PressSummaryMixin
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -135,7 +135,7 @@ class ApplicationController < ActionController::Base
 
   def log_event
     AuditLog.create!(
-      subject: current_subject,
+      subject: current_user || current_subject,
       auditable: form_answer,
       action_type: action_type
       )

--- a/app/controllers/assessor/palace_attendees_controller.rb
+++ b/app/controllers/assessor/palace_attendees_controller.rb
@@ -1,3 +1,4 @@
 class Assessor::PalaceAttendeesController < Assessor::BaseController
+  after_action :log_event, only: [:create, :update, :destroy]
   include PalaceAttendeesMixin
 end

--- a/app/controllers/assessor/press_summaries_controller.rb
+++ b/app/controllers/assessor/press_summaries_controller.rb
@@ -1,3 +1,4 @@
 class Assessor::PressSummariesController < Assessor::BaseController
+  after_action :log_event, only: [:update, :signoff]
   include PressSummaryMixin
 end

--- a/app/controllers/concerns/palace_attendees_mixin.rb
+++ b/app/controllers/concerns/palace_attendees_mixin.rb
@@ -84,4 +84,8 @@ module PalaceAttendeesMixin
       :id
     )
   end
+
+  def action_type
+    "palace_attendee_#{action_name}"
+  end
 end

--- a/app/controllers/concerns/press_summary_mixin.rb
+++ b/app/controllers/concerns/press_summary_mixin.rb
@@ -58,6 +58,14 @@ module PressSummaryMixin
 
   private
 
+  def form_answer
+    load_form_answer
+  end
+
+  def action_type
+    "press_summary_#{action_name}"
+  end
+
   def change_state(message)
     @press_summary.save!
 

--- a/app/controllers/palace_invites_controller.rb
+++ b/app/controllers/palace_invites_controller.rb
@@ -1,6 +1,7 @@
 class PalaceInvitesController < ApplicationController
   before_action :load_invite
   before_action :require_palace_invite_to_be_not_submitted_and_proper_stage!
+  before_action :log_event, only: [:update]
 
   def update
     if palace_invite_attributes.present? &&
@@ -55,5 +56,13 @@ class PalaceInvitesController < ApplicationController
 
       return
     end
+  end
+
+  def action_type
+    params[:submit] ? "palace_attendee_submit" : "palace_attendee_update"
+  end
+
+  def form_answer
+    @invite.form_answer
   end
 end

--- a/app/controllers/users/audit_certificates_controller.rb
+++ b/app/controllers/users/audit_certificates_controller.rb
@@ -1,6 +1,7 @@
 class Users::AuditCertificatesController < Users::BaseController
 
   before_action :check_if_audit_certificate_already_exist!, only: [:create]
+  before_action :log_event, only: [:show, :create]
 
   expose(:form_answer) do
     current_user.account.
@@ -63,6 +64,10 @@ class Users::AuditCertificatesController < Users::BaseController
   end
 
   private
+
+  def action_type
+    action_name == "show" ? "audit_certificate_downloaded" : "audit_certificate_uploaded"
+  end
 
   def audit_certificate_params
     # This is fix of "missing 'audit_certificate' param"

--- a/app/controllers/users/press_summaries_controller.rb
+++ b/app/controllers/users/press_summaries_controller.rb
@@ -6,6 +6,7 @@ class Users::PressSummariesController < Users::BaseController
                 except: [:acceptance, :update_acceptance, :success, :failure]
 
   before_action :require_press_summary_to_be_valid!, only: [:show, :update]
+  after_action :log_event, only:[:update]
 
   expose(:form_answer) do
     FormAnswer.find(params[:form_answer_id])
@@ -49,10 +50,14 @@ class Users::PressSummariesController < Users::BaseController
 
   private
 
+  def action_type
+    params[:submit] ? "press_summary_submit" : "press_summary_update"
+  end
+
   def press_summary_params
     params.require(:press_summary).permit(
-      :comment, 
-      :correct, 
+      :comment,
+      :correct,
       :title,
       :name,
       :last_name,

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -515,6 +515,14 @@ class FormAnswerDecorator < ApplicationDecorator
     "#{award_type_full_name} #{award_year.year - 1} - #{award_year.year}"
   end
 
+  def last_updated_at
+    latest_update && latest_update.created_at.strftime("%d/%m/%Y")
+  end
+
+  def last_updated_by
+    latest_update && latest_update.subject.full_name
+  end
+
   private
 
   def assessment_in_progress_status
@@ -532,5 +540,9 @@ class FormAnswerDecorator < ApplicationDecorator
 
   def sanitize_html(str)
     html_full_sanitizer.sanitize(str)
+  end
+
+  def latest_update
+    object.audit_logs.order("created_at").last
   end
 end

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -1,5 +1,5 @@
 class AuditLog < ApplicationRecord
-  validates :subject_type, inclusion: { in: %w(Admin Assessor Judge) }, presence: true
+  validates :subject_type, inclusion: { in: %w(Admin User Assessor Judge) }, presence: true
   validates :subject_id, presence: true
   validates :action_type, presence: true
 

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -6,6 +6,8 @@ class AuditLog < ApplicationRecord
   belongs_to :subject, polymorphic: true
   belongs_to :auditable, polymorphic: true
 
+  scope :data_export, -> { AuditLog.where(auditable_type: nil).or(AuditLog.where(action_type: "download_form_answer")) }
+
   def to_s
     "On #{date_string} at #{time_string} #{user_string} #{description_for_action_type(action_type)}"
   end

--- a/app/search/form_answer_search.rb
+++ b/app/search/form_answer_search.rb
@@ -53,6 +53,13 @@ class FormAnswerSearch < Search
       .order("assessor_full_name #{sort_order(desc)}").group("assessors.first_name, assessors.last_name")
   end
 
+  def sort_by_updated_at(scoped_results, desc = false)
+    scoped_results
+      .joins("LEFT OUTER JOIN (SELECT audit_logs.auditable_id, audit_logs.auditable_type, MAX(audit_logs.created_at) latest_audit_date FROM audit_logs GROUP BY audit_logs.auditable_id, audit_logs.auditable_type) max_audit_dates ON max_audit_dates.auditable_id = form_answers.id AND max_audit_dates.auditable_type = 'FormAnswer'")
+      .order("COALESCE(max_audit_dates.latest_audit_date, '2010-10-31') #{sort_order(desc)}")
+      .group("max_audit_dates.latest_audit_date")
+  end
+
   def filter_by_status(scoped_results, value)
     scoped_results.where(state: filter_klass.internal_states(value))
   end

--- a/app/services/form_answer_auditor.rb
+++ b/app/services/form_answer_auditor.rb
@@ -1,0 +1,31 @@
+class FormAnswerAuditor
+
+  def initialize(form_answer)
+    @form_answer = form_answer
+  end
+
+  def get_logs
+    logs = @form_answer.audit_logs + create_logs_from_papertrail_versions(@form_answer)
+    logs.sort_by(&:created_at)
+  end
+
+  private
+
+  def create_logs_from_papertrail_versions(form_answer)
+    form_answer.versions.map do |version|
+      AuditLog.new(
+        auditable_type: "FormAnswer",
+        auditable_id: form_answer.id,
+        action_type: "application_#{version.event}",
+        subject: get_user_from_papertrail_version(version),
+        created_at: version.created_at
+        )
+    end
+  end
+
+  def get_user_from_papertrail_version(version)
+    klass, id = version.whodunnit.split(":")
+    klass.capitalize.constantize.find_by_id(id)
+  end
+
+end

--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -66,5 +66,5 @@
           ' Application Audit Log
     #section-logs.section-application-info.panel-collapse.collapse role="tabpanel" aria-labelledby="logs-heading"
       .panel-body
-        - @form_answer.audit_logs.sort_by(&:created_at).reverse.each do |log|
+        - @audit_logs.reverse.each do |log|
           p = log.to_s

--- a/app/views/admin/form_answers/list_components/_table.html.slim
+++ b/app/views/admin/form_answers/list_components/_table.html.slim
@@ -14,8 +14,8 @@ table.table.applications-table
         = sort_link f, "Applied before", @search, :applied_before, disabled: @search.query?
       th.sortable width="110"
         = sort_link f, "Flag", @search, :flag, disabled: @search.query?
-      / th.sortable width="130"
-        / = sort_link f, "Last updated", @search, :updated_at, disabled: @search.query?
+      th.sortable width="130"
+        = sort_link f, "Last updated", @search, :updated_at, disabled: @search.query?
       th &nbsp;
   tbody
     = render("admin/form_answers/list_components/table_body")

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -27,9 +27,9 @@
 
       = application_flags(obj, current_subject)
       = application_flags(obj)
-    / td
-      / = obj.updated_at.strftime("%d/%m/%Y")
-      / br
-      / span.muted
-        / = "by Scarborough"
+    td
+      = obj.last_updated_at
+      br
+      span.muted
+        = obj.last_updated_by
     td = link_to "View", review_admin_form_answer_path(obj), target: "_blank", class: "icon-view"

--- a/app/views/assessor/form_answers/_list_body.html.slim
+++ b/app/views/assessor/form_answers/_list_body.html.slim
@@ -36,8 +36,8 @@ tbody
             = app_comments
         = application_flags(obj)
         = application_flags(obj, current_subject)
-      / td
-        / = obj.updated_at.strftime("%d/%m/%Y")
-        / br
-        / span.muted
-          / = "by Scarborough"
+      td
+        = obj.last_updated_at
+        br
+        span.muted
+          = obj.last_updated_by

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -66,8 +66,8 @@ h1.admin-page-heading
             = render("assessor/form_answers/assessor_header", f: f)
             th.sortable width="110"
               = sort_link f, "Flag", @search, :flag, disabled: @search.query?
-            / th.sortable width="130"
-              / = sort_link f, "Last updated", @search, :updated_at, disabled: @search.query?
+            th.sortable width="130"
+              = sort_link f, "Last updated", @search, :updated_at, disabled: @search.query?
           = render(partial: "assessor/form_answers/list_body")
   .row
   .col-xs-12.text-right

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -252,6 +252,8 @@ en:
       press_summary_update: "updated press book notes"
       press_summary_submit: "confirmed press book notes"
       press_summary_signoff: "signed off press release"
+      application_create: "created the award application"
+      application_update: "updated the award application"
 
   form_answers:
     state:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,6 +249,9 @@ en:
       palace_attendee_submit: "confirmed Buckingham Palace attendee details"
       palace_attendee_create: "added a new Buckingham Palace attendee"
       palace_attendee_destroy: "deleted a Buckingham Palace attendee"
+      press_summary_update: "updated press book notes"
+      press_summary_submit: "confirmed press book notes"
+      press_summary_signoff: "signed off press release"
 
   form_answers:
     state:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -243,6 +243,8 @@ en:
       moderated_appraisal_unsubmit: "unsubmitted moderated appraisal"
       case_summary_submit: "submitted case summary"
       case_summary_unsubmit: "unsubmitted case summary"
+      audit_certificate_downloaded: "downloaded verification of commerical figures form"
+      audit_certificate_uploaded: "uploaded verification of commerical figures form"
 
   form_answers:
     state:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,10 @@ en:
       case_summary_unsubmit: "unsubmitted case summary"
       audit_certificate_downloaded: "downloaded verification of commerical figures form"
       audit_certificate_uploaded: "uploaded verification of commerical figures form"
+      palace_attendee_update: "upated Buckingham Palace attendee details"
+      palace_attendee_submit: "confirmed Buckingham Palace attendee details"
+      palace_attendee_create: "added a new Buckingham Palace attendee"
+      palace_attendee_destroy: "deleted a Buckingham Palace attendee"
 
   form_answers:
     state:


### PR DESCRIPTION
This MR introduces the following features:

1. Add logging for download/upload of the commercial figures form.
1. Add logging for user/admin/assessor changes to the Buckingham Palace attendee list.
1. Add logging for user changes/confirmation of press book notes and admin/assessor sign-off.
1. Reinstate the sortable "Last Updated" column when viewing list of applications as both an admin or assessor.
1. Reinstate paper-trail logs within the "Application Audit Log" panel.
1. Update logic "Data Export Log" to ensure this only show logs for data export and isn't polluted with other events.

https://trello.com/c/YQlNYgcA/1160-qaeimp-last-updated-column-on-applications-page