### PR TITLE
🐛 Ensure `current_subject` can always be called

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -142,6 +142,10 @@ class ApplicationController < ActionController::Base
       )
   end
 
+  def current_subject
+    current_user || dummy_user
+  end
+
   #
   # Disabling browser caching in order
   # to protect sensitive data


### PR DESCRIPTION
To ensure our activity logging works as expected, it's important that
all controllers implement a `current_subject` method. Many controllers
define this method themselves, though for any controllers where the
method hasn't been defined, it should be inherited.

This commit defines `current_subject` on our base `application_controller`
and ensures that, even when there's no authenticated user, a dummy user
is returned.