### PR TITLE
Revert "🔥 Temporarily remove VOCF status"

### DIFF
--- a/app/views/content_only/post_submission/_shortlisted.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted.html.slim
@@ -34,13 +34,13 @@
               span.pull-right
                 ' Due by
                 = application_deadline_short(:audit_certificates)
-              / = link_to users_form_answer_audit_certificate_url(award)
-              /   - if award.audit_certificate.present?
-              /     span.label-status.label-status-green
-              /       ' Complete
-              /   - else
-              /     span.label-status.label-status-red
-              /       ' Incomplete
+              = link_to users_form_answer_audit_certificate_url(award)
+                - if award.audit_certificate.present?
+                  span.label-status.label-status-green
+                    ' Complete
+                - else
+                  span.label-status.label-status-red
+                    ' Incomplete
         .clear
       .clear
   br


### PR DESCRIPTION
This reverts commit b9612b940dcc6cd74a96133f4f6d3550f5fc29b4.

It does not resolve the issue as stated in the original commit, we still need to address it later. 
This will help to avoid users becoming confused with UI now that everyone has uploaded their documents.