### PR TITLE
Google analytics tracking only after explicit consent + new UI

### DIFF
--- a/app/assets/javascripts/frontend/ga-optout.js.coffee
+++ b/app/assets/javascripts/frontend/ga-optout.js.coffee
@@ -1,12 +1,24 @@
 jQuery ->
   if !Cookies.get("gaconsent") && !Cookies.get("gaoptout")
-    $(".govuk-cookie-banner").attr("aria-hidden", "false")
+    $(".govuk-cookie-banner").attr("tabindex", "-1")
+    $(".govuk-cookie-banner").attr("aria-live", "polite")
+    $(".govuk-cookie-banner").removeAttr("hidden")
+    $(".govuk-cookie-banner").attr("role", "alert")
 
-    $(".govuk-cookie-banner .button").click (e) ->
+    $(".govuk-cookie-banner .button.cookies-action").on "click", (e) ->
       e.preventDefault()
 
       Cookies.set("gaconsent", $(@).val(), { expires: 3650 })
-      $(".govuk-cookie-banner").attr("aria-hidden", "true")
+      $(".govuk-cookie-banner .initial-message").attr("hidden", "true")
+
+      if $(@).val() == "accept"
+        $(".govuk-cookie-banner .accept-message").removeAttr("hidden")
+      else
+        $(".govuk-cookie-banner .reject-message").removeAttr("hidden")
+    
+    $(".govuk-cookie-banner .hide-message").on "click", (e) ->
+      e.preventDefault()
+      $(".govuk-cookie-banner").attr("hidden", "true")
 
   if $("#ga-optout-input").length
     $("#ga-optout-input").prop("checked", Cookies.get("gaconsent") == "reject" || Cookies.get("gaoptout"))

--- a/app/assets/javascripts/frontend/ga-optout.js.coffee
+++ b/app/assets/javascripts/frontend/ga-optout.js.coffee
@@ -1,10 +1,19 @@
 jQuery ->
+  if !Cookies.get("gaconsent") && !Cookies.get("gaoptout")
+    $(".govuk-cookie-banner").attr("aria-hidden", "false")
+
+    $(".govuk-cookie-banner .button").click (e) ->
+      e.preventDefault()
+
+      Cookies.set("gaconsent", $(@).val(), { expires: 3650 })
+      $(".govuk-cookie-banner").attr("aria-hidden", "true")
+
   if $("#ga-optout-input").length
-    $("#ga-optout-input").prop("checked", Cookies.get("gaoptout") == "true")
+    $("#ga-optout-input").prop("checked", Cookies.get("gaconsent") == "reject" || Cookies.get("gaoptout"))
     $("#ga-optout").on "click", (e) ->
       e.preventDefault()
 
       if $("#ga-optout-input").prop("checked")
-        Cookies.set("gaoptout", "true", { expires: 3650 })
+        Cookies.set("gaconsent", "reject", { expires: 3650 })
       else
-        Cookies.remove("gaoptout")
+        Cookies.set("gaconsent", "accept", { expires: 3650 })

--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -1,6 +1,8 @@
-#wrapper {
+#wrapper,
+.govuk-width-container {
   @extend %site-width-container;
 }
