### PR TITLE
⬆️ Upgade Capybara from 3.18 to 3.33

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -175,7 +175,7 @@ end
 
 group :test do
   gem 'factory_girl_rails'
-  gem 'capybara', '3.18'
+  gem 'capybara', '3.33'
   gem 'poltergeist'
   gem 'database_cleaner', '1.6.1'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,13 +94,13 @@ GEM
     builder (3.2.4)
     byebug (10.0.2)
     callsite (0.0.11)
-    capybara (3.18.0)
+    capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
+      regexp_parser (~> 1.5)
       xpath (~> 3.2)
     carrierwave (1.2.3)
       activemodel (>= 4.0.0)
@@ -500,7 +500,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    public_suffix (4.0.1)
+    public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
     pundit (0.3.0)
@@ -589,7 +589,7 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.6.0)
       redis (>= 2.2, < 5)
-    regexp_parser (1.6.0)
+    regexp_parser (1.8.2)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.1)
@@ -761,7 +761,7 @@ DEPENDENCIES
   bootscale
   bootstrap-sass (~> 3.4)
   browser (= 2.4.0)
-  capybara (= 3.18)
+  capybara (= 3.33)
   carrierwave (~> 1.2)
   ckeditor!
   codeclimate_circle_ci_coverage


### PR DESCRIPTION
We're currently fighting against some flaky feature specs in our CI
pipeline. Reading around the problem, it seems like Capybara isn't
correctly waiting for elements to become visible on the page after a
javascript interaction, though this _should_ be the default behaviour
for most Capybara method calls.

This commit upgrades our Capybara version from 3.18 to 3.33, in the hope
it might resolve our flaky spec issue.

References:
https://www.varvet.com/blog/why-wait_until-was-removed-from-capybara/