### PR TITLE
♻️ Show "remove" link immediately after doc upload

### DIFF
--- a/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
+++ b/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
@@ -34,6 +34,7 @@ window.AuditCertificatesUpload =
       # Remove `Uploading...`
       list.find(".js-uploading").remove()
       list.find(".li-audit-upload").removeClass("hidden")
+      list.find(".js-remove-verification-document-form").removeClass("hidden")
       $(".js-audit-certificate-status-message").remove()
 
     failed = (error_message) ->

--- a/app/views/users/audit_certificates/_file.html.slim
+++ b/app/views/users/audit_certificates/_file.html.slim
@@ -15,15 +15,16 @@
   - else
       | Uploaded External Accountant's Report is being scanned for viruses.
 
-  small.pull-right.remove-verification-document
-    = form_for(users_form_answer_audit_certificate_path, html: { method: :delete, style: "display:inline-block;"}) do |f|
-
-      = f.submit 'Remove', class: 'if-js-hide'
-
-      = link_to "#", class: "text-danger if-no-js-hide js-remove-verification-document-link", data: {confirm: "Are you sure?"}
-        span.glyphicon.glyphicon-remove
-        span.visible-lg.visible-md
-          ' Remove
 - else
   = link_to "Download Verification of Commercial Figures", "",
             target: "_blank", class: "js-audit-certificate-title"
+
+small.pull-right.remove-verification-document
+  = form_for(users_form_answer_audit_certificate_path, html: { method: :delete, class:"js-remove-verification-document-form", style: "display:inline-block;"}) do |f|
+
+    = f.submit 'Remove', class: 'if-js-hide'
+
+    = link_to "#", class: "text-danger if-no-js-hide js-remove-verification-document-link", data: {confirm: "Are you sure?"}
+      span.glyphicon.glyphicon-remove
+      span.visible-lg.visible-md
+        ' Remove

--- a/app/views/users/list_of_procedures/_file.html.slim
+++ b/app/views/users/list_of_procedures/_file.html.slim
@@ -15,15 +15,16 @@
   - else
       | Uploaded list of procedures is being scanned for viruses.
 
-  small.pull-right.remove-verification-document
-    = form_for(:list_of_procedures, url: users_form_answer_list_of_procedures_path(form_answer), html: { method: :delete, style: "display:inline-block;"}) do |f|
-
-      = f.submit 'Remove', class: 'if-js-hide'
-
-      = link_to "#", class: "text-danger if-no-js-hide js-remove-verification-document-link", data: {confirm: "Are you sure?"}
-        span.glyphicon.glyphicon-remove
-        span.visible-lg.visible-md
-          ' Remove
 - else
   = link_to "Download list of procedures", "",
             target: "_blank", class: "js-audit-certificate-title"
+
+small.pull-right.remove-verification-document
+  = form_for(:list_of_procedures, url: users_form_answer_list_of_procedures_path(form_answer), html: { class: "js-remove-verification-document-form", method: :delete, style: "display:inline-block;"}) do |f|
+
+    = f.submit 'Remove', class: 'if-js-hide'
+
+    = link_to "#", class: "text-danger if-no-js-hide js-remove-verification-document-link", data: {confirm: "Are you sure?"}
+      span.glyphicon.glyphicon-remove
+      span.visible-lg.visible-md
+        ' Remove


### PR DESCRIPTION
In a previous commit we implemented "remove" functionality in our
"Verification of Commercial Figures" page, allowing users to remove the
document(s) they've uploaded for review. During testing, Stephanie
highlighted that the "remove" button doesn't appear when you first
upload a file and instead is only visible after a page reload.

This commit updates our view to always render the "remove" button,
though it's hidden by default and is subsequently made visible by the
(existing) Javascript that updates the UI in response to a file upload.

![PgwbQpxAlM](https://user-images.githubusercontent.com/1914715/97563554-1ffae280-19db-11eb-9ea5-7c0dc524f428.gif)
