### PR TITLE
🐛 Handle `nil` values for `PaperTrail::Version.whodunnit`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 require "app_responder"
+include AuditHelper
 
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
@@ -192,21 +193,6 @@ class ApplicationController < ActionController::Base
 
   def current_subject
     current_user || current_admin || current_assessor || current_judge || dummy_user
-  end
-
-  def dummy_user
-    User.find_by(email: "dummy_user@bitzesty.com") || User.create!(dummy_user_params)
-  end
-
-  def dummy_user_params
-   {
-     email: "dummy_user@bitzesty.com",
-     password: SecureRandom.base64(16),
-     agreed_with_privacy_policy: '1',
-     role: "regular",
-     first_name: "Unknown",
-     last_name: "User"
-   }
   end
 
   def check_account_completion

--- a/app/helpers/audit_helper.rb
+++ b/app/helpers/audit_helper.rb
@@ -1,0 +1,19 @@
+module AuditHelper
+
+  def dummy_user
+    User.find_by(email: "dummy_user@bitzesty.com") || User.create!(dummy_user_params)
+  end
+
+  private
+
+  def dummy_user_params
+   {
+     email: "dummy_user@example.com",
+     password: SecureRandom.base64(16),
+     agreed_with_privacy_policy: '1',
+     role: "regular",
+     first_name: "Unknown",
+     last_name: "User"
+   }
+  end
+end

--- a/app/services/form_answer_auditor.rb
+++ b/app/services/form_answer_auditor.rb
@@ -1,4 +1,5 @@
 class FormAnswerAuditor
+  include AuditHelper
 
   def initialize(form_answer)
     @form_answer = form_answer
@@ -34,6 +35,7 @@ class FormAnswerAuditor
   end
 
   def get_user_from_papertrail_version(version)
+    return dummy_user if version.whodunnit.nil?
     klass, id = version.whodunnit.split(":")
     klass.capitalize.constantize.find_by_id(id)
   end


### PR DESCRIPTION
We've recently seen some Sentry errors trying to call `.split` on a
`nil` object. After looking closer at the issue, it seems we're
occasionally having trouble generating our list of `AuditEvent` records
due to some `PaperTrail::Version` objects having a `nil` value for
`whodunnit`.

This commit avoids the runtime error by moving our `dummy_user` helper
method out of `ApplicationController` and into a reusable `audit_helper`
module. This allows us to return a dummy user record whenever the
`PaperTrail` `whodunnit` value is `nil`.