### PR TITLE
fix form answer sorting by audit dates

### DIFF
--- a/app/search/form_answer_search.rb
+++ b/app/search/form_answer_search.rb
@@ -53,10 +53,10 @@ class FormAnswerSearch < Search
       .order("assessor_full_name #{sort_order(desc)}").group("assessors.first_name, assessors.last_name")
   end
 
-  def sort_by_updated_at(scoped_results, desc = false)
+  def sort_by_audit_updated_at(scoped_results, desc = false)
     scoped_results
       .joins("LEFT OUTER JOIN (SELECT audit_logs.auditable_id, audit_logs.auditable_type, MAX(audit_logs.created_at) latest_audit_date FROM audit_logs GROUP BY audit_logs.auditable_id, audit_logs.auditable_type) max_audit_dates ON max_audit_dates.auditable_id = form_answers.id AND max_audit_dates.auditable_type = 'FormAnswer'")
-      .order("COALESCE(max_audit_dates.latest_audit_date, '2010-10-31') #{sort_order(desc)}")
+      .order("COALESCE(max_audit_dates.latest_audit_date, TO_DATE('20101031', 'YYYYMMDD')) #{sort_order(desc)}")
       .group("max_audit_dates.latest_audit_date")
   end
 

--- a/app/views/admin/form_answers/list_components/_table.html.slim
+++ b/app/views/admin/form_answers/list_components/_table.html.slim
@@ -15,7 +15,7 @@ table.table.applications-table
       th.sortable width="110"
         = sort_link f, "Flag", @search, :flag, disabled: @search.query?
       th.sortable width="130"
-        = sort_link f, "Last updated", @search, :updated_at, disabled: @search.query?
+        = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
       th &nbsp;
   tbody
     = render("admin/form_answers/list_components/table_body")

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -67,7 +67,7 @@ h1.admin-page-heading
             th.sortable width="110"
               = sort_link f, "Flag", @search, :flag, disabled: @search.query?
             th.sortable width="130"
-              = sort_link f, "Last updated", @search, :updated_at, disabled: @search.query?
+              = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
           = render(partial: "assessor/form_answers/list_body")
   .row
   .col-xs-12.text-right


### PR DESCRIPTION
updated_at is a field in form_answers table so the sorting was not working properly.

Actually have no idea how it introduced bugs, and how I've fixed those bugs later, cause this method should have never been called in the first place.