### PR TITLE
✨ Add "Application Audit Log" panel for assessors

### DIFF
--- a/app/controllers/assessor/form_answers_controller.rb
+++ b/app/controllers/assessor/form_answers_controller.rb
@@ -42,6 +42,11 @@ class Assessor::FormAnswersController < Assessor::BaseController
                       .page(params[:page])
   end
 
+  def show
+    super
+    @audit_events = FormAnswerAuditor.new(@form_answer).get_audit_events
+  end
+
   private
 
   def resource

--- a/app/views/assessor/form_answers/_submitted_view.html.slim
+++ b/app/views/assessor/form_answers/_submitted_view.html.slim
@@ -61,3 +61,13 @@
               = render "admin/form_answers/section_press_summary"
             - if show_palace_attendees_subsection?
               = render "admin/form_answers/section_palace_attendees"
+
+  .panel.panel-default.panel-parent
+    .panel-heading#logs-heading role="tab"
+      h4.panel-title
+        a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-logs" aria-expanded="true" aria-controls="section-logs"
+          ' Application Audit Log
+    #section-logs.section-application-info.panel-collapse.collapse role="tabpanel" aria-labelledby="logs-heading"
+      .panel-body
+        - @audit_events.reverse.each do |log|
+          p = log.to_s


### PR DESCRIPTION
Now that we're instrumenting far more events in the QAE system, QAE have
requested that audit logs for each application be made available to
assessor users, as well as admins.

<img width="813" alt="Screenshot 2020-10-20 at 13 34 14" src="https://user-images.githubusercontent.com/1914715/96586474-f7873000-12d8-11eb-96e5-161d337fddb5.png">
