### PR TITLE
🔧 Don't try to log GOVUK_APP_DOMAIN for QAE

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -3,7 +3,6 @@ require 'raven'
 if defined?(Raven) && ENV["VCAP_APPLICATION"].present?
   tags = JSON.parse(ENV["VCAP_APPLICATION"])
              .except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version')
-             .merge({ server_name: ENV["GOVUK_APP_DOMAIN"] })
   Raven.configure do |config|
     config.tags = tags
     config.silence_ready = true


### PR DESCRIPTION
In a previous commit we updated our Raven config to push details from
CloudFoundry (GOV.UK PAAS) into Sentry. After discussing with
@matthewford, it seems that the `GOVUK_APP_DOMAIN` isn't set for QAE
deployments, meaning we shouldn't attempt to capture it.

This commit updates our Raven config to remove mention of
`GOVUK_APP_DOMAIN`.