### PR TITLE
♻️ Move logging from callbacks and into actions

### DIFF
--- a/app/controllers/admin/assessment_submissions_controller.rb
+++ b/app/controllers/admin/assessment_submissions_controller.rb
@@ -1,4 +1,3 @@
 class Admin::AssessmentSubmissionsController < Admin::BaseController
-  after_action :log_event, only: [:create, :unlock]
   include AssessmentSubmissionMixin
 end

--- a/app/controllers/admin/assessor_assignments_controller.rb
+++ b/app/controllers/admin/assessor_assignments_controller.rb
@@ -1,4 +1,3 @@
 class Admin::AssessorAssignmentsController < Admin::BaseController
-  after_action :log_event, only: [:update]
   include AssessorAssignmentContext
 end

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -1,6 +1,5 @@
 class Admin::CommentsController < Admin::BaseController
   helper_method :form_answer
-  after_action :log_event, only: [:create, :update, :destroy]
 
   def new
     @comment = form_answer.comments.build
@@ -16,7 +15,7 @@ class Admin::CommentsController < Admin::BaseController
     authorize @comment, :create?
 
     @comment.authorable = current_admin
-    @comment.save
+    log_event if @comment.save
 
     respond_to do |format|
       format.html do
@@ -36,7 +35,7 @@ class Admin::CommentsController < Admin::BaseController
 
   def update
     authorize resource, :update?
-    resource.update(update_params)
+    log_event if resource.update(update_params)
 
     respond_to do |format|
       format.html { redirect_to([namespace_name, form_answer]) }
@@ -47,7 +46,7 @@ class Admin::CommentsController < Admin::BaseController
   def destroy
     authorize resource, :destroy?
 
-    resource.destroy
+    log_event if resource.destroy
 
     respond_to do |format|
       format.json{ render(json: :ok)}

--- a/app/controllers/admin/feedbacks_controller.rb
+++ b/app/controllers/admin/feedbacks_controller.rb
@@ -1,5 +1,4 @@
 class Admin::FeedbacksController < Admin::BaseController
-  after_action :log_event, only: [:create, :update, :destroy, :submit, :unlock]
   include FeedbackMixin
 
   expose(:form_answer) do

--- a/app/controllers/admin/form_answer_attachments_controller.rb
+++ b/app/controllers/admin/form_answer_attachments_controller.rb
@@ -1,4 +1,3 @@
 class Admin::FormAnswerAttachmentsController < Admin::BaseController
-  after_action :log_event, only: [:create, :destroy]
   include ::FormAnswerAttachmentsContext
 end

--- a/app/controllers/admin/palace_attendees_controller.rb
+++ b/app/controllers/admin/palace_attendees_controller.rb
@@ -1,4 +1,3 @@
 class Admin::PalaceAttendeesController < Admin::BaseController
-  after_action :log_event, only: [:create, :update, :destroy]
   include PalaceAttendeesMixin
 end

--- a/app/controllers/assessor/assessment_submissions_controller.rb
+++ b/app/controllers/assessor/assessment_submissions_controller.rb
@@ -1,4 +1,3 @@
 class Assessor::AssessmentSubmissionsController < Assessor::BaseController
-  after_action :log_event, only: [:create, :unlock]
   include AssessmentSubmissionMixin
 end

--- a/app/controllers/assessor/assessor_assignments_controller.rb
+++ b/app/controllers/assessor/assessor_assignments_controller.rb
@@ -1,4 +1,3 @@
 class Assessor::AssessorAssignmentsController < Assessor::BaseController
-  after_action :log_event, only: [:update]
   include AssessorAssignmentContext
 end

--- a/app/controllers/assessor/comments_controller.rb
+++ b/app/controllers/assessor/comments_controller.rb
@@ -1,13 +1,12 @@
 class Assessor::CommentsController < Assessor::BaseController
   helper_method :form_answer
-  after_action :log_event, only: [:create, :update, :destroy]
 
   def create
     @comment = form_answer.comments.build(create_params)
     authorize @comment, :create?
 
     @comment.authorable = current_assessor
-    @comment.save
+    log_event if @comment.save
 
     respond_to do |format|
       format.html do
@@ -27,7 +26,7 @@ class Assessor::CommentsController < Assessor::BaseController
 
   def update
     authorize resource, :update?
-    resource.update(update_params)
+    log_event if resource.update(update_params)
 
     respond_to do |format|
       format.html { redirect_to([namespace_name, form_answer]) }
@@ -38,7 +37,7 @@ class Assessor::CommentsController < Assessor::BaseController
   def destroy
     authorize resource, :destroy?
 
-    resource.destroy
+    log_event if resource.destroy
 
     respond_to do |format|
       format.json { render(json: :ok) }

--- a/app/controllers/assessor/feedbacks_controller.rb
+++ b/app/controllers/assessor/feedbacks_controller.rb
@@ -1,4 +1,3 @@
 class Assessor::FeedbacksController < Assessor::BaseController
-  after_action :log_event, only: [:create, :update, :destroy, :submit, :unlock]
   include FeedbackMixin
 end

--- a/app/controllers/assessor/form_answer_attachments_controller.rb
+++ b/app/controllers/assessor/form_answer_attachments_controller.rb
@@ -1,4 +1,3 @@
 class Assessor::FormAnswerAttachmentsController < Assessor::BaseController
-  after_action :log_event, only: [:create, :destroy]
   include ::FormAnswerAttachmentsContext
 end

