### PR TITLE
QAE Event Auditing Tweaks

### DIFF
--- a/app/controllers/admin/assessor_assignments_controller.rb
+++ b/app/controllers/admin/assessor_assignments_controller.rb
@@ -1,3 +1,4 @@
 class Admin::AssessorAssignmentsController < Admin::BaseController
+  after_action :log_event, only: [:update]
   include AssessorAssignmentContext
 end

--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -40,7 +40,7 @@ class Admin::FormAnswersController < Admin::BaseController
 
   def show
     super
-    @audit_logs = FormAnswerAuditor.new(@form_answer).get_logs
+    @audit_events = FormAnswerAuditor.new(@form_answer).get_audit_events
   end
 
   def edit

--- a/app/controllers/assessor/assessor_assignments_controller.rb
+++ b/app/controllers/assessor/assessor_assignments_controller.rb
@@ -1,3 +1,4 @@
 class Assessor::AssessorAssignmentsController < Assessor::BaseController
+  after_action :log_event, only: [:update]
   include AssessorAssignmentContext
 end

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -1,0 +1,32 @@
+class AuditEvent
+  attr_accessor :form_answer, :action_type, :subject, :created_at
+
+  def initialize(form_answer:, action_type:, subject:, created_at:)
+    @form_answer = form_answer
+    @action_type = action_type
+    @subject = subject
+    @created_at = created_at
+  end
+
+  def to_s
+    "On #{date_string} at #{time_string} #{user_string} #{description_for_action_type(action_type)}"
+  end
+
+  private
+
+  def date_string
+    created_at.in_time_zone("London").strftime("%d/%m/%Y")
+  end
+
+  def time_string
+    created_at.in_time_zone("London").strftime("%H:%M")
+  end
+
+  def description_for_action_type(action_type)
+    I18n.translate("audit_logs.action_types.#{action_type}")
+  end
+
+  def user_string
+    "#{subject.full_name} (#{subject.class.name})"
+  end
+end

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -7,26 +7,4 @@ class AuditLog < ApplicationRecord
   belongs_to :auditable, polymorphic: true
 
   scope :data_export, -> { AuditLog.where(auditable_type: nil).or(AuditLog.where(action_type: "download_form_answer")) }
-
-  def to_s
-    "On #{date_string} at #{time_string} #{user_string} #{description_for_action_type(action_type)}"
-  end
-
-  private
-
-  def date_string
-    created_at.in_time_zone("London").strftime("%d/%m/%Y")
-  end
-
-  def time_string
-    created_at.in_time_zone("London").strftime("%H:%M")
-  end
-
-  def description_for_action_type(action_type)
-    I18n.translate("audit_logs.action_types.#{action_type}")
-  end
-
-  def user_string
-    "#{subject.full_name} (#{subject.class.name})"
-  end
 end

--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -66,5 +66,5 @@
           ' Application Audit Log
     #section-logs.section-application-info.panel-collapse.collapse role="tabpanel" aria-labelledby="logs-heading"
       .panel-body
-        - @audit_logs.reverse.each do |log|
+        - @audit_events.reverse.each do |log|
           p = log.to_s


### PR DESCRIPTION
This PR achieves the following goals:

1. Add missing logging callbacks for the submission of appraisal notes and case summaries.
2. Adds a new `AuditEvent` [PORO](https://dev.to/sulmanweb/plain-old-ruby-objects-poros-in-rails-fat-models-3l7f) that represents an auditable event from `AuditLog` and `PaperTrail::Version` records. This offer a clean separation of concern between the display of an audit log and the underlying database tables.

https://trello.com/c/YQlNYgcA/1160-qaeimp-last-updated-column-on-applications-page