### PR TITLE
📝 Update copy for shortlisted notification and verification reminder emails

### DIFF
--- a/app/mailers/users/audit_certificate_request_mailer.rb
+++ b/app/mailers/users/audit_certificate_request_mailer.rb
@@ -10,7 +10,7 @@ class Users::AuditCertificateRequestMailer < ApplicationMailer
     @deadline_time = "midnight" if midnight?
     @deadline_time = "midday" if midday?
 
-    @subject = "Queen's Awards for Enterprise: Reminder to submit your Verification of Commercial Figures"
+    @subject = "Queen's Awards for Enterprise: Reminder to provide verification of commercial figures"
     send_mail_if_not_bounces ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @recipient.email, subject: subject_with_env_prefix(@subject)
   end
 

--- a/app/pdf_generators/pdf_audit_certificates/general/guidance_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/guidance_elements.rb
@@ -16,7 +16,7 @@ module PdfAuditCertificates::General::GuidanceElements
   def render_applicant_guidance_text
     p1 = "As a shortlisted applicant, you now need to check the figures which you have provided. If you need to make changes or provide actual figures to replace estimates submitted at the time of application, please make changes on this form and then ask your external accountant to complete this. If you have made changes, then you will need to sign the Applicant’s Management’s Statement section of this form."
 
-    p2 = "Once you and your external accountant has completed this report, please upload it together with the supplementary list of procedures document provided by the accountant  to the Queen’s Awards for Enterprise online portal by 12 noon on #{Settings.current_audit_certificates_deadline.strftime('%A %d %B')}. We are unable to accept late reports due to the strict assessment and judging timetable."
+    p2 = "Once you and your external accountant has completed this report, please upload it together with the accompanying list of procedures document provided by the accountant  to the Queen’s Awards for Enterprise online portal by 12 noon on #{Settings.current_audit_certificates_deadline.strftime('%A %d %B')}. We are unable to accept late reports due to the strict assessment and judging timetable."
 
     [p1, p2].each do |paragraph|
       render_text_line(paragraph, 2, leading: 2)

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -96,7 +96,7 @@ class Notifiers::EmailNotificationService
     collaborator_data = []
 
     award_year.form_answers.business.shortlisted.each do |form_answer|
-      next if form_answer.audit_certificate
+      next if form_answer.audit_certificate && form_answer.list_of_procedures
 
       form_answer.collaborators.each do |collaborator|
         collaborator_data << { form_answer_id: form_answer.id, collaborator_id: collaborator.id }

--- a/app/views/account_mailers/notify_shortlisted_mailer/notify.text.erb
+++ b/app/views/account_mailers/notify_shortlisted_mailer/notify.text.erb
@@ -13,7 +13,7 @@ Please follow the following steps:
   2. We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
   3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
   4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
-  5. Log in and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
+  5. Log in and upload the External Accountant's Report as well as the accompanying list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
      <%= users_form_answer_audit_certificate_url(@form_answer) %>
 
 

--- a/app/views/account_mailers/notify_shortlisted_mailer/notify.text.erb
+++ b/app/views/account_mailers/notify_shortlisted_mailer/notify.text.erb
@@ -10,16 +10,16 @@ Please follow the following steps:
 
   1. Log in now to your Queen's Award account and download the External Accountant's Report form by following the link below:
      <%= users_form_answer_audit_certificate_url(@form_answer) %>
-  2. Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
-  3. If relevant, make any revisions to the figures in the report. If you make revisions, you have to sign the Applicant's Management's Statement section in the report.
-  4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
-  5. Login and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen's Award online portal by following the link below:
+  2. We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
+  3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
+  4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
+  5. Log in and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
      <%= users_form_answer_audit_certificate_url(@form_answer) %>
 
 
 Please note:
 
-  1. The External Accountants Report and the supporting documentation must be submitted by noon on <%= @deadline_date %>. We cannot extend this deadline.
+  1. The External Accountants Report and the accompanying list of procedures document must be submitted by noon on <%= @deadline_date %>. We cannot extend this deadline.
   2. Failure to provide this return on time will mean we do not have sufficient information to complete the assessment of your application, and it will not be considered at the next stage.
   3. Do not make any public announcement of your shortlisted status as the assessment process is ongoing, and reaching this stage is not a guarantee of success.
 

--- a/app/views/account_mailers/notify_shortlisted_mailer/preview/notify.html.slim
+++ b/app/views/account_mailers/notify_shortlisted_mailer/preview/notify.html.slim
@@ -28,7 +28,7 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | 4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 5. Log in and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>
+  | 5. Log in and upload the External Accountant's Report as well as the accompanying list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>
   = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"

