### PR TITLE
Remove javascript disabled cookie banner as we only use it for GA consent, which uses JS

### DIFF
--- a/app/views/layouts/_cookie_banner.html.slim
+++ b/app/views/layouts/_cookie_banner.html.slim
@@ -41,15 +41,3 @@
     .govuk-button-group
       button.button.hide-message type="button"
         | Hide this message
-
-noscript
-  .govuk-cookie-banner role="region" aria-label="Cookies on Queen's Awards for Enterprise"
-    .govuk-cookie-banner__message.govuk-width-container.initial-message
-      .grid-row
-        .column-two-thirds
-          h2.govuk-cookie-banner__heading.govuk-heading-m
-            | Cookies on Queen's Awards for Enterprise
-
-          .govuk-cookie-banner__content
-            p 
-              | We use cookies to make this service work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings or reload this page.


### PR DESCRIPTION
After testing with Stephanie, we decided that since we only take consent for the analytics, and it only runs with JS, it makes no sense to keep a message for people with JS disabled.