### PR TITLE
🐛 Update "All Entries" CSV to support new keys

### DIFF
--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -269,9 +269,9 @@ module Reports::DataPickers::FormDocumentPicker
     service = if innovation?
       doc("innovation_desc_short")
     elsif development?
-      doc("development_management_approach_briefly")
+      obj.award_year.year <= 2019 ? doc("development_management_approach_briefly") : doc("one_line_description_of_interventions")
     elsif mobility?
-      doc("mobility_desc_short")
+      obj.award_year.year <= 2020 ? doc("mobility_desc_short") : doc("organisation_desc_short")
     else
       doc("trade_goods_briefly")
     end


### PR DESCRIPTION
This morning, we received a support request from QAE highlighting how,
when viewing "Recommended" applications in the "All Entries" CSV export,
the "ProductService" column was blank for "Sustainable Development" and
"Promoting Opportunities" awards.

After reading through the exporter code I've found that, in recent
years, we've subtly reworded the questions from which this column is
populated, including changing the name of the `document` hash key in
which the user's answer is saved.

This commit updates our CSV exporter logic to read from the appropriate
hash key depending on the application year being exported.