### PR TITLE
🐛 Handle logging without authenticated user

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -27,10 +27,6 @@ class Admin::BaseController < ApplicationController
     :admin
   end
 
-  def current_subject
-    current_admin
-  end
-
   def user_for_paper_trail
     "ADMIN:#{current_admin.id}" if current_admin.present?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -135,7 +135,7 @@ class ApplicationController < ActionController::Base
 
   def log_event
     AuditLog.create!(
-      subject: current_user || current_subject,
+      subject: current_subject,
       auditable: form_answer,
       action_type: action_type
       )
@@ -188,6 +188,25 @@ class ApplicationController < ActionController::Base
         :agree_being_contacted_by_department_of_business
       ]
     )
+  end
+
+  def current_subject
+    current_user || current_admin || current_assessor || current_judge || dummy_user
+  end
+
+  def dummy_user
+    User.find_by(email: "dummy_user@bitzesty.com") || User.create!(dummy_user_params)
+  end
+
+  def dummy_user_params
+   {
+     email: "dummy_user@bitzesty.com",
+     password: SecureRandom.base64(16),
+     agreed_with_privacy_policy: '1',
+     role: "regular",
+     first_name: "Unknown",
+     last_name: "User"
+   }
   end
 
   def check_account_completion

--- a/app/controllers/assessor/base_controller.rb
+++ b/app/controllers/assessor/base_controller.rb
@@ -23,10 +23,6 @@ class Assessor::BaseController < ApplicationController
     :assessor
   end
 
-  def current_subject
-    current_assessor
-  end
-
   def user_not_authorized
     flash.alert = "You are not authorized to perform this action."
     redirect_to(assessor_root_path)

--- a/app/controllers/judge/base_controller.rb
+++ b/app/controllers/judge/base_controller.rb
@@ -23,10 +23,6 @@ class Judge::BaseController < ApplicationController
     :judge
   end
 
-  def current_subject
-    current_judge
-  end
-
   def user_not_authorized
     flash.alert = "You are not authorized to perform this action."
     redirect_to(judge_root_path)


### PR DESCRIPTION
We're currently seeing a failing spec due to our attempts to log updates
to the `press_summary` resource. Until now, we've assumed that changes
to a resource require a user to be logged in, although the
`press_summary` resource doesn't actually require authentication since
it'll often be completed by someone who doesn't have a QAE login. The
URL does, however, contain a secret token, so the public URLs aren't
easily guessable.

This commit refactors the `current_user` helper method so that it's no
longer defined in multiple places. If an authenticated user can't be
found, we'll log the action against a "dummy user", instead.

https://trello.com/c/YQlNYgcA/1160-qaeimp-last-updated-column-on-applications-page

<img width="800" alt="Screenshot 2020-10-19 at 16 05 08" src="https://user-images.githubusercontent.com/1914715/96469369-0b715a00-1225-11eb-8e6f-f14db51e5ffc.png">
