### PR TITLE
Fix overlapping elements and rename user to applicant

### DIFF
--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -27,6 +27,7 @@ class AuditEvent
   end
 
   def user_string
-    "#{subject.full_name} (#{subject.class.name})"
+    user_type = subject.class.name == "User" ? "Applicant" : subject.class.name
+    "#{subject.full_name} (#{user_type})"
   end
 end

--- a/app/views/admin/form_answers/_section_financial_summary.html.slim
+++ b/app/views/admin/form_answers/_section_financial_summary.html.slim
@@ -13,6 +13,7 @@
 
     #financial-summary.section-financial-summary.panel-collapse.collapse role="tabpanel" aria-labelledby="financial-summary-heading"
       .panel-body
+        label.form-label Verification of Commercial Figures
         - if resource.audit_certificate.present?
           - review_audit_certificate = ReviewAuditCertificate.new(form_answer_id: resource.id, status: resource.audit_certificate.status, changes_description: resource.audit_certificate.changes_description)
 

--- a/app/views/admin/form_answers/financial_summary/_audit_certificate.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_audit_certificate.html.slim
@@ -1,6 +1,5 @@
 - url_namespace = admin_signed_in? ? :admin : :assessor
 
-label.form-label Verification of Commercial Figures
 - if policy(resource).download_audit_certificate_pdf?
   p = link_to "View Verification of Commercial Figures", [url_namespace, resource, resource.audit_certificate],
       target: "_blank", class: "js-audit-certificate-title"


### PR DESCRIPTION
During testing, Stephanie spotted that controls for commercial figure
verification, whilst viewing an application that doesn't have an
associated `audit_certificate` (AKA External Accountant's Report),
renders a label that overlaps with the form radio inputs.

This PR resolves the overlapping elements by moving the label to the
top of the Financial Summary panel, rather than having it rendered by a
partial *after* the radio buttons have been rendered, which was the
cause of the overlap.

This PR updates our audit log feature to replace the term "User"
with "Applicant", since this terminology more accurately reflects the
roles of users in the QAE system (arguably, _everyone_ is a user).

 **Verification Controls**
<img width="787" alt="Verification Controls Before" src="https://user-images.githubusercontent.com/1914715/99691913-a0b07a00-2a81-11eb-8eb7-26ff5702f5de.png">
<img width="797" alt="Verification Controls After" src="https://user-images.githubusercontent.com/1914715/99691946-a908b500-2a81-11eb-9c97-a9485c70b90c.png">

**Audit Log**
<img width="652" alt="Audit Log Before" src="https://user-images.githubusercontent.com/1914715/99691922-a312d400-2a81-11eb-8d8c-278a6141c9ea.png">
<img width="696" alt="Audit Log After" src="https://user-images.githubusercontent.com/1914715/99691960-ac9c3c00-2a81-11eb-8400-4bd37be9adad.png">
