### PR TITLE
📝 Further updates to the "Head of org" winner 📧

### DIFF
--- a/app/views/users/winners_head_of_organisation_mailer/notify.text.erb
+++ b/app/views/users/winners_head_of_organisation_mailer/notify.text.erb
@@ -12,8 +12,9 @@ It has been an exceptionally hard year for businesses and we would like to pay t
 
 I understand that this is a very exciting time for you personally and for your employees, supply chain and clients. However, please note:
 
-The Award winners will be announced on Her Majesty’s birthday, Tuesday 21 April 2021. Although you can make arrangements for publicity now, and we would encourage you to do so, there
-# is a strict embargo preventing public announcement or publication of any Awards information until 01:00 hours on <%= @end_of_embargo_day %>. You must not make any announcement about your Award, either to your employees or those outside your organisation, before this date.
+#There is a strict embargo preventing public announcement or publication of any Awards information until 01:00 hours on <%= @end_of_embargo_day %>. You must not make any announcement about your Award, either to your employees or those outside your organisation, before this date.
+
+The Award winners will be announced on Her Majesty's birthday, Wednesday 21 April 2021, and we encourage you to make arrangements now for publicity from <%= @end_of_embargo_day %>.
 
 #The Winners’ Manual (located on the Winners’ Dashboard) provides more detail and suggestions on how you can maximise this opportunity (see below for more information).
 
@@ -26,12 +27,13 @@ Your online account holder has received an email today with a link to the Winner
 * check the contact details for press enquiries.
 
 Your account holder needs to complete the above actions by
-# 12:00 noon on <%= @press_book_entry_datetime %>,
+#12:00 noon on <%= @press_book_entry_datetime %>.
 
 Otherwise, we will use the proposed text together with your press contact’s details that we already hold.
 
 Under the terms of the embargo, we will provide the press book summaries and your press contact’s details to the press and media in advance of the announcement. Prior to the official announcement, you may be contacted by the press regarding your Award. You are permitted to speak to them however this will still be under the strict embargo terms. You are also permitted to approach your own press contacts such as local media, trade press and online publishers to pre-arrange coverage on your Award.
-# Please make it clear to anyone you approach in the media that they cannot publish anything until <%= @end_of_embargo_date %>.
+
+#Please make it clear to anyone you approach in the media that they cannot publish anything until <%= @end_of_embargo_date %>.
 
 The list of winners will be published in the supplement to the London Gazette.
 
@@ -49,6 +51,7 @@ As many of you will be aware, in the past, winning companies have been invited t
 
 I appreciate your patience at this time and I will keep you informed of any developments.
 Congratulations once again on your Queen’s Award for Enterprise.
+
 Yours sincerely,
 
 Nichola Bruno

--- a/app/views/users/winners_head_of_organisation_mailer/preview/notify.html.slim
+++ b/app/views/users/winners_head_of_organisation_mailer/preview/notify.html.slim
@@ -29,11 +29,11 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | I understand that this is a very exciting time for you personally and for your employees, supply chain and clients. However, please note:
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  | The Award winners will be announced on Her Majesty’s birthday, Tuesday 21 April 2021. Although you can make arrangements for publicity now, and we would encourage you to do so, there
   strong
-    |&nbsp;is a strict embargo preventing public announcement or publication of any Awards information until 01:00 hours on
-    =< @end_of_embargo_date
-    |. You must not make any announcement about your Award, either to your employees or those outside your organisation, before this date.
+  | There is a strict embargo preventing public announcement or publication of any Awards information until 01:00 hours on #{@end_of_embargo_date}. You must not make any announcement about your Award, either to your employees or those outside your organisation, before this date.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
+  | The Award winners will be announced on Her Majesty's birthday, Wednesday 21 April 2021, and we encourage you to make arrangements now for publicity from #{@end_of_embargo_date}.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   strong
@@ -53,21 +53,18 @@ div style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
     li check the contact details for press enquiries.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  | Your account holder needs to complete the above actions by
-  strong
-    |&nbsp;12:00 noon on
-    =< @press_book_entry_datetime
-    |.
+  | Your account holder needs to complete the above actions by<br/>
+  | <strong>12 noon on #{@press_book_entry_datetime}</strong>.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Otherwise, we will use the proposed text together with your press contact’s details that we already hold.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Under the terms of the embargo, we will provide the press book summaries and your press contact’s details to the press and media in advance of the announcement. Prior to the official announcement, you may be contacted by the press regarding your Award. You are permitted to speak to them however this will still be under the strict embargo terms. You are also permitted to approach your own press contacts such as local media, trade press and online publishers to pre-arrange coverage on your Award.
+
+p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   strong
-    |&nbsp;Please make it clear to anyone you approach in the media that they cannot publish anything until 01.00 hours on
-    =< @end_of_embargo_date
-    |.
+    | Please make it clear to anyone you approach in the media that they cannot publish anything until 01.00 hours on #{@end_of_embargo_date}.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | The list of winners will be published in the supplement to the London Gazette.


### PR DESCRIPTION
In a recent PR we updated the emails sent to the winning applicants of
QAE awards for Award Year 2021. As part of the updated copy, QAE were
hoping to have section of bold text inline with regular text, though
unfortunately, inline bold formatting isnt' supported by our email
sender, Gov UK Notify.

This commit reformats the Head of Organisation winner email, moving bold
text into standalone paragraphs, which can be rendered by Gov UK Notify
as headers (denoted by a `#` prefix).

https://app.asana.com/0/1199190913173550/1200070703986120

![HTML Preview](https://user-images.githubusercontent.com/1914715/112175748-64d41f80-8bef-11eb-8c10-8855741823b3.png)

![Gov UK Notify Email](https://user-images.githubusercontent.com/1914715/112177182-9f8a8780-8bf0-11eb-97e0-8b6d11b38ce0.png)

