### PR TITLE
📝 Update deadline time for verifying details

### DIFF
--- a/app/views/account_mailers/business_apps_winners_mailer/notify.text.erb
+++ b/app/views/account_mailers/business_apps_winners_mailer/notify.text.erb
@@ -28,7 +28,7 @@ Log in via this link: <%= dashboard_url %> to access the Winners' Dashboard in o
 * check the other details for your organisation are correct; and,
 * check the details of your contact for press enquiries.
 
-#Then click the "Submit" button by 12:00 noon on <%= @book_notes_deadline %>. If you do not respond by the deadline, we will use the proposed text together with the contact details that we already hold.
+#Then click the "Submit" button by 6pm on <%= @book_notes_deadline %>. If you do not respond by the deadline, we will use the proposed text together with the contact details that we already hold.
 
 #Winners’ Manual
 

--- a/app/views/account_mailers/business_apps_winners_mailer/preview/notify.html.slim
+++ b/app/views/account_mailers/business_apps_winners_mailer/preview/notify.html.slim
@@ -64,7 +64,7 @@ div style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   strong
-    ' Then click the "Submit" button by 12:00 noon on
+    ' Then click the "Submit" button by 6pm on
     =< @book_notes_deadline
     | . If you do not respond by the deadline, we will use the proposed text together with the contact details that we already hold.
 

--- a/app/views/users/winners_head_of_organisation_mailer/notify.text.erb
+++ b/app/views/users/winners_head_of_organisation_mailer/notify.text.erb
@@ -27,7 +27,7 @@ Your online account holder has received an email today with a link to the Winner
 * check the contact details for press enquiries.
 
 Your account holder needs to complete the above actions by
-#12:00 noon on <%= @press_book_entry_datetime %>.
+#6pm on <%= @press_book_entry_datetime %>.
 
 Otherwise, we will use the proposed text together with your press contact’s details that we already hold.
 

--- a/app/views/users/winners_head_of_organisation_mailer/preview/notify.html.slim
+++ b/app/views/users/winners_head_of_organisation_mailer/preview/notify.html.slim
@@ -54,7 +54,7 @@ div style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Your account holder needs to complete the above actions by<br/>
-  | <strong>12 noon on #{@press_book_entry_datetime}</strong>.
+  | <strong>6pm on #{@press_book_entry_datetime}</strong>.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Otherwise, we will use the proposed text together with your press contact’s details that we already hold.


### PR DESCRIPTION
This commit updates the (hard-coded) deadline hour by which successful
award applicants (winners) need to verify their details. Ideally, this
deadline would be pulled from the date-time picker in the settings menu,
though the time has always been hard-coded in the mailer and, due to
time constraints, we need to ship the updated time ASAP.

https://app.asana.com/0/1199190913173550/1200070703986120