### PR TITLE
remove html email template

### DIFF
--- a/app/views/judges/mailer/confirmation_instructions.html.erb
+++ b/app/views/judges/mailer/confirmation_instructions.html.erb
@@ -1,1 +1,0 @@
-<%= render(template: "admins/mailer/confirmation_instructions", formats: [:text]) %>

--- a/app/views/judges/mailer/confirmation_instructions.text.erb
+++ b/app/views/judges/mailer/confirmation_instructions.text.erb
@@ -7,7 +7,7 @@ You can confirm your email account and login using the link below:
 
 We recommend that you bookmark the login page to make it easier to find it in future.
 
-If you believe you have been added to the account by mistake, please contact queensawards@beis.gov.uk.
+If you believe you have been added to the account by mistake, please contact queensawards@beis.gov.uk.
 
 Thank you,
 The Queen’s Awards Office


### PR DESCRIPTION
this breaks judge creation and confirmation email on dev

This file was added during rails 6 upgrade, not sure why. 