### PR TITLE
✅ Capybara sleep whilst DOM is updated

### DIFF
--- a/spec/features/assessor/appraisal_form_submission_spec.rb
+++ b/spec/features/assessor/appraisal_form_submission_spec.rb
@@ -24,7 +24,7 @@ describe "Assessor submits appraisal form", %(
     it "submits the form" do
       allow_any_instance_of(AssessorAssignment).to receive(:valid?).and_return(true)
       find("#appraisal-form-primary-heading .panel-title a").click
-      expect(page).to have_css("#section-appraisal-form-primary") # Forces capybara to wait for the section to become visible
+      take_a_nap
       within "#section-appraisal-form-primary" do
         click_button "Submit appraisal"
       end

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -86,8 +86,8 @@ def assert_rag_change(section_id, header_id)
   visit show_path
 
   find("#{header_id} .panel-title a").click
+  take_a_nap
 
-  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_selector(rag, text: "Select RAG", count: 3)
     expect(page).to have_selector(rag, text: "Red", count: 1)
@@ -98,10 +98,11 @@ end
 
 def assert_description_change(section_id, header_id)
   find("#{header_id} .panel-title a").click
+  take_a_nap
+
   selector = section_id == moderated ? "assessor_assignment_verdict_desc" : "assessor_assignment_level_of_innovation_desc"
   parent_selector = section_id == moderated ? ".form-overall-verdict" : ".form-level-of-innovation"
 
-  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     within ".#{selector}" do
       expect(page).to have_selector("textarea", count: 1)
@@ -116,8 +117,8 @@ def assert_description_change(section_id, header_id)
   visit show_path
 
   find("#{header_id} .panel-title a").click
+  take_a_nap
 
-  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_selector(".form-value p", text: text, count: 1)
     first(".form-edit-link").click
@@ -130,8 +131,8 @@ def assert_multiple_description_change(section_id, header_id)
   text = "should NOT be saved"
   text2 = "should be saved"
   find("#{header_id} .panel-title a").click
+  take_a_nap
 
-  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     unless section_id == moderated
       fill_in("assessor_assignment_level_of_innovation_desc", with: text)
@@ -144,8 +145,8 @@ def assert_multiple_description_change(section_id, header_id)
 
   visit show_path
   find("#{header_id} .panel-title a").click
+  take_a_nap
 
-  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_content(text2)
 
@@ -157,8 +158,8 @@ end
 
 def assert_verdict_change(section_id, header_id)
   find("#{header_id} .panel-title a").click
+  take_a_nap
 
-  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to have_selector(".rag-text", text: "Select verdict", count: 1)
     all(".btn-rag").last.click
@@ -168,8 +169,8 @@ def assert_verdict_change(section_id, header_id)
 
   visit show_path
   page.find("#{header_id} .panel-title a").click
+  take_a_nap
 
-  expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
     expect(page).to_not have_selector(".rag-text", text: "Select verdict")
     expect(page).to have_content "Recommended"
@@ -182,4 +183,10 @@ def show_path
   else
     admin_form_answer_path form_answer
   end
+end
+
+# For some reason, Capybara isn't waiting for elements to become visible when JS fires.
+# Let's take a nap and give the DOM time to update.
+def take_a_nap
+  sleep(2)
 end


### PR DESCRIPTION
Since switching from GitLab CI to GitHub Actions we're seeing
intermittent failures in a handful of feature (Capybara) specs.
We're using sprinkles of Javascript to toggle visibility of DOM
elements, though despite documentation to the contrary, it seems that
Capybara doesn't reliably wait for elements to become visible and
instead raises runtime errors about expected elements being unavailable.

This commit introduces a `take_a_nap` helper with sleeps the rspec
thread for 2 seconds, hopefully giving the DOM enough time to update.