### PR TITLE
📝 Update confirmation email sent to a new judge

### DIFF
--- a/app/views/admins/mailer/confirmation_instructions.text.erb
+++ b/app/views/admins/mailer/confirmation_instructions.text.erb
@@ -2,8 +2,8 @@ Welcome <%= @email %>
 
 You have signed up for a Queen's Awards for Enterprise account.
 
-You can confirm your email account using link below: 
-<%= confirmation_url(@resource, confirmation_token: @token) %>.
+You can confirm your email account using link below:
+<%= confirmation_url(@resource, confirmation_token: @token) %>
 
 We recommend that you bookmark the login page to make it easier to find it in future.
 

--- a/app/views/judges/mailer/confirmation_instructions.html.erb
+++ b/app/views/judges/mailer/confirmation_instructions.html.erb
@@ -1,1 +1,0 @@
-<%= render(template: "admins/mailer/confirmation_instructions", formats: ["text"]) %>

--- a/app/views/judges/mailer/confirmation_instructions.text.erb
+++ b/app/views/judges/mailer/confirmation_instructions.text.erb
@@ -1,0 +1,13 @@
+Welcome <%= @email %>
+
+You have been added to the Queen’s Awards for Enterprise system.
+
+You can confirm your email account and login using the link below:
+<%= confirmation_url(@resource, confirmation_token: @token) %>
+
+We recommend that you bookmark the login page to make it easier to find it in future.
+
+If you believe you have been added to the account by mistake, please contact queensawards@beis.gov.uk.
+
+Thank you,
+The Queen’s Awards Office


### PR DESCRIPTION
📝 Update confirmation email sent to a new judge

Until now, newly added judges have been sent the same confirmation email
as newly added admin users.

This commit updates the email copy sent to a judge that's newly added to
the QAE system. We also update the admin confirmation email to remove a
rogue full-stop (.) character that's erroneously added to the end of the
confirmation URL, leading to an "invalid token" error when the admin tries
to confirm their account.

https://app.asana.com/0/1199190913173559/1199360327624221/f

<img width="845" alt="Screenshot 2020-11-26 at 13 25 34" src="https://user-images.githubusercontent.com/1914715/100357207-474dcb00-2fec-11eb-8196-a2f881bfee11.png">
