### PR TITLE
📈 Track when an assessor's note can't be saved

### DIFF
--- a/app/controllers/concerns/assessor_assignment_context.rb
+++ b/app/controllers/concerns/assessor_assignment_context.rb
@@ -10,6 +10,7 @@ module AssessorAssignmentContext
       else
         format.json { render status: :unprocessable_entity,
                              json: { errors: assessment.resource.errors } }
+        Raven.send_event("Failed to save `AssessorAssignment##{assessor_assignment.id}. \n #{assessment.resource.errors} \n #{params}")
       end
 
       format.html { redirect_back(fallback_location: root_path) }


### PR DESCRIPTION
We've recently received a support request from QAE reporting that, for a
handful of assessors, submitted case summaries (a type of
`AssessorAssignment`) haven't saved correctly. So far we've been unable
to verify or replicate the issue.

This commit adds a Sentry notification if/when an `AssessorAssignment`
object fails to be successfully updated.

https://app.asana.com/0/1183526305150907/1199195899126653