### PR TITLE
⬆️ Upgrade Nokogiri to 1.11.1 (fixing CVE)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'enumerize'
 # PDF generation
 gem 'prawn'
 gem 'prawn-table'
-gem 'nokogiri', '~> 1.10.9'
+gem 'nokogiri'
 
 # Uploads
 gem 'carrierwave', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,7 +458,7 @@ GEM
     mime-types-data (3.2019.1009)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     money (6.13.1)
       i18n (>= 0.6.4, <= 2)
@@ -470,8 +470,9 @@ GEM
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
     nio4r (2.5.4)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
     notifications-ruby-client (5.3.0)
@@ -531,6 +532,7 @@ GEM
       pusher-signature (~> 0.1.8)
     pusher-signature (0.1.8)
     raabro (1.1.6)
+    racc (1.5.2)
     rack (2.2.3)
     rack-contrib (2.2.0)
       rack (~> 2.0)
@@ -822,7 +824,7 @@ DEPENDENCIES
   mail-notify (~> 1.0)
   meta_request
   nilify_blanks
-  nokogiri (~> 1.10.9)
+  nokogiri
   paper_trail (~> 10.3)
   pdf-inspector
   pg (~> 0.20)


### PR DESCRIPTION
Our security scanner, Snyk, has highlighted a CVE in our current version
of `nokogiri` (`1.10.10`). This PR upgrades Nokogiri to the latest
stable release, `1.11.1`, which contains a fix for the security issue.

References:
https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-1055008