--- a/app/views/account_mailers/notify_shortlisted_mailer/preview/notify.html.slim
+++ b/app/views/account_mailers/notify_shortlisted_mailer/preview/notify.html.slim
@@ -19,23 +19,23 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 2. Send the report to the accountant to agree on the timelines and let them know if you will be providing revisions to the figures.
+  | 2. We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 3. If relevant, make any revisions to the figures in the report. If you make revisions, you have to sign the Applicant's Management's Statement section in the report.
+  | 3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report as well as the supplementary list of procedures document to you.
+  | 4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 5. Login and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen's Award online portal by following the link below:<br/>
+  | 5. Log in and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>
   = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | Please note:
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  = "1. The External Accountants Report and the supporting documentation must be submitted by noon on #{@deadline_date}. We cannot extend this deadline."
+  = "1. The External Accountants Report and the accompanying list of procedures document must be submitted by noon on #{@deadline_date}. We cannot extend this deadline."
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | 2. Failure to provide this return on time will mean we do not have sufficient information to complete the assessment of your application, and it will not be considered at the next stage.

--- a/app/views/users/audit_certificate_request_mailer/notify.text.erb
+++ b/app/views/users/audit_certificate_request_mailer/notify.text.erb
@@ -4,7 +4,7 @@ We are emailing to remind you that you have until
 
 #noon on <%= @deadline %>
 
-to provide verification of the commercial figures by submitting an External Accountant's Report and the supplementary list of procedures by following the link below:
+to provide verification of the commercial figures by submitting an External Accountant's Report and the accompanying list of procedures by following the link below:
 <%= users_form_answer_audit_certificate_url(@form_answer) %>
 
 #We cannot extend this deadline.
@@ -18,7 +18,7 @@ If you do not submit your External Accountant's Report and the accompanying list
   2. We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
   3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
   4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
-  5. Log in and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
+  5. Log in and upload the External Accountant's Report as well as the accompanying list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
      <%= users_form_answer_audit_certificate_url(@form_answer) %>
 
 Yours sincerely,

--- a/app/views/users/audit_certificate_request_mailer/notify.text.erb
+++ b/app/views/users/audit_certificate_request_mailer/notify.text.erb
@@ -1,18 +1,27 @@
 <%= "Dear #{@recipient.full_name}," %>
 
-We are emailing to remind you that you have until 
-#<%= @deadline_time %> on <%= @deadline %> 
-to upload your completed Verification of Commercial Figures via the link below:
+We are emailing to remind you that you have until
+
+#noon on <%= @deadline %>
+
+to provide verification of the commercial figures by submitting an External Accountant's Report and the supplementary list of procedures by following the link below:
 <%= users_form_answer_audit_certificate_url(@form_answer) %>
 
 #We cannot extend this deadline.
 
-If you do not submit your Verification of Commercial Figures before the deadline, we will not have sufficient information to assess your application and it will be withdrawn.
+If you do not submit your External Accountant's Report and the accompanying list of procedures document before the deadline, we will not have sufficient information to assess your application and it will be withdrawn.
 
-You can download a blank copy of the Verification of Commercial Figures via the link below:
-<%= users_form_answer_audit_certificate_url(@form_answer, format: :pdf) %>
+#Below is a reminder of the steps you need to take:
 
-Thank you,
+  1. Log in now to your Queen's Award account and download the External Accountant's Report form by following the link below:
+     <%= users_form_answer_audit_certificate_url(@form_answer) %>
+  2. We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
+  3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
+  4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
+  5. Log in and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
+     <%= users_form_answer_audit_certificate_url(@form_answer) %>
+
+Yours sincerely,
 
 Nichola Bruno
-Head of the Queen's Awards Office
+Head, The Queen’s Awards for Enterprise Office

--- a/app/views/users/audit_certificate_request_mailer/preview/notify.html.slim
+++ b/app/views/users/audit_certificate_request_mailer/preview/notify.html.slim
@@ -2,15 +2,16 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   = "Dear #{@recipient.full_name},"
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | We are emailing to remind you that you have until 
-  
-p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  strong
-    = "#{@deadline_time} on #{@deadline}"
+  = "We are emailing to remind you that you have until"
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | to upload your completed Verification of Commercial Figures via the link below:
-  br
+  strong
+    = "noon on #{@deadline}"
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  ' to provide verification of the commercial figures by submitting External Accountant's Report and the supplementary list of procedures by following the link below:
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   = link_to users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer)
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
@@ -18,17 +19,33 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
     ' We cannot extend this deadline.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' If you do not submit your Verification of Commercial Figures before the deadline, we will not have sufficient information to assess your application and it will be withdrawn.
