### PR TITLE
🐛 Define current_subject in each controller

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -16,6 +16,10 @@ class Admin::BaseController < ApplicationController
     current_admin
   end
 
+  def current_subject
+    current_admin
+  end
+
   private
 
   def user_not_authorized

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -191,10 +191,6 @@ class ApplicationController < ActionController::Base
     )
   end
 
-  def current_subject
-    current_user || current_admin || current_assessor || current_judge || dummy_user
-  end
-
   def check_account_completion
     if !current_user.completed_registration?
       redirect_to correspondent_details_account_path

--- a/app/controllers/assessor/base_controller.rb
+++ b/app/controllers/assessor/base_controller.rb
@@ -15,6 +15,10 @@ class Assessor::BaseController < ApplicationController
     current_assessor
   end
 
+  def current_subject
+    current_assessor
+  end
+
   private
 
   helper_method :namespace_name, :current_subject

--- a/app/controllers/judge/base_controller.rb
+++ b/app/controllers/judge/base_controller.rb
@@ -15,6 +15,10 @@ class Judge::BaseController < ApplicationController
     current_judge
   end
 
+  def current_subject
+    current_judge
+  end
+
   private
 
   helper_method :namespace_name, :current_subject


### PR DESCRIPTION
We've recently started to see the below runtime error in Sentry:

```
ActionView::Template::Error: undefined method `lead?' for #<User:0x00007f69ed22f278>
```

The `lead?` method is defined on our `admin` and `assessor` models,
though it seems that we're now calling it on an instance of `user`. I
suspect this change in behaviour relates to my recent attempts to DRY up
the code, unifying all instances of `current_subject` into a single
method in `application_controller`.

This commit reverts my previous refactoring, allowing each controller
to implement the `current_subject` helper method as appropriate.