### PR TITLE
📝 Tweak copy for account verification pages

### DIFF
--- a/app/controllers/users/list_of_procedures_controller.rb
+++ b/app/controllers/users/list_of_procedures_controller.rb
@@ -20,7 +20,7 @@ class Users::ListOfProceduresController < Users::BaseController
       format.html do
         if saved
           redirect_to users_form_answer_audit_certificate_url(form_answer),
-                      notice: "List of Procedures successfully uploaded!"
+                      notice: "List of procedures successfully uploaded!"
         else
           render :show
         end

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -23,10 +23,10 @@
 
     - if resource.object.list_of_procedures.present? && resource.object.list_of_procedures.clean?
       li
-        = link_to "View/print List of Procedures", [url_namespace, resource.object, resource.object.list_of_procedures], target: "_blank"
+        = link_to "View/print list of procedures", [url_namespace, resource.object, resource.object.list_of_procedures], target: "_blank"
     - elsif resource.object.list_of_procedures.present? && resource.object.list_of_procedures.attachment_scan_results.blank?
       li style="color:green"
-        ' Scanning List of Procedures. You may need to refresh the page.
+        ' Scanning list of procedures. You may need to refresh the page.
 
     - if policy(resource).download_case_summary_pdf?
       li

--- a/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
@@ -3,8 +3,6 @@ p
     ' Verification of Commercial Figures
   | -  To enable us to proceed with your entry, you are required to provide verification of the commercial figures you provided in your application from an external, qualified, practising accountant or auditor (as stated in the commercial performance section of the online entry).
 
-
-
 p
   strong
     = "Please do so by noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_time_short}."
@@ -14,10 +12,10 @@ p Please follow the steps below:
 p
   ol
     li Follow the "Verification of Commercial Figures" link next to your Shortlisted entries below to download the External Accountant's Report form.
-    li Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
-    li If relevant, make changes or provide actual figures to replace estimates submitted at the time of application in the External Accountant's Report form. If you make any of these revisions, you have to sign the Applicant's Management's Statement section in the report.
-    li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
-    li = "Login and upload the External Accountant's Report as well as the supplementary list of procedures document to this online portal by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_time_short}</strong>".html_safe
+    li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
+    li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.revisions, you have to sign the Applicant's Management's Statement section in the report.
+    li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
+    li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report as well as the accompanying list of procedures document, provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
 
 p Please note, we are unable to accept late reports due to the strict assessment and judging timetable.
 

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -13,10 +13,10 @@ header.page-header.group class=('page-header-wider')
         p
           ol
             li = link_to("Download the External Accountant's Report form.", users_form_answer_audit_certificate_url(form_answer, format: :pdf))
-            li Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
-            li If relevant, make changes or provide actual figures to replace estimates submitted at the time of application in the External Accountant's Report form. If you make any of these revisions, you have to sign the Applicant's Management's Statement section in the report.
-            li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
-            li = "Login and upload the External Accountant's Report as well as the supplementary list of procedures document to this online portal by <strong> noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
+            li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
+            li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.revisions, you have to sign the Applicant's Management's Statement section in the report.
+            li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
+            li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report as well as the accompanying list of procedures document, provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
       br
 
       = render "users/audit_certificates/upload_block", award: form_answer,

--- a/app/views/users/list_of_procedures/_file.html.slim
+++ b/app/views/users/list_of_procedures/_file.html.slim
@@ -3,17 +3,17 @@
 
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
-      = link_to "Download List of Procedures", att_record.attachment_url,
+      = link_to "Download list of procedures", att_record.attachment_url,
                 target: "_blank", class: "js-audit-certificate-title"
     - elsif att_record.attachment_scan_results == "scanning"
-      | Uploaded List of Procedures is being scanned for viruses.
+      | Uploaded list of procedures is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"
       | Uploaded file has been blocked (virus detected), please remove.
     - else
-      = link_to "Download List of Procedures", "",
+      = link_to "Download list of procedures", "",
                 target: "_blank", class: "js-audit-certificate-title"
   - else
-      | Uploaded List of Procedures is being scanned for viruses.
+      | Uploaded list of procedures is being scanned for viruses.
 - else
