### PR TITLE
Styling question A4 option other

### DIFF
--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -1513,3 +1513,20 @@ fieldset.account-contact-preferences-other-ops {
   min-width: 4em !important;
   box-sizing: border-box !important;
 }
+
+.other-organization-type {
+
+  max-width: 465px !important;
+  
+  input {
+    width: 100% !important;
+    display: block;
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    font-weight: normal;
+    @include core-19;
+    margin-bottom: 0;
+  }
+}

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step1.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step1.rb
@@ -182,7 +182,8 @@ class AwardYears::V2022::QAEForms
           option "other", "Other"
         end
 
-        text :other_organisation_type, "" do
+        text :other_organisation_type, "Please specify" do
+          classes "other-organization-type"
           required
           conditional :organisation_type, "other"
         end


### PR DESCRIPTION
Styling question A4 option other so that:
- The other field has a label
- input extends to the same width as the question

This applies only to question A4, but can be easily used by other questions, if needed.