### PR TITLE
✨ Add Winners Dashboard for 2021

### DIFF
--- a/app/views/content_only/award_winners_section/2021.html.slim
+++ b/app/views/content_only/award_winners_section/2021.html.slim
@@ -1,0 +1,133 @@
+- winners = FormAnswerDecorator.decorate_collection(@user_award_forms_submitted).select{ |app| app.awarded? }
+- any_promotion_winner = winners.select{ |app| app.mobility? }.any?
+- any_innovation_winner = winners.select{ |app| app.innovation? }.any?
+- any_trade_winner = winners.select{ |app| app.trade? }.any?
+- any_development_winner = winners.select{ |app| app.development? }.any?
+
+div
+  header.group.page-header.page-header-wider
+    div
+      h1 Winners' Resources 2021
+
+  .article-container.article-container-wider
+    article.group role="article"
+      .inner
+        p Here you can download Queen's Awards for Enterprise resources for use in your websites and advertising materials. The Winners' Manual provides more detailed information on where and how you are allowed to use these resources.
+
+        br
+
+        h2 Download The Queen's Awards for Enterprise Winners' Manual 2021
+
+        .form-download
+          p
+            = link_to "Queen's Awards for Enterprise Winners' Manual 2021 (PDF, 877KB)",
+                      static_s3_asset_path(2021, "Winners- Manual 2021.pdf"),
+                      class: "thumbnail",
+                      target: "_blank"
+
+        h2 Download The Queen's Awards Emblem Guidance 2021
+
+        .form-download
+          p
+            = link_to "Queen's Awards Emblem Guidance 2021 (PDF, 991)",
+                      static_s3_asset_path(2021, "QAE Emblem Guidance 2021.pdf"),
+                      class: "thumbnail",
+                      target: "_blank"
+
+        h2 Download The Queen's Awards for Enterprise 2021 Emblems in various formats
+
+        .form-download
+          - if any_promotion_winner
+            p
+              = link_to "Queen's Awards for Enterprise 2021 Emblem - Promoting Opportunities (PNG, 100KB)",
+                      static_s3_asset_path(2021, "QA-logo-categories-2021_promoting_digital.png"),
+                      target: "_blank"
+            p
+              = link_to "Queen's Awards for Enterprise 2021 Emblem - Promoting Opportunities (EPS, 5.5MB)",
+                      static_s3_asset_path(2021, "QA-logo-categories-2021_promoting-print-.eps"),
+                      target: "_blank"
+
+          - if any_innovation_winner
+            p
+              = link_to "Queen's Awards for Enterprise 2021 Emblem - Enterprise Innovation (PNG, 95KB)",
+                      static_s3_asset_path(2021, "QA-logo-categories-2021_innovation_digital.png"),
+                      target: "_blank"
+
+            p
+              = link_to "Queen's Awards for Enterprise 2021 Emblem - Enterprise Innovation (EPS, 5.6MB)",
+                      static_s3_asset_path(2021, "QA-logo-categories-2021_innovation-print-.eps"),
+                      target: "_blank"
+
+          - if any_trade_winner
+            p
+              = link_to "Queen's Awards for Enterprise 2021 Emblem - International Trade (PNG, 96KB)",
+                      static_s3_asset_path(2021, "QA-logo-categories-2021_international trade_digital.png"),
+                      target: "_blank"
+            p
+              = link_to "Queen's Awards for Enterprise 2021 Emblem - International Trade (EPS, 5.5MB)",
+                      static_s3_asset_path(2021, "QA-logo-categories-2021_international trade-print-.eps"),
+                      target: "_blank"
+
+          - if any_development_winner
+            p
+              = link_to "Queen's Awards for Enterprise 2021 Emblem - Sustainable Development (PNG, KB)",
+                      static_s3_asset_path(2021, "QA-logo-categories-2021_Sustainable_digital.png"),
+                      target: "_blank"
+            p
+              = link_to "Queen's Awards for Enterprise 2021 Emblem - Sustainable Development (EPS, 5.6MB)",
+                      static_s3_asset_path(2021, "QA-logo-categories-2021_Sustainable-print-.eps"),
+                      target: "_blank"
+
+        .form-download
+          p
+            = link_to "Queen's Awards for Enterprise 2021 Emblem: Black (PNG, 78KB)",
+                      static_s3_asset_path(2021, "QA-logo2021-digital-_black.png"),
+                      target: "_blank"
+
+          p
+            = link_to "Queen's Awards for Enterprise 2021 Emblem: Black (EPS, 5.4B)",
+                      static_s3_asset_path(2021, "QA-logo2021-print-_black.eps"),
+                      target: "_blank"
+
+
+        .form-download
+          p
+            = link_to "Queen's Awards for Enterprise 2021 Emblem: Blue (PNG, 77KB)",
+                      static_s3_asset_path(2021, "QA-logo2021-digital-_blue.png"),
+                      target: "_blank"
+
+          p
+            = link_to "Queen's Awards for Enterprise 2021 Emblem: Blue (EPS, 5.4MB)",
+                      static_s3_asset_path(2021, "QA-logo2021-print-_blue.eps"),
+                      target: "_blank"
+
+
+        .form-download
+          p
+            = link_to "Queen's Awards for Enterprise 2021 Emblem: Gold (PNG, 77KB)",
+                      static_s3_asset_path(2021, "QA-logo2021-digital-_gold.png"),
+                      target: "_blank"
+
+          p
+            = link_to "Queen's Awards for Enterprise 2021 Emblem: Gold (EPS, 5.4MB)",
+                      static_s3_asset_path(2021, "QA-logo2021-print-_gold.eps"),
+                      target: "_blank"
+
+
+        .form-download
+          p
+            = link_to "Queen's Awards for Enterprise 2021 Emblem: White (PNG, 73KB)",
+                      static_s3_asset_path(2021, "QA-logo2021-digital-_white.png"),
+                      target: "_blank"
+
+          p
+            = link_to "Queen's Awards for Enterprise 2021 Emblem: White (EPS, 5.4MB)",
+                      static_s3_asset_path(2021, "QA-logo2021-print-_white.eps"),
+                      target: "_blank"
+
+        footer
+          nav.pagination.no-border aria-label="Pagination" role="navigation"
+            ul.group
+              li.previous.previous-alternate
+                = link_to dashboard_path
+                  span.pagination-label Back


### PR DESCRIPTION
If/when an organisation wins a QAE, they're granted access to a
"Winner's Dashboard" containing download links for helpful PDF documents
and emblem graphics for websites and publicity materials.

This commit adds a new dashboard for 2021 winners, including update S3
links for (newly uploaded) resources.