+  ' If you do not submit your External Accountant's Report and the accompanying List of Procedures document before the deadline, we will not have sufficient information to assess your application and it will be withdrawn.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' You can download a blank copy of the Verification of Commercial Figures via the link below:
-  br
-  = link_to users_form_answer_audit_certificate_url(@form_answer, format: :pdf), users_form_answer_audit_certificate_url(@form_answer, format: :pdf)
+  strong
+    ' Below is a reminder of the steps you need to take:
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 1. Log in now to your Queen's Award account and download the External Accountant's Report form by following the link below:<br/>
+  = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 2. We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
+  | 5. Log in and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>
+  = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 38px 0 38px 0;"
-  | Thank you,
+  | Yours sincerely,
   br
   br
   | Nichola Bruno
   br
-  | Head of the Queen's Awards Office
+  | Head, The Queen’s Awards for Enterprise Office

--- a/app/views/users/audit_certificate_request_mailer/preview/notify.html.slim
+++ b/app/views/users/audit_certificate_request_mailer/preview/notify.html.slim
@@ -9,7 +9,7 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
     = "noon on #{@deadline}"
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  ' to provide verification of the commercial figures by submitting External Accountant's Report and the supplementary list of procedures by following the link below:
+  ' to provide verification of the commercial figures by submitting External Accountant's Report and the accompanying list of procedures by following the link below:
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   = link_to users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer)
@@ -39,7 +39,7 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | 4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 5. Log in and upload the External Accountant's Report as well as the supplementary list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>
+  | 5. Log in and upload the External Accountant's Report as well as the accompanying list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>
   = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 38px 0 38px 0;"

--- a/spec/factories/list_of_procedures.rb
+++ b/spec/factories/list_of_procedures.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :list_of_procedures do
+    association :form_answer, factory: :form_answer
+    attachment_scan_results "clean"
+    attachment do
+      Rack::Test::UploadedFile.new(
+        File.join(
+          Rails.root,'spec','support','file_samples','list_of_procedures_sample.txt'
+        )
+      )
+    end
+  end
+end

--- a/spec/mailers/users/audit_certificate_request_mailer_spec.rb
+++ b/spec/mailers/users/audit_certificate_request_mailer_spec.rb
@@ -14,7 +14,7 @@ describe Users::AuditCertificateRequestMailer do
 
   let(:award_title) { form_answer.decorate.award_application_title }
   let(:subject) {
-    "Queen's Awards for Enterprise: Reminder to submit your Verification of Commercial Figures"
+    "Queen's Awards for Enterprise: Reminder to provide verification of commercial figures"
   }
 
   before do
@@ -33,7 +33,6 @@ describe Users::AuditCertificateRequestMailer do
     it "renders the body" do
       expect(mail.body.raw_source).to match(user.decorate.full_name)
       expect(mail.body.raw_source).to match(users_form_answer_audit_certificate_url(form_answer))
-      expect(mail.body.raw_source).to match(users_form_answer_audit_certificate_url(form_answer, format: :pdf))
       expect(mail.body.raw_source).to match(deadline)
     end
   end

--- a/spec/support/file_samples/list_of_procedures_sample.txt
+++ b/spec/support/file_samples/list_of_procedures_sample.txt
@@ -1,0 +1,1 @@
+This is a sample list of procedures document.


### PR DESCRIPTION
Each year QAE send out emails to notify applicants who've successfully
been shortlisted for award, requesting that they login to their QAE
account, download, complete and re-upload a "Verification of Figures"
AKA "External Accountants Report" document. Shortly after sending the
initial congratulations email, a second email is sent, reminding users
to upload their documents, if they haven't done so already.

This PR updates the email copy for both the initial notification message
and the follow-up message if an applicant hasn't uploaded their
verification documents. Since the verification process now involves two
documents, an `audit_certificate` and `list_of_procedures`, we also
update our `EmailNotificationService` to check for the presence of both
documents when sending out reminder emails.

https://trello.com/c/9QZaxIuy/1192-qaeimp-update-the-content-of-the-email-sent-to-remind-applicants-to-upload-their-external-accountants-report-and-the-supplementa

![Notification Of Shortlisting Preview](https://user-images.githubusercontent.com/1914715/97577967-0a3fea00-19e8-11eb-821e-e04c93bdacc8.png)
<img width="1438" alt="Notification Of Shortlisting Raw Email" src="https://user-images.githubusercontent.com/1914715/97577983-0e6c0780-19e8-11eb-8764-1cd6ed9ed884.png">
![Reminder Of Shortlisting Preview](https://user-images.githubusercontent.com/1914715/97577996-1166f800-19e8-11eb-9039-ea0944e981e8.png)
<img width="1436" alt="Reminder Of Shortlisting Raw Email" src="https://user-images.githubusercontent.com/1914715/97577998-12982500-19e8-11eb-81c0-88859bd31b42.png">
