### PR TITLE
🐛 Handle audit events from deleted users

### DIFF
--- a/app/services/form_answer_auditor.rb
+++ b/app/services/form_answer_auditor.rb
@@ -17,7 +17,7 @@ class FormAnswerAuditor
       AuditEvent.new(
         form_answer: form_answer,
         action_type: audit_log.action_type,
-        subject: audit_log.subject,
+        subject: audit_log.subject || dummy_user,
         created_at: audit_log.created_at
         )
     end
@@ -37,7 +37,7 @@ class FormAnswerAuditor
   def get_user_from_papertrail_version(version)
     return dummy_user if version.whodunnit.nil?
     klass, id = version.whodunnit.split(":")
-    klass.capitalize.constantize.find_by_id(id)
+    klass.capitalize.constantize.find_by_id(id) || dummy_user
   end
 
 end


### PR DESCRIPTION
This morning we saw a Sentry error (linked below) where we're an
`AuditEvent` object had a `subject` value of `nil`. Upon closer
inspection, I've found that 74 `PaperTrail::Version` records were
created by an Assessor that no longer exists in the database, hence
a `nil` value is being set for the `subject` association.

This commit ensures that a `subject` is always set by falling back to
our `dummy_user`, if/when the "real" subject can't be retrieved from the
database.

https://sentry.io/organizations/bit-zesty-client-apps/issues/2020379239/?referrer=slack

https://trello.com/c/Wa3DxWGF/1209-qae1120-sentry-error-undefined-method-fullname-for-nilnilclass