### PR TITLE
📝 Update non_shortlisted email copy

### DIFF
--- a/app/views/account_mailers/notify_non_shortlisted_mailer/notify.text.erb
+++ b/app/views/account_mailers/notify_non_shortlisted_mailer/notify.text.erb
@@ -1,14 +1,14 @@
 Dear <%= @user.decorate.full_name %>,
 
-Thank you for your application to the <%= @current_year %> Queen's Awards for Enterprise. We are very sorry to inform you that, this time, you have not been shortlisted.
+Thank you for your application to the <%= @current_year %> Queen's Awards for Enterprise. I am sorry to inform you that you have not been shortlisted.
 
 This year we received many high quality applications and the competition was particularly strong.
 
-We are aware that the application process is quite substantial and that feedback is important. We will, therefore, write again in April <%= @current_year %> to provide comprehensive feedback on your application, which we hope you will find useful for any future applications.
+We are aware that the application process is comprehensive and that feedback is important. We will, therefore, write again in April <%= @current_year %> to provide feedback on your application, which we hope you will find useful for any future applications.
 
-#Please note that The Queen's Awards Office will not have any further information on the assessment of your application before April, so will not be able to discuss anything relating to your <%= @current_year %> application until then.
+Please note that The Queen's Awards Office will not have any further information on the assessment of your application before April so will not be able to discuss anything related to your <%= @current_year %> application until then.
 
 Thank you for taking the time to enter The Queen's Awards for Enterprise.
 
-Nichola Bruno,
-Head of the Queen's Awards Office
+Nichola Bruno
+Head, The Queen's Awards Office

--- a/app/views/account_mailers/notify_non_shortlisted_mailer/preview/notify.html.slim
+++ b/app/views/account_mailers/notify_non_shortlisted_mailer/preview/notify.html.slim
@@ -4,19 +4,19 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' Thank you for your application to the
   => @current_year
-  | Queen's Awards for Enterprise. We are very sorry to inform you that, this time, you have not been shortlisted.
+  | Queen's Awards for Enterprise. I am sorry to inform you that you have not been shortlisted.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' This year we received many high quality applications and the competition was particularly strong.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' We are aware that the application process is quite substantial and that feedback is important. We will, therefore, write again in April
+  ' We are aware that the application process is comprehensive and that feedback is important. We will, therefore, write again in April
   => @current_year
-  | to provide comprehensive feedback on your application, which we hope you will find useful for any future applications.
+  | to provide feedback on your application, which we hope you will find useful for any future applications.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   strong
-    ' Please note that The Queen's Awards Office will not have any further information on the assessment of your application before April, so will not be able to discuss anything relating to your
+    ' Please note that The Queen's Awards Office will not have any further information on the assessment of your application before April so will not be able to discuss anything related to your
     => @current_year
     | application until then.
 
@@ -27,4 +27,4 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   br
   ' Nichola Bruno
   br
-  ' Head of the Queen's Awards Office
+  ' Head, the Queen's Awards Office


### PR DESCRIPTION
Each year QAE send out emails to notify applicants who, unfortunately,
haven't been short-listed for an award. Understandably, the content of
this email evolves over time, presumably to better set applicant
expectations and avoid a surge of support requests.

This commit updates the content of the mailer, as well as the on-screen
preview, to match the latest copy provided by the client.

https://trello.com/c/I7q6ywU1/1185-qae1020-update-the-content-of-the-email-sent-to-not-shortlisted-applicants

**Admin Preview**
<img width="1174" alt="Screenshot 2020-10-22 at 10 02 36" src="https://user-images.githubusercontent.com/1914715/96850569-dc3e3100-144e-11eb-9d14-7e37409997b7.png">

**Raw Email Content (Before Processing By Gov.uk Notify**
<img width="838" alt="Screenshot 2020-10-22 at 10 09 02" src="https://user-images.githubusercontent.com/1914715/96850560-da746d80-144e-11eb-8f79-823683019186.png">

