### PR TITLE
💄 Push "remove" links further to the right ➡️

### DIFF
--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -1015,7 +1015,7 @@ details {
 }
 
 .js-audit-certificate-title {
-  margin-right: 10px;
+  margin-right: 20px;
 }
 
 .download-link {


### PR DESCRIPTION
Laura and Stephanie have requested that the "remove" links, displayed
alongside a user's uploaded verification document(s), be moved slightly
to the right.

This very simple commit simply increases the right margin from `10px` to
`20px`.

**Before**
<img width="814" alt="Remove Link Before" src="https://user-images.githubusercontent.com/1914715/99658467-73e76d00-2a57-11eb-89ec-1717c0ee4e39.png">

**After**
<img width="823" alt="Remove Link After" src="https://user-images.githubusercontent.com/1914715/99658488-7b0e7b00-2a57-11eb-9e9d-8b8351ac4903.png">
