### PR TITLE
Fix CI Suite After QAE Copy Changes 

### DIFF
--- a/app/controllers/users/audit_certificates_controller.rb
+++ b/app/controllers/users/audit_certificates_controller.rb
@@ -16,10 +16,6 @@ class Users::AuditCertificatesController < Users::BaseController
     form_answer.audit_certificate
   end
 
-  expose(:deadline) do
-    form_answer.award_year.settings.deadlines.find{ |d| d.kind == "audit_certificates" }
-  end
-
   def show
     respond_to do |format|
       format.html

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -15,7 +15,7 @@ header.page-header.group class=('page-header-wider')
             li Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
             li If relevant, make changes or provide actual figures to replace estimates submitted at the time of application in the External Accountant's Report from. If you make any of these revisions, you have to sign the Applicant's Management's Statement section in the report.
             li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
-            li = "Login and upload the External Accountant's Report as well as the supplementary list of procedures document to this online portal by <strong> noon on #{deadline.trigger_at.strftime("%A %d %B")} </strong>".html_safe
+            li = "Login and upload the External Accountant's Report as well as the supplementary list of procedures document to this online portal by <strong> noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
       br
 
       = render "users/audit_certificates/upload_block", award: form_answer,

--- a/spec/features/users/form_answers/audit_certificate_request_spec.rb
+++ b/spec/features/users/form_answers/audit_certificate_request_spec.rb
@@ -30,7 +30,7 @@ So that I can check, complete it and then upload it to application
     it "should render page" do
       expect_to_see "Verification of Commercial Figures"
       expect(page).to have_link(
-        "this Verification of Commercial Figures",
+        "Download the External Accountant's Report form",
         href: users_form_answer_audit_certificate_url(form_answer, format: :pdf)
       )
     end


### PR DESCRIPTION
This PR resolves a handful of [CI failures](https://github.com/bitzesty/qae/runs/1293603513?check_suite_focus=true) after updating the copy around the download/upload of `audit_certificate` resources.

Please see individual commits for more information.

https://trello.com/c/mVosjF0g/1191-update-the-copy-shown-to-shortlisted-users-who-must-upload-verification-of-their-figures