### PR TITLE
✨ Implement list of procedures upload

### DIFF
--- a/app/assets/stylesheets/admin/page-settings.scss
+++ b/app/assets/stylesheets/admin/page-settings.scss
@@ -26,8 +26,7 @@
     }
   }
 
-  .form-value,
-  .date-time-text {
+  .form-value {
     display: inline-block;
     width: 39em;
 
@@ -36,6 +35,10 @@
       width: auto;
       margin-right: 10px;
     }
+  }
+
+  .date-time-text {
+    padding-right: 1em;
   }
 
   .edit-deadline {

--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -903,6 +903,11 @@ input[type="file"] {
   margin-top: -1.5em;
 }
 
+.button-upload {
+  padding: 0.5em !important;
+  margin: -4.5em 0.5em 0em 0.5em !important;
+}
+
 .button-add {
   @include core-19;
   position: relative;

--- a/app/controllers/admin/list_of_procedures_controller.rb
+++ b/app/controllers/admin/list_of_procedures_controller.rb
@@ -1,0 +1,3 @@
+class Admin::ListOfProceduresController < Admin::BaseController
+  include ListOfProceduresContext
+end

--- a/app/controllers/assessor/list_of_procedures_controller.rb
+++ b/app/controllers/assessor/list_of_procedures_controller.rb
@@ -1,0 +1,3 @@
+class Assessor::ListOfProceduresController < Assessor::BaseController
+  include ListOfProceduresContext
+end

--- a/app/controllers/concerns/list_of_procedures_context.rb
+++ b/app/controllers/concerns/list_of_procedures_context.rb
@@ -1,0 +1,16 @@
+module ListOfProceduresContext
+  def show
+    authorize form_answer, :download_list_of_procedures_pdf?
+    redirect_to resource.attachment_url
+  end
+
+  private
+
+  def resource
+    @list_of_procedures ||= form_answer.list_of_procedures
+  end
+
+  def form_answer
+    @form_answer ||= FormAnswer.find(params[:form_answer_id])
+  end
+end

--- a/app/controllers/users/audit_certificates_controller.rb
+++ b/app/controllers/users/audit_certificates_controller.rb
@@ -16,6 +16,10 @@ class Users::AuditCertificatesController < Users::BaseController
     form_answer.audit_certificate
   end
 
+  expose(:list_of_procedures) do
+    form_answer.list_of_procedures
+  end
+
   def show
     respond_to do |format|
       format.html

--- a/app/controllers/users/list_of_procedures_controller.rb
+++ b/app/controllers/users/list_of_procedures_controller.rb
@@ -1,0 +1,69 @@
+class Users::ListOfProceduresController < Users::BaseController
+
+  expose(:form_answer) do
+    current_user.account.
+                form_answers.
+                find(params[:form_answer_id])
+  end
+
+  expose(:list_of_procedures) do
+    form_answer.list_of_procedures
+  end
+
+  def create
+    self.list_of_procedures = form_answer.build_list_of_procedures(list_of_procedures_params)
+
+    saved = list_of_procedures.save
+    log_event if saved
+
+    respond_to do |format|
+      format.html do
+        if saved
+          redirect_to users_form_answer_audit_certificate_url(form_answer),
+                      notice: "List of Procedures successfully uploaded!"
+        else
+          render :show
+        end
+      end
+
+      format.json do
+        if saved
+          render json: list_of_procedures,
+                 status: :created,
+                 content_type: "text/plain"
+        else
+          render json: { errors: humanized_errors }.to_json,
+                 status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  private
+
+  def list_of_procedures_params
+    # Handle situation where user hasn't attached anything through the file picker
+    if params[:list_of_procedures].blank?
+      params.merge!(
+        list_of_procedures: {
+          attachment: ""
+        }
+      )
+    end
+
+    params.require(:list_of_procedures).permit(:attachment)
+  end
+
+  def action_type
+    "list_of_procedures_uploaded"
+  end
+
+  def humanized_errors
+    list_of_procedures.errors
+                     .full_messages
+                     .reject { |m| m == "Attachment This field cannot be blank" }
+                     .join(", ")
+                     .gsub("Attachment ", "")
+  end
+
+end

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -68,6 +68,7 @@ class FormAnswer < ApplicationRecord
     has_one :mobility_eligibility, class_name: 'Eligibility::Mobility', dependent: :destroy
     has_one :promotion_eligibility, class_name: 'Eligibility::Promotion', dependent: :destroy
     has_one :audit_certificate, dependent: :destroy
+    has_one :list_of_procedures, dependent: :destroy
     has_one :feedback, dependent: :destroy
     has_one :press_summary, dependent: :destroy
     has_one :draft_note, as: :notable, dependent: :destroy

--- a/app/models/list_of_procedures.rb
+++ b/app/models/list_of_procedures.rb
@@ -1,0 +1,46 @@
+class ListOfProcedures < ApplicationRecord
+  mount_uploader :attachment, ListOfProceduresUploader
+  scan_file      :attachment
+
+  include ::InfectedFileCleaner
+  clean_after_scan :attachment
+
+  begin :associations
+    belongs_to :form_answer
+    belongs_to :reviewable, polymorphic: true
+  end
+
+  begin :validations
+    validates :form_answer_id, uniqueness: true,
+                               presence: true
+    validates :attachment, presence: true,
+                           on: :create,
+                           file_size: {
+                             maximum: 5.megabytes.to_i
+                           }
+    validates :reviewable_type,
+              :reviewable_id,
+              :reviewed_at,
+              presence: true,
+              if: :reviewed?
+  end
+
+  before_save :clean_changes_description
+
+  enum status: {
+    no_changes_necessary: 0,
+    confirmed_changes: 1
+  }
+
+  def reviewed?
+    reviewed_at.present?
+  end
+
+  private
+
+  def clean_changes_description
+    if status_changed? && status == "no_changes_necessary" && changes_description.present?
+      self.changes_description = nil
+    end
+  end
+end

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -90,6 +90,13 @@ class FormAnswerPolicy < ApplicationPolicy
     (Rails.env.development? || record.audit_certificate.clean?)
   end
 
+  def download_list_of_procedures_pdf?
+    (admin? || subject.lead_or_assigned?(record)) &&
+    record.list_of_procedures.present? &&
+    record.list_of_procedures.attachment.present? &&
+    (Rails.env.development? || record.list_of_procedures.clean?)
+  end
+
   def create_audit_certificate_pdf?
     admin? || subject.lead_or_assigned?(record)
     (record.audit_certificate.nil? || record.audit_certificate.attachment.nil?)
@@ -103,8 +110,7 @@ class FormAnswerPolicy < ApplicationPolicy
     download_feedback_pdf? ||
     download_case_summary_pdf? ||
     (admin? || subject.lead_or_assigned?(record)) &&
-    record.audit_certificate.present? &&
-    record.audit_certificate.attachment.present?
+    (audit_certificate_available? || list_of_procedures_available?)
   end
 
   def can_download_initial_audit_certificate_pdf?
@@ -129,5 +135,15 @@ class FormAnswerPolicy < ApplicationPolicy
 
   def can_add_collaborators_to_application?
     admin?
+  end
+
+  private
+
+  def audit_certificate_available?
+    record.audit_certificate.present? && record.audit_certificate.attachment.present?
+  end
+
+  def list_of_procedures_available?
+    record.list_of_procedures.present? && record.list_of_procedures.attachment.present?
   end
 end

--- a/app/uploaders/list_of_procedures_uploader.rb
+++ b/app/uploaders/list_of_procedures_uploader.rb
@@ -1,0 +1,2 @@
+class ListOfProceduresUploader < FileUploader
+end

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -21,6 +21,13 @@
       li style="color:green"
         ' Scanning audit certificate. You may need to refresh the page.
 
+    - if resource.object.list_of_procedures.present? && resource.object.list_of_procedures.clean?
+      li
+        = link_to "View/print List of Procedures", [url_namespace, resource.object, resource.object.list_of_procedures], target: "_blank"
+    - elsif resource.object.list_of_procedures.present? && resource.object.list_of_procedures.attachment_scan_results.blank?
+      li style="color:green"
+        ' Scanning List of Procedures. You may need to refresh the page.
+
     - if policy(resource).download_case_summary_pdf?
       li
         = link_to "View/print Case Summary", admin_form_answer_case_summaries_path(resource.object, format: :pdf), target: admin_conditional_pdf_link_target(resource.object, "case_summary")

--- a/app/views/content_only/post_submission/_shortlisted.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted.html.slim
@@ -34,13 +34,13 @@
               span.pull-right
                 ' Due by
                 = application_deadline_short(:audit_certificates)
-              = link_to users_form_answer_audit_certificate_url(award)
-                - if award.audit_certificate.present?
-                  span.label-status.label-status-green
-                    ' Complete
-                - else
-                  span.label-status.label-status-red
-                    ' Incomplete
+              / = link_to users_form_answer_audit_certificate_url(award)
+              /   - if award.audit_certificate.present?
+              /     span.label-status.label-status-green
+              /       ' Complete
+              /   - else
+              /     span.label-status.label-status-red
+              /       ' Incomplete
         .clear
       .clear
   br

--- a/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
@@ -15,7 +15,7 @@ p
   ol
     li Follow the "Verification of Commercial Figures" link next to your Shortlisted entries below to download the External Accountant's Report form.
     li Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
-    li If relevant, make changes or provide actual figures to replace estimates submitted at the time of application in the External Accountant's Report from. If you make any of these revisions, you have to sign the Applicant's Management's Statement section in the report.
+    li If relevant, make changes or provide actual figures to replace estimates submitted at the time of application in the External Accountant's Report form. If you make any of these revisions, you have to sign the Applicant's Management's Statement section in the report.
     li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
     li = "Login and upload the External Accountant's Report as well as the supplementary list of procedures document to this online portal by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_time_short}</strong>".html_safe
 

--- a/app/views/users/audit_certificates/_file.html.slim
+++ b/app/views/users/audit_certificates/_file.html.slim
@@ -3,17 +3,17 @@
 
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
-      = link_to "Uploaded External Accountant's Report", att_record.attachment_url,
+      = link_to "Download External Accountant's Report", att_record.attachment_url,
                 target: "_blank", class: "js-audit-certificate-title"
     - elsif att_record.attachment_scan_results == "scanning"
       | Uploaded External Accountant's Report is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"
       | Uploaded file has been blocked (virus detected), please remove.
     - else
-      = link_to "Uploaded Verification of Commercial Figures", "",
+      = link_to "Download Verification of Commercial Figures", "",
                 target: "_blank", class: "js-audit-certificate-title"
   - else
       | Uploaded External Accountant's Report is being scanned for viruses.
 - else
-  = link_to "Uploaded Verification of Commercial Figures", "",
+  = link_to "Download Verification of Commercial Figures", "",
             target: "_blank", class: "js-audit-certificate-title"

--- a/app/views/users/audit_certificates/_non_js_form.html.slim
+++ b/app/views/users/audit_certificates/_non_js_form.html.slim
@@ -9,5 +9,5 @@
                 required: true,
                 label: "Upload Verification of Commercial Figures"
 
-  = f.submit "Upload", class: "button button-add non-js-audit-certificate-submit"
+  = f.submit "Upload", class: "button button-add button-upload non-js-audit-certificate-submit"
 .clear

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -14,7 +14,7 @@ header.page-header.group class=('page-header-wider')
           ol
             li = link_to("Download the External Accountant's Report form.", users_form_answer_audit_certificate_url(form_answer, format: :pdf))
             li Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
-            li If relevant, make changes or provide actual figures to replace estimates submitted at the time of application in the External Accountant's Report from. If you make any of these revisions, you have to sign the Applicant's Management's Statement section in the report.
+            li If relevant, make changes or provide actual figures to replace estimates submitted at the time of application in the External Accountant's Report form. If you make any of these revisions, you have to sign the Applicant's Management's Statement section in the report.
             li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
             li = "Login and upload the External Accountant's Report as well as the supplementary list of procedures document to this online portal by <strong> noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
       br

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -1,4 +1,5 @@
 - cert_exists = form_answer.audit_certificate.present? && form_answer.audit_certificate.persisted?
+- list_exists = form_answer.list_of_procedures.present? && form_answer.list_of_procedures.persisted?
 
 header.page-header.group class=('page-header-wider')
   div
@@ -20,6 +21,8 @@ header.page-header.group class=('page-header-wider')
 
       = render "users/audit_certificates/upload_block", award: form_answer,
                                                         cert_exists: cert_exists
+      = render "users/list_of_procedures/upload_block", award: form_answer,
+                                                        list_exists: list_exists
 
       footer
         nav.pagination.no-border aria-label="Pagination" role="navigation"

--- a/app/views/users/list_of_procedures/_file.html.slim
+++ b/app/views/users/list_of_procedures/_file.html.slim
@@ -1,0 +1,19 @@
+- if list_exists
+  - att_record = award.list_of_procedures
+
+  - if att_record.attachment_scan_results.present?
+    - if att_record.clean?
+      = link_to "Uploaded List of Procedures", att_record.attachment_url,
+                target: "_blank", class: "js-audit-certificate-title"
+    - elsif att_record.attachment_scan_results == "scanning"
+      | Uploaded List of Procedures is being scanned for viruses.
+    - elsif att_record.attachment_scan_results == "infected"
+      | Uploaded file has been blocked (virus detected), please remove.
+    - else
+      = link_to "Uploaded List of Procedures", "",
+                target: "_blank", class: "js-audit-certificate-title"
+  - else
+      | Uploaded List of Procedures is being scanned for viruses.
+- else
+  = link_to "Uploaded List of Procedures", "",
+            target: "_blank", class: "js-audit-certificate-title"

--- a/app/views/users/list_of_procedures/_file.html.slim
+++ b/app/views/users/list_of_procedures/_file.html.slim
@@ -3,17 +3,17 @@
 
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
-      = link_to "Uploaded List of Procedures", att_record.attachment_url,
+      = link_to "Download List of Procedures", att_record.attachment_url,
                 target: "_blank", class: "js-audit-certificate-title"
     - elsif att_record.attachment_scan_results == "scanning"
       | Uploaded List of Procedures is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"
       | Uploaded file has been blocked (virus detected), please remove.
     - else
-      = link_to "Uploaded List of Procedures", "",
+      = link_to "Download List of Procedures", "",
                 target: "_blank", class: "js-audit-certificate-title"
   - else
       | Uploaded List of Procedures is being scanned for viruses.
 - else
-  = link_to "Uploaded List of Procedures", "",
+  = link_to "Download List of Procedures", "",
             target: "_blank", class: "js-audit-certificate-title"

--- a/app/views/users/list_of_procedures/_form.html.slim
+++ b/app/views/users/list_of_procedures/_form.html.slim
@@ -1,0 +1,19 @@
+= simple_form_for (list_of_procedures || form_answer.build_list_of_procedures),
+                  as: :list_of_procedures,
+                  url: users_form_answer_list_of_procedures_path(form_answer),
+                  html: {class: "qae-form audit-certificate-upload-form #{"hidden" if list_exists}", method: :post} do |f|
+  .errors-container
+  .clear
+  span.button.button-add
+    span + Upload List of Procedures form
+    = f.input :attachment,
+              as: :file,
+              required: true,
+              label: false,
+              input_html: { class: "fileinput-button js-audit-certificate-file-upload" }
+
+  footer.display-none
+    nav.pagination role="navigation"
+      ul.group
+        li.submit
+          = f.submit "Upload", class: "button"

--- a/app/views/users/list_of_procedures/_non_js_form.html.slim
+++ b/app/views/users/list_of_procedures/_non_js_form.html.slim
@@ -1,0 +1,13 @@
+= simple_form_for (list_of_procedures || form_answer.build_list_of_procedures),
+                  as: :list_of_procedures,
+                  url: users_form_answer_list_of_procedures_path(form_answer),
+                  html: {class: "qae-form", method: :post} do |f|
+  ul.list-add
+    li
+      = f.input :attachment,
+                as: :file,
+                required: true,
+                label: "Upload List of Procedures form"
+
+  = f.submit "Upload", class: "button button-add non-js-audit-certificate-submit"
+.clear

--- a/app/views/users/list_of_procedures/_non_js_form.html.slim
+++ b/app/views/users/list_of_procedures/_non_js_form.html.slim
@@ -9,5 +9,5 @@
                 required: true,
                 label: "Upload List of Procedures form"
 
-  = f.submit "Upload", class: "button button-add non-js-audit-certificate-submit"
+  = f.submit "Upload", class: "button button-add button-upload non-js-audit-certificate-submit"
 .clear

--- a/app/views/users/list_of_procedures/_upload_block.html.slim
+++ b/app/views/users/list_of_procedures/_upload_block.html.slim
@@ -1,0 +1,15 @@
+.js-upload-wrapper data-max-attachments=1 data-form-name="audit-cert-form" data-name="audit-cert-name" data-filename="Uploaded List of Procedures"
+  ul.js-uploaded-list class=("hidden" unless list_exists)
+    li.li-audit-upload
+      div
+        = render "users/list_of_procedures/file", list_exists: list_exists,
+                                                  award: award
+
+  / JS Upload Form
+  .if-no-js-hide
+    = render "users/list_of_procedures/form", form_answer: award, audit_certificate: award.audit_certificate, list_exists: list_exists
+
+  / Non JS Upload Form
+  - unless list_exists
+    .if-js-hide
+      = render "users/list_of_procedures/non_js_form"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,7 +141,7 @@ en:
     buckingham_palace_confirm_press_book_notes: Press Book Entry confirmation due by
     buckingham_palace_reception_attendee_information_due_by: Buckingham Palace reception attendee information due by
     buckingham_palace_attendees_invite: Buckingham Palace Reception on
-    audit_certificates: Verification of Commercial Figures due by
+    audit_certificates: Verification of Commercial Figures (External Accountant's Report & List of Procedures) due by
 
   deadline_help_messages:
     award_year_switch: "This date marks the start of the new award year, and will update the website accordingly. Users will not yet be able to start any applications"
@@ -184,8 +184,8 @@ en:
     buckingham_palace_invite: "WINNERS : Buckingham Palace Invite - to heads of winning organisations only."
     unsuccessful_notification: "UNSUCCESSFUL: Email notification to unsuccessful Business categories Registered Account holder."
     unsuccessful_ep_notification: "UNSUCCESSFUL: Email notification of unsuccessful QAEP nominations."
-    shortlisted_notifier: "SHORTLISTED : Email notifying shortlisted applicants of their success, including Verification of Commercial Figures instructions."
-    shortlisted_audit_certificate_reminder: "SHORTLISTED : Reminder to submit Verification of Commercial Figures (for shortlisted applicants who have not yet done so)."
+    shortlisted_notifier: "SHORTLISTED : Email notifying shortlisted applicants of their success, including Verification of Commercial Figures (External Accountant's Report & List of Procedures) instructions."
+    shortlisted_audit_certificate_reminder: "SHORTLISTED : Reminder to submit Verification of Commercial Figures (External Accountant's Report & List of Procedures) for shortlisted applicants who have not yet done so."
     not_shortlisted_notifier: "NOT SHORTLISTED : Email notifying unsuccessful applicants."
 
   custom_login_messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,7 @@ en:
       case_summary_unsubmit: "unlocked case summary"
       audit_certificate_downloaded: "downloaded verification of commercial figures form"
       audit_certificate_uploaded: "uploaded verification of commercial figures form"
+      list_of_procedures_uploaded: "uploaded list of procedures document"
       palace_attendee_update: "updated Buckingham Palace attendee details"
       palace_attendee_submit: "confirmed Buckingham Palace attendee details"
       palace_attendee_create: "added a new Buckingham Palace attendee"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,7 @@ Rails.application.routes.draw do
       resources :form_answer_attachments, only: [:create, :show, :destroy]
       resources :support_letters, only: [:show]
       resources :audit_certificates, only: [:show, :create]
+      resources :list_of_procedures, only: [:show]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit
@@ -266,6 +267,7 @@ Rails.application.routes.draw do
       resources :audit_certificates, only: [:show, :create] do
         get :download_initial_pdf, on: :collection
       end
+      resources :list_of_procedures, only: [:show]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
       end
 
       resource :audit_certificate, only: [:show, :create]
+      resource :list_of_procedures, only: [:create]
       resource :support_letter_attachments, only: :create
       resources :supporters, only: [:create, :destroy]
       resources :support_letters, only: [:create, :show, :destroy]

--- a/db/migrate/20201023115307_create_list_of_procedures.rb
+++ b/db/migrate/20201023115307_create_list_of_procedures.rb
@@ -1,0 +1,14 @@
+class CreateListOfProcedures < ActiveRecord::Migration[5.2]
+  def change
+    create_table :list_of_procedures do |t|
+      t.references :form_answer, foreign_key: true
+      t.string :attachment
+      t.text :changes_description
+      t.references :reviewable, polymorphic: true
+      t.datetime :reviewed_at
+      t.integer :status
+      t.string :attachment_scan_results
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -871,6 +871,44 @@ ALTER SEQUENCE public.judges_id_seq OWNED BY public.judges.id;
 
 
 --
+-- Name: list_of_procedures; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.list_of_procedures (
+    id bigint NOT NULL,
+    form_answer_id bigint,
+    attachment character varying,
+    changes_description text,
+    reviewable_type character varying,
+    reviewable_id bigint,
+    reviewed_at timestamp without time zone,
+    status integer,
+    attachment_scan_results character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: list_of_procedures_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.list_of_procedures_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: list_of_procedures_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.list_of_procedures_id_seq OWNED BY public.list_of_procedures.id;
+
+
+--
 -- Name: palace_attendees; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2776,6 +2814,13 @@ ALTER TABLE ONLY public.judges ALTER COLUMN id SET DEFAULT nextval('public.judge
 
 
 --
+-- Name: list_of_procedures id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.list_of_procedures ALTER COLUMN id SET DEFAULT nextval('public.list_of_procedures_id_seq'::regclass);
+
+
+--
 -- Name: palace_attendees id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3040,6 +3085,14 @@ ALTER TABLE ONLY public.form_answers
 
 ALTER TABLE ONLY public.judges
     ADD CONSTRAINT judges_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: list_of_procedures list_of_procedures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.list_of_procedures
+    ADD CONSTRAINT list_of_procedures_pkey PRIMARY KEY (id);
 
 
 --
@@ -3406,6 +3459,20 @@ CREATE UNIQUE INDEX index_judges_on_unlock_token ON public.judges USING btree (u
 
 
 --
+-- Name: index_list_of_procedures_on_form_answer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_list_of_procedures_on_form_answer_id ON public.list_of_procedures USING btree (form_answer_id);
+
+
+--
+-- Name: index_list_of_procedures_on_reviewable_type_and_reviewable_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_list_of_procedures_on_reviewable_type_and_reviewable_id ON public.list_of_procedures USING btree (reviewable_type, reviewable_id);
+
+
+--
 -- Name: index_palace_attendees_on_palace_invite_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3627,6 +3694,14 @@ ALTER TABLE ONLY public.feedbacks
 
 ALTER TABLE ONLY public.feedbacks
     ADD CONSTRAINT fk_rails_85a1d7f049 FOREIGN KEY (form_answer_id) REFERENCES public.form_answers(id);
+
+
+--
+-- Name: list_of_procedures fk_rails_89004f7c1e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.list_of_procedures
+    ADD CONSTRAINT fk_rails_89004f7c1e FOREIGN KEY (form_answer_id) REFERENCES public.form_answers(id);
 
 
 --
@@ -3884,7 +3959,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20161021111201'),
 ('20161021140457'),
 ('20161116104612'),
-('20170401215454'),
 ('20180820050136'),
 ('20181102125508'),
 ('20181102125923'),
@@ -3900,6 +3974,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200714125921'),
 ('20200814122259'),
 ('20200918110854'),
-('20200918151320');
+('20200918151320'),
+('20201023115307');
 
 


### PR DESCRIPTION
For this new award year, QAE are adding an extra verification step for
applicants who have been short-listed for an award. Going forward, in
addition to uploading the regular "Verification of Figures" document,
now known as an "External Accountant's Report", applicants must also
upload a "List of Procedures" document.

This PR introduces a new `ListOfProcedures` object that's associated
with a `form_answer`, has a (user-uploaded) attachment and is
downloadable by an admin/assessor with appropriate permissions.

This PR makes a tiny CSS change to improve styling when a deadline
has a long description.

**Before CSS Fix:**
<img width="1182" alt="Before CSS Fix" src="https://user-images.githubusercontent.com/1914715/97179061-4b3dc180-1790-11eb-9482-a4e55d76f665.png">

**After CSS Fix:**
<img width="1175" alt="After CSS Fix" src="https://user-images.githubusercontent.com/1914715/97179185-70323480-1790-11eb-8171-cfcd962a5144.png">

We also update the styling of the "Upload" button for the non-JS upload form, making them smaller and inline with the file-picker, since we now have multiple uploads buttons on the same page.

<img width="636" alt="Screenshot 2020-10-26 at 13 55 52" src="https://user-images.githubusercontent.com/1914715/97181257-fa7b9800-1792-11eb-808a-3aa7aad5388b.png">
