### PR TITLE
🔧 Update Sentry to capture GOV.UK App name

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,7 +1,13 @@
 require 'raven'
 
-Raven.configure do |config|
-  config.silence_ready = true
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-  config.environments = [ 'production' ]
+if defined?(Raven) && ENV["VCAP_APPLICATION"].present?
+  tags = JSON.parse(ENV["VCAP_APPLICATION"])
+             .except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version')
+             .merge({ server_name: ENV["GOVUK_APP_DOMAIN"] })
+  Raven.configure do |config|
+    config.tags = tags
+    config.silence_ready = true
+    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+    config.environments = [ 'production' ]
+  end
 end


### PR DESCRIPTION
We're currently seeing a spate of Sentry errors relating to Redis being
unreachable, though we're unsure which environment the errors stems
from, since all deployments are running in `production` mode.

This commit reads the `GOVUK_APP_DOMAIN` environment variable from the
host and passes it into Sentry (via Raven), helping us to identify which
host(s) are reporting errors.