### PR TITLE
🐛 Update how filename is extracted from URLs

### DIFF
--- a/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
+++ b/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
@@ -29,7 +29,7 @@ window.AuditCertificatesUpload =
     upload_done = (e, data, link) ->
       # Immediately show a link to download the uploaded file
       file_url = data.result["attachment"]["url"]
-      filename = file_url.split('/').pop()
+      filename = file_url.match(/[^\/?#]+(?=$|[?#])/);
       list.find(".js-audit-certificate-title").attr("href", file_url)
       list.find(".js-audit-certificate-title").text(filename)
       list.find(".js-audit-certificate-title").attr("download", filename)


### PR DESCRIPTION
We've recently updated the Verification of Commercial Figures UI to
display the name of your file during upload. Extracting the filename
from the URL was achieved rather naively using a method that doesn't
play nicely when a URL contains query parameters.

This commit extracts the filename from the URL using a more specialised
regular expression, which will hopefully correctly handle URLs with
query parameters.