### PR TITLE
🚢 Production Deploy 🐛 Handle PO initiative vs org when exporting

### DIFF
--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -271,7 +271,11 @@ module Reports::DataPickers::FormDocumentPicker
     elsif development?
       obj.award_year.year <= 2019 ? doc("development_management_approach_briefly") : doc("one_line_description_of_interventions")
     elsif mobility?
-      obj.award_year.year <= 2020 ? doc("mobility_desc_short") : doc("organisation_desc_short")
+      if obj.award_year.year <= 2020
+        doc("mobility_desc_short")
+      else
+        doc("application_category") == "initiative" ? doc("initiative_desc_short") : doc("organisation_desc_short")
+      end
     else
       doc("trade_goods_briefly")
     end


### PR DESCRIPTION
For the 2021 application year we updated the "Promoting Opportunities"
form to ask different questions depending on whether the user is
submitting a single initiative for consideration or their entire
organisation. Depending on the option chosen by the user, they'll be
shown different sets of questions.

This commit updates our "All Entries" exporter to handle the initiative
vs organisation question, reading from the appropriate sub-questions
accordingly.