### PR TITLE
🐛 Correctly log deletion of verification documents

### DIFF
--- a/app/controllers/users/audit_certificates_controller.rb
+++ b/app/controllers/users/audit_certificates_controller.rb
@@ -83,6 +83,8 @@ class Users::AuditCertificatesController < Users::BaseController
       "audit_certificate_uploaded"
     when "destroy"
       "audit_certificate_destroyed"
+    else
+      raise "Attempted to log an unsupported action (#{action_name})"
     end
   end
 

--- a/app/controllers/users/list_of_procedures_controller.rb
+++ b/app/controllers/users/list_of_procedures_controller.rb
@@ -60,7 +60,14 @@ class Users::ListOfProceduresController < Users::BaseController
   end
 
   def action_type
-    "list_of_procedures_uploaded"
+    case action_name
+    when "create"
+      "list_of_procedures_uploaded"
+    when "destroy"
+      "list_of_procedures_destroy"
+    else
+      raise "Attempted to log an unsupported action (#{action_name})"
+    end
   end
 
   def humanized_errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,6 +247,7 @@ en:
       audit_certificate_uploaded: "uploaded External Accountant's Report form"
       audit_certificate_destroyed: "removed External Accountant's Report form"
       list_of_procedures_uploaded: "uploaded list of procedures document"
+      list_of_procedures_destroy: "removed list of procedures document"
       palace_attendee_update: "updated Buckingham Palace attendee details"
       palace_attendee_submit: "confirmed Buckingham Palace attendee details"
       palace_attendee_create: "added a new Buckingham Palace attendee"


### PR DESCRIPTION
Now that users are allowed to remove their uploaded verification
document(s), it's important that an accurate audit trail is captured,
else there'll be inevitable confusion.

Whilst testing the new removal functionality I realised that removal of
the "list of procedures" document was being incorrectly logged as a
document upload, since until recently, only the `create` action existed
on the controller.

This commit updates both of our document controllers to ensure accurate
audit logs are written to the database.

https://trello.com/c/UGpnY8ei/1194-qaeimp-add-an-upload-list-of-procedures-feature