--- a/app/controllers/assessor/palace_attendees_controller.rb
+++ b/app/controllers/assessor/palace_attendees_controller.rb
@@ -1,4 +1,3 @@
 class Assessor::PalaceAttendeesController < Assessor::BaseController
-  after_action :log_event, only: [:create, :update, :destroy]
   include PalaceAttendeesMixin
 end

--- a/app/controllers/concerns/assessment_submission_mixin.rb
+++ b/app/controllers/concerns/assessment_submission_mixin.rb
@@ -3,6 +3,7 @@ module AssessmentSubmissionMixin
     authorize resource, :submit?
     @service = AssessmentSubmissionService.new(resource, current_subject)
     @service.perform
+    log_event if resource.reload.locked_at.present?
 
     respond_to do |format|
       format.json { render(json_response) }
@@ -15,6 +16,7 @@ module AssessmentSubmissionMixin
   def unlock
     authorize resource, :can_unlock?
     resource.update_column(:locked_at, nil)
+    log_event
 
     redirect_to [namespace_name, resource.form_answer]
   end

--- a/app/controllers/concerns/assessor_assignment_context.rb
+++ b/app/controllers/concerns/assessor_assignment_context.rb
@@ -5,6 +5,7 @@ module AssessorAssignmentContext
 
     respond_to do |format|
       if assessment.save
+        log_event
         format.json { render json: { errors: [] } }
       else
         format.json { render status: :unprocessable_entity,

--- a/app/controllers/concerns/feedback_mixin.rb
+++ b/app/controllers/concerns/feedback_mixin.rb
@@ -20,7 +20,7 @@ module FeedbackMixin
 
     authorize @feedback, :create?
     @feedback.authorable = current_subject
-    @feedback.save
+    log_event if @feedback.save
 
     render_create
   end
@@ -30,7 +30,7 @@ module FeedbackMixin
 
     @feedback.assign_attributes(feedback_params)
     @feedback.authorable = current_subject
-    @feedback.save
+    log_event if @feedback.save
 
     render_create
   end
@@ -96,7 +96,7 @@ module FeedbackMixin
   end
 
   def save_and_render_submit(action)
-    @feedback.save
+    log_event if @feedback.save
 
     respond_to do |format|
       format.html do

--- a/app/controllers/concerns/form_answer_attachments_context.rb
+++ b/app/controllers/concerns/form_answer_attachments_context.rb
@@ -4,6 +4,8 @@ module FormAnswerAttachmentsContext
     authorize service.resource, :create?
 
     if service.save
+      log_event
+
       respond_to do |format|
         format.html do
           redirect_to [namespace_name, form_answer]
@@ -40,7 +42,7 @@ module FormAnswerAttachmentsContext
 
   def destroy
     authorize resource, :destroy?
-    resource.destroy
+    log_event if resource.destroy
 
     respond_to do |format|
       format.html do

--- a/app/controllers/concerns/palace_attendees_mixin.rb
+++ b/app/controllers/concerns/palace_attendees_mixin.rb
@@ -13,6 +13,7 @@ module PalaceAttendeesMixin
     limit = palace_invite.attendees_limit
     if palace_invite.palace_attendees.count < limit
       palace_attendee = palace_invite.palace_attendees.create(create_params)
+      log_event if palace_attendee.persisted?
       render_attendee_form(palace_attendee, palace_invite)
     else
       head :ok
@@ -23,14 +24,14 @@ module PalaceAttendeesMixin
     authorize form_answer, :update?
 
     palace_attendee = palace_invite.palace_attendees.find(params[:id])
-    palace_attendee.update(create_params)
+    log_event if palace_attendee.update(create_params)
     render_attendee_form(palace_attendee, palace_invite)
   end
 
   def destroy
     authorize form_answer, :update?
     palace_attendee = palace_invite.palace_attendees.find(params[:id])
-    palace_attendee.destroy
+    log_event if palace_attendee.destroy
     respond_to do |format|
       format.html { redirect_to [namespace_name, form_answer] }
       format.js { head :ok }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,7 +245,7 @@ en:
       case_summary_unsubmit: "unlocked case summary"
       audit_certificate_downloaded: "downloaded verification of commercial figures form"
       audit_certificate_uploaded: "uploaded verification of commercial figures form"
-      palace_attendee_update: "upated Buckingham Palace attendee details"
+      palace_attendee_update: "updated Buckingham Palace attendee details"
       palace_attendee_submit: "confirmed Buckingham Palace attendee details"
       palace_attendee_create: "added a new Buckingham Palace attendee"
       palace_attendee_destroy: "deleted a Buckingham Palace attendee"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,7 +250,7 @@ en:
       palace_attendee_create: "added a new Buckingham Palace attendee"
       palace_attendee_destroy: "deleted a Buckingham Palace attendee"
       press_summary_update: "updated press book notes"
-      press_summary_submit: "confirmed press book notes"
+      press_summary_submit: "submitted press book notes"
       press_summary_signoff: "signed off press release"
       application_create: "created the award application"
       application_update: "updated the award application"


### PR DESCRIPTION
Until now we've been calling the `log_event` method for any/all requests
that route to particular controller actions. Unfortunately, this means
that new `audit_log` records will be written even when the requests
fail, meaning we're logging requests that made no changes to the
database.

This commit moves our call(s) to `log_event` out of controller callbacks
and into the appropriate parts of our controller action(s), thus
allowing us to more precisely instrument our requests.

https://trello.com/c/YQlNYgcA/1160-qaeimp-add-a-last-updated-column-on-applications-page-and-add-logging-actions-throughout-the-app