### PR TITLE
🐛 Separate data export logs from data update logs

### DIFF
--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -543,6 +543,6 @@ class FormAnswerDecorator < ApplicationDecorator
   end
 
   def latest_update
-    object.audit_logs.order("created_at").last
+    object.audit_logs.data_update.order("created_at").last
   end
 end

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -7,4 +7,5 @@ class AuditLog < ApplicationRecord
   belongs_to :auditable, polymorphic: true
 
   scope :data_export, -> { AuditLog.where(auditable_type: nil).or(AuditLog.where(action_type: "download_form_answer")) }
+  scope :data_update, -> { AuditLog.where(auditable_type: "FormAnswer").where("action_type != 'download_form_answer'") }
 end

--- a/app/search/form_answer_search.rb
+++ b/app/search/form_answer_search.rb
@@ -55,7 +55,9 @@ class FormAnswerSearch < Search
 
   def sort_by_audit_updated_at(scoped_results, desc = false)
     scoped_results
-      .joins("LEFT OUTER JOIN (SELECT audit_logs.auditable_id, audit_logs.auditable_type, MAX(audit_logs.created_at) latest_audit_date FROM audit_logs GROUP BY audit_logs.auditable_id, audit_logs.auditable_type) max_audit_dates ON max_audit_dates.auditable_id = form_answers.id AND max_audit_dates.auditable_type = 'FormAnswer'")
+      .joins("LEFT OUTER JOIN (SELECT audit_logs.auditable_id, audit_logs.auditable_type, MAX(audit_logs.created_at) latest_audit_date FROM audit_logs
+       WHERE audit_logs.action_type != 'download_form_answer'
+       GROUP BY audit_logs.auditable_id, audit_logs.auditable_type) max_audit_dates ON max_audit_dates.auditable_id = form_answers.id AND max_audit_dates.auditable_type = 'FormAnswer'")
       .order("COALESCE(max_audit_dates.latest_audit_date, TO_DATE('20101031', 'YYYYMMDD')) #{sort_order(desc)}")
       .group("max_audit_dates.latest_audit_date")
   end

--- a/app/services/form_answer_auditor.rb
+++ b/app/services/form_answer_auditor.rb
@@ -13,7 +13,7 @@ class FormAnswerAuditor
   private
 
   def create_events_from_audit_logs(form_answer)
-    form_answer.audit_logs.map do |audit_log|
+    form_answer.audit_logs.data_update.map do |audit_log|
       AuditEvent.new(
         form_answer: form_answer,
         action_type: audit_log.action_type,


### PR DESCRIPTION
We've recently overhauled the data auditing functionality of QAE to
capture many more admin/assessor/applicant events. Historically, the
only captured events related to the exporting of applicant data, and
this is something we continue to capture for data protection purposes.

When we introduced new`AuditLog` records, we added a helpful
`data_export` scope to help separate the export logs from the
application update logs. Using this helpful scope, we could ensure that
application updates didn't appear in the "Data Export Log" page.
Unfortunately, we didn't create the inverse scope which means, until
now, exporting an application as a PDF file has been treated as a change
to an application, which is incorrect.

This MR introduces a new `data_update` scope that can be used to
retrieve only the `AuditLogs` that represent a change (update) to an
application. Furthermore, we update the raw SQL used in our sorting
logic to filter out `AuditLog` records where 
`action_type = download_form_answer`

https://trello.com/c/YQlNYgcA/1160-qaeimp-add-a-last-updated-column-on-applications-page-and-add-logging-actions-throughout-the-app