### PR TITLE
Improve UX for upload and download of verification documents

### DIFF
--- a/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
+++ b/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
@@ -32,6 +32,7 @@ window.AuditCertificatesUpload =
       filename = file_url.split('/').pop()
       list.find(".js-audit-certificate-title").attr("href", file_url)
       list.find(".js-audit-certificate-title").text(filename)
+      list.find(".js-audit-certificate-title").attr("download", filename)
       list.removeClass("hidden")
 
       # Remove `Uploading...`

--- a/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
+++ b/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
@@ -33,6 +33,7 @@ window.AuditCertificatesUpload =
       list.find(".js-audit-certificate-title").attr("href", file_url)
       list.find(".js-audit-certificate-title").text(filename)
       list.find(".js-audit-certificate-title").attr("download", filename)
+      list.find(".js-audit-certificate-title").attr("title", filename)
       list.removeClass("hidden")
 
       # Remove `Uploading...`

--- a/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
+++ b/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
@@ -27,9 +27,12 @@ window.AuditCertificatesUpload =
       list.find(".li-audit-upload").addClass("hidden")
 
     upload_done = (e, data, link) ->
+      # Immediately show a link to download the uploaded file
       file_url = data.result["attachment"]["url"]
-      list.removeClass("hidden")
+      filename = file_url.split('/').pop()
       list.find(".js-audit-certificate-title").attr("href", file_url)
+      list.find(".js-audit-certificate-title").text(filename)
+      list.removeClass("hidden")
 
       # Remove `Uploading...`
       list.find(".js-uploading").remove()

--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -1044,3 +1044,7 @@ ul.no-bullets {
   list-style-image: none !important;
   padding-left: 0em;
 }
+
+form.audit-certificate-upload-form span.button-add {
+  margin-bottom: 20px;
+}

