### PR TITLE
💄 Tweak style of assessor financial verification

### DIFF
--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -336,7 +336,6 @@
 }
 
 .section-financial-summary .form-group {
-  margin-bottom: 30px;
   border-bottom: none;
 
   &:last-child {
@@ -346,6 +345,10 @@
   .table {
     margin-bottom: 0;
   }
+}
+
+.section-financial-summary .form-actions {
+  margin: 0 0 1em 0;
 }
 
 .form-edit-link {

--- a/app/views/admin/form_answers/_section_financial_summary.html.slim
+++ b/app/views/admin/form_answers/_section_financial_summary.html.slim
@@ -43,7 +43,7 @@
                 = link_to "#", class: "form-edit-link pull-right edit-review-audit"
                   span.glyphicon.glyphicon-pencil
                   ' Edit
-                .form-actions.text-right
+                .form-actions.text-left
                   .form-fields
                     = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide"
                     = link_to "Save", "#", class: "btn btn-primary save-review-audit pull-right", style: "display: none"


### PR DESCRIPTION
We've received a handful of reports from assessor users claiming the
notes they've added under the the "Financial Summary" section, whilst
reviewing an application, either haven't been or saved or have been
lost. Whilst we continue to investigate these reports, let's tweak the
UI to move the form controls to the left of the page and closer to the
confirmation radio buttons, ensuring users notice them when applying
changes.

https://app.asana.com/0/1199190913173550/1199198194706069/f

**Before**
<img width="762" alt="Assessor Controls Before" src="https://user-images.githubusercontent.com/1914715/99536154-e0079980-29a1-11eb-8597-d02d19443047.png">

**After**
<img width="798" alt="Assessor Controls After" src="https://user-images.githubusercontent.com/1914715/99536170-e7c73e00-29a1-11eb-8e51-1c813b4581b9.png">
