### PR TITLE
WIP upgrade error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,7 +168,10 @@ end
 
 group :production do
   # Error reporting
-  gem 'sentry-raven'
+  gem "sentry-ruby"
+  gem "sentry-rails"
+  gem "sentry-sidekiq"
+
   # Log to the STDOUT and dev/prod parity when delivering assets, 12factor.net
   gem 'rails_12factor', '~> 0.0.3'
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
 
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_raven_context
+  before_action :set_sentry_context
   before_action :set_paper_trail_whodunnit
   before_action :disable_browser_caching!
 
@@ -158,8 +158,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_raven_context
-    context = { current_user: current_user.try(:id) }
-    Raven.user_context(context)
+    Sentry.configure_scope do |scope|
+      scope.set_user(id: current_user.try(:id))
+    end
   end
 
   private

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,12 +1,7 @@
-require 'raven'
-
-if defined?(Raven) && ENV["VCAP_APPLICATION"].present?
+if defined?(Sentry) && ENV["VCAP_APPLICATION"].present?
   tags = JSON.parse(ENV["VCAP_APPLICATION"])
              .except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version')
-  Raven.configure do |config|
-    config.tags = tags
-    config.silence_ready = true
-    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-    config.environments = [ 'production' ]
+  Sentry.configure_scope do |scope|
+    config.set_tags = tags
   end
 end


### PR DESCRIPTION
Can't install gems due to conflict dependency in vigilion-rails using older version of farady we should upgrade that first.