### PR TITLE
♻️ Change collaborators check from 3 to 6 months

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -44,6 +44,6 @@ class Account < ApplicationRecord
   end
 
   def collaborators_checked?
-    collaborators_checked_at && collaborators_checked_at > Time.zone.now - 3.months
+    collaborators_checked_at && collaborators_checked_at > Time.zone.now - 6.months
   end
 end


### PR DESCRIPTION
In a recent(ish) update we added some new logic to ensure that users
review (and potentially amend) their account collaborators every 3
months. Unfortunately, this change in behaviour generated a spike in
support requests for the QAE team as users were confused by the forced
redirect and didn't understand/notice the instructions to review and
confirm their collaborators on screen.

This commit bumps the collaborators grace period from 3 to 6 months,
thus reducing the frequency with which QAE users will be prompted to
review their collaborator users. Furthermore, extending this period
should reduce the number of users seeing the prompt during busy periods
(for example, around the submission deadline).

https://trello.com/c/BtUgUjoY/1186-prompt-users-to-review-their-collaborators-every-6-months-rather-than-3-months