### PR TITLE
🐛 Attempt to fix flaky Capybara spec

### DIFF
--- a/spec/features/assessor/appraisal_form_submission_spec.rb
+++ b/spec/features/assessor/appraisal_form_submission_spec.rb
@@ -24,6 +24,7 @@ describe "Assessor submits appraisal form", %(
     it "submits the form" do
       allow_any_instance_of(AssessorAssignment).to receive(:valid?).and_return(true)
       find("#appraisal-form-primary-heading .panel-title a").click
+      expect(page).to have_css("#section-appraisal-form-primary") # Forces capybara to wait for the section to become visible
       within "#section-appraisal-form-primary" do
         click_button "Submit appraisal"
       end

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -70,6 +70,7 @@ def assert_rag_change(section_id, header_id)
 
   find("#{header_id} .panel-title a").click
 
+  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_selector(rag, text: "Select RAG", count: 4)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
@@ -86,6 +87,7 @@ def assert_rag_change(section_id, header_id)
 
   find("#{header_id} .panel-title a").click
 
+  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_selector(rag, text: "Select RAG", count: 3)
     expect(page).to have_selector(rag, text: "Red", count: 1)
@@ -99,6 +101,7 @@ def assert_description_change(section_id, header_id)
   selector = section_id == moderated ? "assessor_assignment_verdict_desc" : "assessor_assignment_level_of_innovation_desc"
   parent_selector = section_id == moderated ? ".form-overall-verdict" : ".form-level-of-innovation"
 
+  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     within ".#{selector}" do
       expect(page).to have_selector("textarea", count: 1)
@@ -114,6 +117,7 @@ def assert_description_change(section_id, header_id)
 
   find("#{header_id} .panel-title a").click
 
+  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_selector(".form-value p", text: text, count: 1)
     first(".form-edit-link").click
@@ -127,6 +131,7 @@ def assert_multiple_description_change(section_id, header_id)
   text2 = "should be saved"
   find("#{header_id} .panel-title a").click
 
+  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     unless section_id == moderated
       fill_in("assessor_assignment_level_of_innovation_desc", with: text)
@@ -140,6 +145,7 @@ def assert_multiple_description_change(section_id, header_id)
   visit show_path
   find("#{header_id} .panel-title a").click
 
+  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_content(text2)
 
@@ -152,6 +158,7 @@ end
 def assert_verdict_change(section_id, header_id)
   find("#{header_id} .panel-title a").click
 
+  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_selector(".rag-text", text: "Select verdict", count: 1)
     all(".btn-rag").last.click
@@ -161,6 +168,8 @@ def assert_verdict_change(section_id, header_id)
 
   visit show_path
   page.find("#{header_id} .panel-title a").click
+
+  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to_not have_selector(".rag-text", text: "Select verdict")
     expect(page).to have_content "Recommended"


### PR DESCRIPTION
Since migrating from GitLab CI to GitHub Actions, we've spotted some
flaky capybara specs that intermittently fails in our CI pipeline,
causing our deployments to fail and needing to be retried.

After reading through the spec, I've found that we're trying to interact
with HTML elements that are originally hidden and become visible as
part of a Javascript interaction. Ordinarily, Capybara is smart enough
to wait for Javascript interactions to complete and will look for the
element multiple times, though I suspect this courtesy doesn't extend
to `within` blocks, meaning the element to which we're scoping our
interaction isn't always visible and thus causing a race condition.

This commit forces Capybara to wait for the element to become visible
(within a sensible period of time) using the `expect` method, which has
the nice behaviour of silently retrying if/when a selector doesn't match
any visible elements.

https://trello.com/c/HG1f8xNL/1196-qae1020-dig-into-the-flaky-spec-that-intermittently-causes-our-ci-pipelines-to-fail