--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -1007,6 +1007,7 @@ details {
 .remove-verification-document {
   font-size: 16px;
   display: inline-block;
+  vertical-align: top;
 
   .text-danger {
     color: #a94442;
@@ -1022,6 +1023,11 @@ details {
   padding-left: 1.75em;
   position: relative;
   font-weight: bold;
+  max-width: 420px;
+  max-width: calc(100% - 150px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &:before {
     content: " ";

--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -1016,3 +1016,31 @@ details {
 .js-audit-certificate-title {
   margin-right: 10px;
 }
+
+.download-link {
+  display: inline-block;
+  padding-left: 1.75em;
+  position: relative;
+  font-weight: bold;
+
+  &:before {
+    content: " ";
+    display: block;
+    width: 18px;
+    height: 16px;
+    background-image: image-url("icon_download.svg");
+    background-repeat: no-repeat;
+    background-size: 100% auto;
+    background-position: center;
+
+    position: absolute;
+    left: 0;
+    top: 2px;
+  }
+}
+
+ul.no-bullets {
+  list-style-type: none !important;
+  list-style-image: none !important;
+  padding-left: 0em;
+}

--- a/app/views/users/audit_certificates/_file.html.slim
+++ b/app/views/users/audit_certificates/_file.html.slim
@@ -4,7 +4,7 @@
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
       = link_to att_record.attachment.file.filename, att_record.attachment_url,
-                target: "_blank", class: "js-audit-certificate-title download-link"
+                target: "_blank", class: "js-audit-certificate-title download-link", download: att_record.attachment.file.filename
     - elsif att_record.attachment_scan_results == "scanning"
       | Uploaded External Accountant's Report is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"
@@ -15,7 +15,7 @@
   - else
       | Uploaded External Accountant's Report is being scanned for viruses.
 
-- else # The below link gets displayed by javascript when the user uploads a file (no page reload)
+- else # The below link gets displayed by javascript when the user uploads a file (no page reload). The link attributes are updated automatically.
   = link_to "Download Verification of Commercial Figures", "",
             target: "_blank", class: "js-audit-certificate-title download-link"
 

--- a/app/views/users/audit_certificates/_file.html.slim
+++ b/app/views/users/audit_certificates/_file.html.slim
@@ -3,21 +3,21 @@
 
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
-      = link_to "Download External Accountant's Report", att_record.attachment_url,
-                target: "_blank", class: "js-audit-certificate-title"
+      = link_to att_record.attachment.file.filename, att_record.attachment_url,
+                target: "_blank", class: "js-audit-certificate-title download-link"
     - elsif att_record.attachment_scan_results == "scanning"
       | Uploaded External Accountant's Report is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"
       | Uploaded file has been blocked (virus detected), please remove.
     - else
-      = link_to "Download Verification of Commercial Figures", "",
-                target: "_blank", class: "js-audit-certificate-title"
+      = link_to att_record.attachment.file.filename, "",
+                target: "_blank", class: "js-audit-certificate-title download-link"
   - else
       | Uploaded External Accountant's Report is being scanned for viruses.
 
-- else
+- else # The below link gets displayed by javascript when the user uploads a file (no page reload)
   = link_to "Download Verification of Commercial Figures", "",
-            target: "_blank", class: "js-audit-certificate-title"
+            target: "_blank", class: "js-audit-certificate-title download-link"
 
 small.pull-right.remove-verification-document
   = form_for(users_form_answer_audit_certificate_path, html: { method: :delete, class:"js-remove-verification-document-form", style: "display:inline-block;"}) do |f|

--- a/app/views/users/audit_certificates/_file.html.slim
+++ b/app/views/users/audit_certificates/_file.html.slim
@@ -4,7 +4,7 @@
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
       = link_to att_record.attachment.file.filename, att_record.attachment_url,
-                target: "_blank", class: "js-audit-certificate-title download-link", download: att_record.attachment.file.filename
+                target: "_blank", class: "js-audit-certificate-title download-link", download: att_record.attachment.file.filename, title: att_record.attachment.file.filename
     - elsif att_record.attachment_scan_results == "scanning"
       | Uploaded External Accountant's Report is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"

--- a/app/views/users/audit_certificates/_form.html.slim
+++ b/app/views/users/audit_certificates/_form.html.slim
@@ -5,7 +5,7 @@
   .errors-container
   .clear
   span.button.button-add
-    span + Upload External Accountant's Report form
+    span + Upload External Accountant's Report
     = f.input :attachment,
               as: :file,
               required: true,

--- a/app/views/users/audit_certificates/_non_js_form.html.slim
+++ b/app/views/users/audit_certificates/_non_js_form.html.slim
@@ -7,7 +7,7 @@
       = f.input :attachment,
                 as: :file,
                 required: true,
-                label: "Upload Verification of Commercial Figures"
+                label: "Upload External Accountant's Report"
 
   = f.submit "Upload", class: "button button-add button-upload non-js-audit-certificate-submit"
 .clear

--- a/app/views/users/audit_certificates/_upload_block.html.slim
+++ b/app/views/users/audit_certificates/_upload_block.html.slim
@@ -1,5 +1,5 @@
 .js-upload-wrapper data-max-attachments=1 data-form-name="audit-cert-form" data-name="audit-cert-name" data-filename="Uploaded Verification of Commercial Figures"
-  ul.js-uploaded-list class=("hidden" unless cert_exists)
+  ul.js-uploaded-list.no-bullets class=("hidden" unless cert_exists)
     li.li-audit-upload
       div
         = render "users/audit_certificates/file", cert_exists: cert_exists,

--- a/app/views/users/list_of_procedures/_file.html.slim
+++ b/app/views/users/list_of_procedures/_file.html.slim
@@ -4,7 +4,7 @@
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
       = link_to att_record.attachment.file.filename, att_record.attachment_url,
-                target: "_blank", class: "js-audit-certificate-title download-link", download: att_record.attachment.file.filename
+                target: "_blank", class: "js-audit-certificate-title download-link", download: att_record.attachment.file.filename, title: att_record.attachment.file.filename
     - elsif att_record.attachment_scan_results == "scanning"
       | Uploaded list of procedures is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"

--- a/app/views/users/list_of_procedures/_file.html.slim
+++ b/app/views/users/list_of_procedures/_file.html.slim
@@ -4,7 +4,7 @@
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
       = link_to att_record.attachment.file.filename, att_record.attachment_url,
-                target: "_blank", class: "js-audit-certificate-title download-link"
+                target: "_blank", class: "js-audit-certificate-title download-link", download: att_record.attachment.file.filename
     - elsif att_record.attachment_scan_results == "scanning"
       | Uploaded list of procedures is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"
@@ -15,7 +15,7 @@
   - else
       | Uploaded list of procedures is being scanned for viruses.
 
-- else # The below link gets displayed by javascript when the user uploads a file (no page reload)
+- else # The below link gets displayed by javascript when the user uploads a file (no page reload). The link attributes are updated automatically.
   = link_to "Download list of procedures", "",
             target: "_blank", class: "js-audit-certificate-title download-link"
 

--- a/app/views/users/list_of_procedures/_file.html.slim
+++ b/app/views/users/list_of_procedures/_file.html.slim
@@ -3,21 +3,21 @@
 
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
-      = link_to "Download list of procedures", att_record.attachment_url,
-                target: "_blank", class: "js-audit-certificate-title"
+      = link_to att_record.attachment.file.filename, att_record.attachment_url,
+                target: "_blank", class: "js-audit-certificate-title download-link"
     - elsif att_record.attachment_scan_results == "scanning"
       | Uploaded list of procedures is being scanned for viruses.
     - elsif att_record.attachment_scan_results == "infected"
       | Uploaded file has been blocked (virus detected), please remove.
     - else
-      = link_to "Download list of procedures", "",
+      = link_to att_record.attachment.file.filename, "",
                 target: "_blank", class: "js-audit-certificate-title"
   - else
       | Uploaded list of procedures is being scanned for viruses.
 
-- else
+- else # The below link gets displayed by javascript when the user uploads a file (no page reload)
   = link_to "Download list of procedures", "",
-            target: "_blank", class: "js-audit-certificate-title"
+            target: "_blank", class: "js-audit-certificate-title download-link"
 
 small.pull-right.remove-verification-document
   = form_for(:list_of_procedures, url: users_form_answer_list_of_procedures_path(form_answer), html: { class: "js-remove-verification-document-form", method: :delete, style: "display:inline-block;"}) do |f|

--- a/app/views/users/list_of_procedures/_upload_block.html.slim
+++ b/app/views/users/list_of_procedures/_upload_block.html.slim
@@ -1,5 +1,5 @@
 .js-upload-wrapper data-max-attachments=1 data-form-name="audit-cert-form" data-name="audit-cert-name" data-filename="Uploaded list of procedures"
-  ul.js-uploaded-list class=("hidden" unless list_exists)
+  ul.js-uploaded-list.no-bullets class=("hidden" unless list_exists)
     li.li-audit-upload
       div
         = render "users/list_of_procedures/file", list_exists: list_exists,


### PR DESCRIPTION
As part of our ongoing efforts to improve the QAE UX, we'd like the
download links for user-uploaded documents to feature the name of the
document, making it easier for the user to verify what they've uploaded
and to understand what they're about to re-download.

![hJtW9cTixT](https://user-images.githubusercontent.com/1914715/99525473-c5c5bf80-2991-11eb-996a-36ee8e71b510.gif)