-  = link_to "Download List of Procedures", "",
+  = link_to "Download list of procedures", "",
             target: "_blank", class: "js-audit-certificate-title"

--- a/app/views/users/list_of_procedures/_form.html.slim
+++ b/app/views/users/list_of_procedures/_form.html.slim
@@ -5,7 +5,7 @@
   .errors-container
   .clear
   span.button.button-add
-    span + Upload List of Procedures form
+    span + Upload list of procedures document
     = f.input :attachment,
               as: :file,
               required: true,

--- a/app/views/users/list_of_procedures/_non_js_form.html.slim
+++ b/app/views/users/list_of_procedures/_non_js_form.html.slim
@@ -7,7 +7,7 @@
       = f.input :attachment,
                 as: :file,
                 required: true,
-                label: "Upload List of Procedures form"
+                label: "Upload list of procedures document"
 
   = f.submit "Upload", class: "button button-add button-upload non-js-audit-certificate-submit"
 .clear

--- a/app/views/users/list_of_procedures/_upload_block.html.slim
+++ b/app/views/users/list_of_procedures/_upload_block.html.slim
@@ -1,4 +1,4 @@
-.js-upload-wrapper data-max-attachments=1 data-form-name="audit-cert-form" data-name="audit-cert-name" data-filename="Uploaded List of Procedures"
+.js-upload-wrapper data-max-attachments=1 data-form-name="audit-cert-form" data-name="audit-cert-name" data-filename="Uploaded list of procedures"
   ul.js-uploaded-list class=("hidden" unless list_exists)
     li.li-audit-upload
       div

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,7 +141,7 @@ en:
     buckingham_palace_confirm_press_book_notes: Press Book Entry confirmation due by
     buckingham_palace_reception_attendee_information_due_by: Buckingham Palace reception attendee information due by
     buckingham_palace_attendees_invite: Buckingham Palace Reception on
-    audit_certificates: Verification of Commercial Figures (External Accountant's Report & List of Procedures) due by
+    audit_certificates: Verification of Commercial Figures (External Accountant's Report & list of procedures) due by
 
   deadline_help_messages:
     award_year_switch: "This date marks the start of the new award year, and will update the website accordingly. Users will not yet be able to start any applications"
@@ -184,8 +184,8 @@ en:
     buckingham_palace_invite: "WINNERS : Buckingham Palace Invite - to heads of winning organisations only."
     unsuccessful_notification: "UNSUCCESSFUL: Email notification to unsuccessful Business categories Registered Account holder."
     unsuccessful_ep_notification: "UNSUCCESSFUL: Email notification of unsuccessful QAEP nominations."
-    shortlisted_notifier: "SHORTLISTED : Email notifying shortlisted applicants of their success, including Verification of Commercial Figures (External Accountant's Report & List of Procedures) instructions."
-    shortlisted_audit_certificate_reminder: "SHORTLISTED : Reminder to submit Verification of Commercial Figures (External Accountant's Report & List of Procedures) for shortlisted applicants who have not yet done so."
+    shortlisted_notifier: "SHORTLISTED : Email notifying shortlisted applicants of their success, including Verification of Commercial Figures (External Accountant's Report & list of procedures) instructions."
+    shortlisted_audit_certificate_reminder: "SHORTLISTED : Reminder to submit Verification of Commercial Figures (External Accountant's Report & list of procedures) for shortlisted applicants who have not yet done so."
     not_shortlisted_notifier: "NOT SHORTLISTED : Email notifying unsuccessful applicants."
 
   custom_login_messages:


### PR DESCRIPTION
This MR makes some last-minute amendments to the copy displayed to shortlisted users who must upload their verification documents (Accountant's Report and list of procedures).

https://trello.com/c/UGpnY8ei/1194-qaeimp-add-an-upload-list-of-procedures-feature

![screencapture-qae-dvjon-es-3000-dashboard-2020-10-27-15_47_32](https://user-images.githubusercontent.com/1914715/97326296-c45e1700-186b-11eb-897a-deeddcb36e0b.png)
![screencapture-qae-dvjon-es-3000-users-form-answers-1-audit-certificate-2020-10-27-15_47_19](https://user-images.githubusercontent.com/1914715/97326309-c7f19e00-186b-11eb-87b2-cb007c60a5fe.png)
