### PR TITLE
📝 Update shortlisted reminder email copy

### DIFF
--- a/app/mailers/users/audit_certificate_request_mailer.rb
+++ b/app/mailers/users/audit_certificate_request_mailer.rb
@@ -10,7 +10,7 @@ class Users::AuditCertificateRequestMailer < ApplicationMailer
     @deadline_time = "midnight" if midnight?
     @deadline_time = "midday" if midday?
 
-    @subject = "Queen's Awards for Enterprise: Reminder to submit your Verification of Commercial Figures"
+    @subject = "Queen's Awards for Enterprise: Reminder to provide verification of commercial figures"
     send_mail_if_not_bounces ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @recipient.email, subject: subject_with_env_prefix(@subject)
   end
 

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -96,7 +96,7 @@ class Notifiers::EmailNotificationService
     collaborator_data = []
 
     award_year.form_answers.business.shortlisted.each do |form_answer|
-      next if form_answer.audit_certificate
+      next if form_answer.audit_certificate && form_answer.list_of_procedures
 
       form_answer.collaborators.each do |collaborator|
         collaborator_data << { form_answer_id: form_answer.id, collaborator_id: collaborator.id }

--- a/app/views/users/audit_certificate_request_mailer/notify.text.erb
+++ b/app/views/users/audit_certificate_request_mailer/notify.text.erb
@@ -1,18 +1,27 @@
 <%= "Dear #{@recipient.full_name}," %>
 
-We are emailing to remind you that you have until 
-#<%= @deadline_time %> on <%= @deadline %> 
-to upload your completed Verification of Commercial Figures via the link below:
+We are emailing to remind you that you have until
+
+#noon on <%= @deadline %>
+
+to provide verification of the commercial figures by submitting an External Accountant's Report and the supplementary list of procedures by following the link below:
 <%= users_form_answer_audit_certificate_url(@form_answer) %>
 
 #We cannot extend this deadline.
 
-If you do not submit your Verification of Commercial Figures before the deadline, we will not have sufficient information to assess your application and it will be withdrawn.
+If you do not submit your External Accountant's Report and the accompanying List of Procedures document before the deadline, we will not have sufficient information to assess your application and it will be withdrawn.
 
-You can download a blank copy of the Verification of Commercial Figures via the link below:
-<%= users_form_answer_audit_certificate_url(@form_answer, format: :pdf) %>
+#Below is a reminder of the steps you need to take:
 
-Thank you,
+  1. Log in now to your Queen's Award account and download the External Accountant's Report form by following the link below:
+     <%= users_form_answer_audit_certificate_url(@form_answer) %>
+  2. Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
+  3. If relevant, make any revisions to the figures in the report. If you make revisions, you have to sign the Applicant's Management's Statement section in the report.
+  4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
+  5. Login and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen's Award online portal by following the link below:
+     <%= users_form_answer_audit_certificate_url(@form_answer) %>
+
+Yours sincerely,
 
 Nichola Bruno
-Head of the Queen's Awards Office
+Head, The Queen’s Awards for Enterprise Office

--- a/app/views/users/audit_certificate_request_mailer/preview/notify.html.slim
+++ b/app/views/users/audit_certificate_request_mailer/preview/notify.html.slim
@@ -2,15 +2,16 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   = "Dear #{@recipient.full_name},"
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | We are emailing to remind you that you have until 
-  
-p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  strong
-    = "#{@deadline_time} on #{@deadline}"
+  = "We are emailing to remind you that you have until"
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | to upload your completed Verification of Commercial Figures via the link below:
-  br
+  strong
+    = "noon on #{@deadline}"
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  ' to provide verification of the commercial figures by submitting External Accountant's Report and the supplementary list of procedures by following the link below:
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   = link_to users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer)
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
@@ -18,17 +19,33 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
     ' We cannot extend this deadline.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' If you do not submit your Verification of Commercial Figures before the deadline, we will not have sufficient information to assess your application and it will be withdrawn.
+  ' If you do not submit your External Accountant's Report and the accompanying List of Procedures document before the deadline, we will not have sufficient information to assess your application and it will be withdrawn.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' You can download a blank copy of the Verification of Commercial Figures via the link below:
-  br
-  = link_to users_form_answer_audit_certificate_url(@form_answer, format: :pdf), users_form_answer_audit_certificate_url(@form_answer, format: :pdf)
+  strong
+    ' Below is a reminder of the steps you need to take:
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 1. Log in now to your Queen's Award account and download the External Accountant's Report form by following the link below:<br/>
+  = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 2. Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 3. If relevant, make any revisions to the figures in the report. If you make revisions, you have to sign the Applicant's Management's Statement section in the report.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 5. Login and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen's Award online portal by following the link below:<br/>
+  = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 38px 0 38px 0;"
-  | Thank you,
+  | Yours sincerely,
   br
   br
   | Nichola Bruno
   br
-  | Head of the Queen's Awards Office
+  | Head, The Queen’s Awards for Enterprise Office

--- a/spec/factories/list_of_procedures.rb
+++ b/spec/factories/list_of_procedures.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :list_of_procedures do
+    association :form_answer, factory: :form_answer
+    attachment_scan_results "clean"
+    attachment do
+      Rack::Test::UploadedFile.new(
+        File.join(
+          Rails.root,'spec','support','file_samples','list_of_procedures_sample.txt'
+        )
+      )
+    end
+  end
+end

--- a/spec/mailers/users/audit_certificate_request_mailer_spec.rb
+++ b/spec/mailers/users/audit_certificate_request_mailer_spec.rb
@@ -14,7 +14,7 @@ describe Users::AuditCertificateRequestMailer do
 
   let(:award_title) { form_answer.decorate.award_application_title }
   let(:subject) {
-    "Queen's Awards for Enterprise: Reminder to submit your Verification of Commercial Figures"
+    "Queen's Awards for Enterprise: Reminder to provide verification of commercial figures"
   }
 
   before do
@@ -33,7 +33,6 @@ describe Users::AuditCertificateRequestMailer do
     it "renders the body" do
       expect(mail.body.raw_source).to match(user.decorate.full_name)
       expect(mail.body.raw_source).to match(users_form_answer_audit_certificate_url(form_answer))
-      expect(mail.body.raw_source).to match(users_form_answer_audit_certificate_url(form_answer, format: :pdf))
       expect(mail.body.raw_source).to match(deadline)
     end
   end

--- a/spec/support/file_samples/list_of_procedures_sample.txt
+++ b/spec/support/file_samples/list_of_procedures_sample.txt
@@ -1,0 +1,1 @@
+This is a sample list of procedures document.


### PR DESCRIPTION
Each year QAE send out emails to notify applicants who've successfully
been shortlisted for award, requesting that they login to their QAE
account and upload 2 documents as part of a "Verification of commercial
figures" process. Shortly after sending the initial congratulations email, a 
second email is sent, reminding users to upload their documents, if they
haven't done so already.

This PR updates the content of the mailer, as well as the on-screen
preview, to match the latest copy provided by the client. We also
update our reminder logic to check for both the (historic) 
`audit_certificate` and (new) `list_of_procedures` document, when 
deciding whether an applicant should be sent a reminder email.

https://trello.com/c/9QZaxIuy/1192-qaeimp-update-the-content-of-the-email-sent-to-remind-applicants-to-upload-their-external-accountants-report-and-the-supplementa