+
 .grid-row {
   @extend %grid-row;
 

--- a/app/assets/stylesheets/qae.scss
+++ b/app/assets/stylesheets/qae.scss
@@ -44,6 +44,8 @@ $gutter-one-sixth: $gutter/6;
 //
 @import "qae-slimmer-patch";
 
+@import "styleguide/cookie-banner";
+
 // Page specific styles
 #QAE {
   @import "frontend/views/landing";

--- a/app/assets/stylesheets/styleguide/_cookie-banner.scss
+++ b/app/assets/stylesheets/styleguide/_cookie-banner.scss
@@ -1,0 +1,108 @@
+.govuk-cookie-banner {
+  @include core-19;
+  padding-top: 20px;
+  padding-bottom: 30px;
+  border-bottom: 10px solid transparent;
+  background-color: $grey-3;
+
+  p {
+    margin-bottom: 1em;
+  }
+
+  h2 {
+    margin-bottom: 1.2em;
+    font-weight: 600;
+  }
+
+  &[aria-hidden="true"] {
+    display: none;
+  }
+}
+
+.govuk-cookie-banner[hidden] {
+  display: none;
+}
+
+.govuk-cookie-banner__message {
+
+  margin-bottom: -10px;
+
+  &[hidden] {
+
+    display: none;
+  }
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.govuk-button-group {
+ $horizontal-gap: 15px;
+  $vertical-gap: 15px;
+
+  // These need to be kept in sync with the button component's styles
+  $button-padding: 10px;
+  $button-shadow-size: 4px;
+
+  $link-spacing: 5px;
+
+  //lolwtf
+  // @include govuk-responsive-margin(6, "bottom", $adjustment: $vertical-gap * -1);
+
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+
+
+  .govuk-link {
+    @include core-19;
+    display: inline-block;
+    // Prevent links overflowing their container in IE10/11 because of bug
+    // with align-items: center
+    max-width: 100%;
+    margin-top: $link-spacing;
+    margin-bottom: $link-spacing + $vertical-gap;
+    text-align: center;
+  }
+
+  .govuk-button,
+  .button {
+    margin-bottom: $vertical-gap + $button-shadow-size;
+  }
+
+  @include screen-sm-min {
+
+    margin-right: ($horizontal-gap * -1);
+
+    -webkit-box-orient: horizontal;
+
+    -webkit-box-direction: normal;
+
+        -ms-flex-direction: row;
+
+            flex-direction: row;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -webkit-box-align: baseline;
+        -ms-flex-align: baseline;
+            align-items: baseline;
+
+    .govuk-button,
+    .govuk-link,
+    .button {
+      margin-right: $horizontal-gap;
+    }
+
+    .govuk-link {
+      text-align: left;
+    }
+  }
+}

--- a/app/views/content_only/cookies.html.slim
+++ b/app/views/content_only/cookies.html.slim
@@ -105,8 +105,12 @@ header.page-header.page-header-large.group
                   th Expires
               tbody
                 tr
-                  td gaoptout
+                  td gaoptout (superseded)
                   td This allows us to make sure Google Analytics cookies are turned off when you visit our service in future.
+                  td 10 years
+                tr
+                  td gaconsent
+                  td Stores explicit consent from user whether or not they allow Google Analytics to track them.
                   td 10 years
 
             label.hint

--- a/app/views/layouts/_cookie_banner.html.slim
+++ b/app/views/layouts/_cookie_banner.html.slim
@@ -1,0 +1,55 @@
+.govuk-cookie-banner role="region" aria-label="Cookies on Queen's Awards for Enterprise" hidden="true"
+  .govuk-cookie-banner__message.govuk-width-container.initial-message
+    .grid-row
+      .column-two-thirds
+        h2.govuk-cookie-banner__heading.govuk-heading-m
+          | Cookies on Queen's Awards for Enterprise
+
+        .govuk-cookie-banner__content
+          p 
+            | We use some essential cookies to make this service work.
+          p
+            | We’d also like to use analytics cookies so we can understand how you use the service and make improvements.
+
+    .govuk-button-group
+      button.button.cookies-action value="accept" type="button" name="cookies" data-module="govuk-button"
+        | Accept analytics cookies
+      button.button.cookies-action value="reject" type="button" name="cookies" data-module="govuk-button"
+        | Reject analytics cookies
+      = link_to "View cookies", cookies_path, class: "govuk-link"
+  
+  .govuk-cookie-banner__message.govuk-width-container.reject-message hidden="true"
+    .grid-row
+      .column-two-thirds
+        .govuk-cookie-banner__content
+            p 
+              | You’ve rejected analytics cookies. You can
+              =<> link_to "change your cookie settings", cookies_path, class: "govuk-link"
+              | at any time.
+    .govuk-button-group
+      button.button.hide-message type="button"
+        | Hide this message
+  
+  .govuk-cookie-banner__message.govuk-width-container.accept-message hidden="true"
+    .grid-row
+      .column-two-thirds
+        .govuk-cookie-banner__content
+            p 
+              | You’ve accepted analytics cookies. You can
+              =<> link_to "change your cookie settings", cookies_path, class: "govuk-link"
+              | at any time.
+    .govuk-button-group
+      button.button.hide-message type="button"
+        | Hide this message
+
+noscript
+  .govuk-cookie-banner role="region" aria-label="Cookies on Queen's Awards for Enterprise"
+    .govuk-cookie-banner__message.govuk-width-container.initial-message
+      .grid-row
+        .column-two-thirds
+          h2.govuk-cookie-banner__heading.govuk-heading-m
+            | Cookies on Queen's Awards for Enterprise
+
+          .govuk-cookie-banner__content
+            p 
+              | We use cookies to make this service work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings or reload this page.

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -36,25 +36,7 @@
     ' with-proposition
 
 - content_for :cookie_message do
-  .govuk-cookie-banner role="region" aria-label="Cookies on Queen's Awards for Enterprise" aria-hidden="true"
-    .govuk-cookie-banner__message.govuk-width-container
-      .grid-row
-        .column-two-thirds
-          h2.govuk-cookie-banner__heading.govuk-heading-m
-            | Cookies on Queen's Awards for Enterprise
-
-          .govuk-cookie-banner__content
-            p 
-              | We use some essential cookies to make this service work.
-            p
-              | We’d also like to use analytics cookies so we can understand how you use the service and make improvements.
-
-      .govuk-button-group
-        button.button value="accept" type="button" name="cookies" data-module="govuk-button"
-          | Accept analytics cookies
-        button.button value="reject" type="button" name="cookies" data-module="govuk-button"
-          | Reject analytics cookies
-        = link_to "View cookies", cookies_path, class: "govuk-link"
+  = render "layouts/cookie_banner"
 
 - content_for :proposition_header do
   - unless landing_page?

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -36,11 +36,25 @@
     ' with-proposition
 
 - content_for :cookie_message do
-  .outer-block
-    .inner-block
-      p
-        ' GOV.UK uses cookies to make the site simpler.
-        = link_to "Find out more about cookies", cookies_path
+  .govuk-cookie-banner role="region" aria-label="Cookies on Queen's Awards for Enterprise" aria-hidden="true"
+    .govuk-cookie-banner__message.govuk-width-container
+      .grid-row
+        .column-two-thirds
+          h2.govuk-cookie-banner__heading.govuk-heading-m
+            | Cookies on Queen's Awards for Enterprise
+
+          .govuk-cookie-banner__content
+            p 
+              | We use some essential cookies to make this service work.
+            p
+              | We’d also like to use analytics cookies so we can understand how you use the service and make improvements.
+
+      .govuk-button-group
+        button.button value="accept" type="button" name="cookies" data-module="govuk-button"
+          | Accept analytics cookies
+        button.button value="reject" type="button" name="cookies" data-module="govuk-button"
+          | Reject analytics cookies
+        = link_to "View cookies", cookies_path, class: "govuk-link"
 
 - content_for :proposition_header do
   - unless landing_page?
@@ -153,7 +167,8 @@
   - if ENV["GOOGLE_ANALYTICS_ID"].present?
     / Google Analytics
     script type="text/javascript"
-      | if (!Cookies.get("gaoptout")) {
+      | if (Cookies.get("gaconsent") === "accept" && !Cookies.get("gaoptout")) {
+      |   console.log("hi")
       |   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
       |   ga('create', '#{ENV["GOOGLE_ANALYTICS_ID"]}', 'auto');
 

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -72,14 +72,7 @@
       </div>
     </div>
 
-    <div id="global-cookie-message">
-      <% if content_for?(:cookie_message) %>
-        <%= yield :cookie_message %>
-      <% else %>
-        <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
-      <% end %>
-    </div>
-    <!--end global-cookie-message-->
+    <%= yield :cookie_message %>
 
     <% unless @omit_header %>
     <header role="banner" id="global-header" class="<%= yield(:header_class) %>">


### PR DESCRIPTION
To comply with GDPR law, any tracking can only take place after explicit consent from the user.
Previously the user could only opt out, but they would always be tracked until they did so.

In this PR, we implement updated UI and change Google Analytics to only track users that have explicitly consented to be tracked by Google Analytics, while still being able to opt out any time.

It covers

- Initial message
- Accept/reject messages
- Javascript disabled  message

Card: https://app.asana.com/0/1199190913173550/1200019173027652/f

---

## Screenshots

![Selection_509](https://user-images.githubusercontent.com/758001/110338424-e12b0800-801e-11eb-86e5-d90cee2fcb18.png)
![Selection_508](https://user-images.githubusercontent.com/758001/110338425-e1c39e80-801e-11eb-9b72-b02d476a0fcc.png)
![Selection_507](https://user-images.githubusercontent.com/758001/110338426-e1c39e80-801e-11eb-9721-688fee736211.png)
![Selection_506](https://user-images.githubusercontent.com/758001/110338429-e25c3500-801e-11eb-93b7-99a8aea143f6.png)
