### PR TITLE
Adds upload attachment for list of procedures

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -175,8 +175,6 @@ ready = ->
 
           $("#audit-certificate-buffer").empty()
 
-    moveAttachDocumentButton()
-
   if $("html").hasClass("lte-ie7")
     $(".attachment-link", $("#list-of-procedure-form")).removeClass("if-js-hide")
   else
@@ -187,7 +185,7 @@ ready = ->
         forceIframeTransport: true
         add: (e, data) ->
           newForm = $("#new_list_of-procedure")
-          $("#list-of-procedure-form .attachment-title").val(data.files[0].name)
+          $("#new_list_of_procedure .attachment-title").val(data.files[0].name)
           newForm.closest(".sidebar-section").addClass("show-attachment-form")
           newForm.find(".btn-submit").focus().blur()
           newForm.find(".btn-submit").unbind("click").on "click", (e) ->
@@ -208,6 +206,8 @@ ready = ->
             sidebarSection.removeClass("show-attachment-form")
 
           $("#list-of-procedure-buffer").empty()
+
+    moveAttachDocumentButton()
 
   $(document).on "click", ".js-attachment-form .btn-cancel", (e) ->
     e.preventDefault()

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -27,9 +27,16 @@ ready = ->
     wrapper = $("#audit-certificate-form")
     $(".attachment-link", wrapper).removeClass("if-js-hide")
     $(".attachment-link", wrapper).addClass("btn btn-default btn-block btn-attachment")
-    $(".attachment-link", wrapper).prepend("<span class='btn-title'>Attach audit certificate</span>")
+    $(".attachment-link", wrapper).prepend("<span class='btn-title'>Attach External Accountant's Report</span>")
     $(".attachment-link", wrapper).prepend("<span class='glyphicon glyphicon-paperclip'></span>")
     $(".attachment-link", wrapper).prependTo("#new_audit_certificate")
+
+    wrapper = $("#list-of-procedure-form")
+    $(".attachment-link", wrapper).removeClass("if-js-hide")
+    $(".attachment-link", wrapper).addClass("btn btn-default btn-block btn-attachment")
+    $(".attachment-link", wrapper).prepend("<span class='btn-title'>Attach list of procedures</span>")
+    $(".attachment-link", wrapper).prepend("<span class='glyphicon glyphicon-paperclip'></span>")
+    $(".attachment-link", wrapper).prependTo("#new_list_of_procedure")
 
   $("#new_review_audit_certificate").on "ajax:success", (e, data, status, xhr) ->
     $(this).find(".form-group").removeClass("form-edit")
@@ -94,6 +101,12 @@ ready = ->
       authenticity_token: $("meta[name='csrf-token']").attr("content")
       format: "js"
       "audit_certificate[attachment]": $("#audit_certificate_attachment").val()
+
+  $("#new_list_of_procedure").on "fileuploadsubmit", (e, data) ->
+    data.formData =
+      authenticity_token: $("meta[name='csrf-token']").attr("content")
+      format: "js"
+      "list_of_procedure[attachment]": $("#list_of_procedure_attachment").val()
 
   if $("html").hasClass("lte-ie7")
     $(".attachment-link", $("#application-attachment-form")).removeClass("if-js-hide")
@@ -163,6 +176,38 @@ ready = ->
           $("#audit-certificate-buffer").empty()
 
     moveAttachDocumentButton()
+
+  if $("html").hasClass("lte-ie7")
+    $(".attachment-link", $("#list-of-procedure-form")).removeClass("if-js-hide")
+  else
+    do initializeFileUpload = ->
+      $("#new_list_of_procedure").fileupload
+        autoUpload: false
+        dataType: "html"
+        forceIframeTransport: true
+        add: (e, data) ->
+          newForm = $("#new_list_of-procedure")
+          $("#list-of-procedure-form .attachment-title").val(data.files[0].name)
+          newForm.closest(".sidebar-section").addClass("show-attachment-form")
+          newForm.find(".btn-submit").focus().blur()
+          newForm.find(".btn-submit").unbind("click").on "click", (e) ->
+            e.preventDefault()
+            data.submit()
+        success: (result, textStatus, jqXHR) ->
+          result = $($.parseHTML(result))
+          $("#list-of-procedure-buffer").append(result.text())
+
+          if $("#form-list_of_procedure-valid", $("#list-of-procedure-buffer")).length
+            $("#list-of-procedure-form").html(result.text())
+            moveAttachDocumentButton()
+            initializeFileUpload()
+          else
+            form = $("#new_list_of_procedure")
+            sidebarSection = form.closest(".sidebar-section")
+            sidebarSection.find(".document-list").html(result.text())
+            sidebarSection.removeClass("show-attachment-form")
+
+          $("#list-of-procedure-buffer").empty()
 
   $(document).on "click", ".js-attachment-form .btn-cancel", (e) ->
     e.preventDefault()

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -184,7 +184,7 @@ ready = ->
         dataType: "html"
         forceIframeTransport: true
         add: (e, data) ->
-          newForm = $("#new_list_of-procedure")
+          newForm = $("#new_list_of_procedure")
           $("#new_list_of_procedure .attachment-title").val(data.files[0].name)
           newForm.closest(".sidebar-section").addClass("show-attachment-form")
           newForm.find(".btn-submit").focus().blur()

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -684,7 +684,10 @@
       display: block;
     }
   }
+  .btn-cancel { float: left; margin-right: 0 }
 }
+
+.sidebar-section.no-margin-bottom { margin-bottom: 0; }
 
 .uploaded-file .btn-attachment {
   display: none;

--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -6,7 +6,8 @@ class Admin::FormAnswersController < Admin::BaseController
     :show,
     :update,
     :update_financials,
-    :remove_audit_certificate
+    :remove_audit_certificate,
+    :remove_list_of_procedures
   ]
 
   skip_after_action :verify_authorized, only: [:awarded_trade_applications]
@@ -65,6 +66,23 @@ class Admin::FormAnswersController < Admin::BaseController
       end
     end
   end
+
+  def remove_list_of_procedures
+    authorize @form_answer, :remove_list_of_procedures?
+
+    @form_answer.list_of_procedures.destroy
+
+    respond_to do |format|
+      format.html do
+        flash.notice = "List of procedures successfully removed"
+        redirect_to admin_form_answer_url(@form_answer)
+      end
+      format.js do
+        head :ok
+      end
+    end
+  end
+
 
   def awarded_trade_applications
     @csv_data = AwardedTradeApplicationsCsv.run

--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -58,7 +58,7 @@ class Admin::FormAnswersController < Admin::BaseController
 
     respond_to do |format|
       format.html do
-        flash.notice = "Verification of Commercial Figures successfully removed"
+        flash.notice = "External Accountant's Report successfully removed"
         redirect_to admin_form_answer_url(@form_answer)
       end
       format.js do

--- a/app/controllers/admin/form_answers_controller.rb
+++ b/app/controllers/admin/form_answers_controller.rb
@@ -70,7 +70,7 @@ class Admin::FormAnswersController < Admin::BaseController
   def remove_list_of_procedures
     authorize @form_answer, :remove_list_of_procedures?
 
-    @form_answer.list_of_procedures.destroy
+    @form_answer.list_of_procedure.destroy
 
     respond_to do |format|
       format.html do

--- a/app/controllers/admin/list_of_procedures_controller.rb
+++ b/app/controllers/admin/list_of_procedures_controller.rb
@@ -1,3 +1,20 @@
 class Admin::ListOfProceduresController < Admin::BaseController
   include ListOfProceduresContext
+
+  expose(:pdf_data) do
+    form_answer.decorate.pdf_audit_certificate_generator
+  end
+
+  def download_initial_pdf
+    authorize form_answer, :can_download_initial_audit_certificate_pdf?
+
+    respond_to do |format|
+      format.pdf do
+        send_data pdf_data.render,
+                  filename: "list_of_procedures_#{@form_answer.decorate.pdf_filename}",
+                  type: "application/pdf",
+                  disposition: "attachment"
+      end
+    end
+  end
 end

--- a/app/controllers/concerns/list_of_procedures_context.rb
+++ b/app/controllers/concerns/list_of_procedures_context.rb
@@ -7,7 +7,7 @@ module ListOfProceduresContext
   private
 
   def resource
-    @list_of_procedures ||= form_answer.list_of_procedures
+    @list_of_procedure ||= form_answer.list_of_procedure
   end
 
   def form_answer

--- a/app/controllers/concerns/list_of_procedures_context.rb
+++ b/app/controllers/concerns/list_of_procedures_context.rb
@@ -4,6 +4,46 @@ module ListOfProceduresContext
     redirect_to resource.attachment_url
   end
 
+  def create
+    authorize form_answer, :create_list_of_procedures_pdf?
+
+    list_of_procedure = form_answer.build_list_of_procedure(list_of_procedure_params)
+
+    if saved = list_of_procedure.save
+      if form_answer.assessors.primary.present?
+        Assessors::GeneralMailer.list_of_procedure_uploaded(form_answer.id).deliver_later!
+      end
+
+      Users::AuditCertificateMailer.notify(form_answer.id, form_answer.user_id).deliver_later!
+    end
+
+    respond_to do |format|
+      if saved
+        format.html do
+          redirect_to [namespace_name, form_answer]
+        end
+
+        format.js do
+          render  partial: "admin/form_answers/docs/post_shortlisting_docs",
+            locals: {
+            resource: form_answer.decorate
+          },
+          content_type: "text/plain"
+        end
+      else
+        format.html do
+          redirect_to [namespace_name, form_answer],
+            alert: list_of_procedure.errors.full_messages.join(", ")
+        end
+        format.js do
+          render json: list_of_procedure,
+            status: :created,
+            content_type: "text/plain"
+        end
+      end
+    end
+  end
+
   private
 
   def resource
@@ -12,5 +52,17 @@ module ListOfProceduresContext
 
   def form_answer
     @form_answer ||= FormAnswer.find(params[:form_answer_id])
+  end
+
+  def list_of_procedure_params
+    if params[:list_of_procedure].blank?
+      params.merge!(
+        list_of_procedure: {
+          attachment: ""
+        }
+      )
+    end
+
+    params.require(:list_of_procedure).permit(:attachment)
   end
 end

--- a/app/controllers/users/audit_certificates_controller.rb
+++ b/app/controllers/users/audit_certificates_controller.rb
@@ -16,8 +16,8 @@ class Users::AuditCertificatesController < Users::BaseController
     form_answer.audit_certificate
   end
 
-  expose(:list_of_procedures) do
-    form_answer.list_of_procedures
+  expose(:list_of_procedure) do
+    form_answer.list_of_procedure
   end
 
   def show

--- a/app/controllers/users/list_of_procedures_controller.rb
+++ b/app/controllers/users/list_of_procedures_controller.rb
@@ -6,14 +6,14 @@ class Users::ListOfProceduresController < Users::BaseController
                 find(params[:form_answer_id])
   end
 
-  expose(:list_of_procedures) do
-    form_answer.list_of_procedures
+  expose(:list_of_procedure) do
+    form_answer.list_of_procedure
   end
 
   def create
-    self.list_of_procedures = form_answer.build_list_of_procedures(list_of_procedures_params)
+    self.list_of_procedure = form_answer.build_list_of_procedure(list_of_procedures_params)
 
-    saved = list_of_procedures.save
+    saved = list_of_procedure.save
     log_event if saved
 
     respond_to do |format|
@@ -28,7 +28,7 @@ class Users::ListOfProceduresController < Users::BaseController
 
       format.json do
         if saved
-          render json: list_of_procedures,
+          render json: list_of_procedure,
                  status: :created,
                  content_type: "text/plain"
         else
@@ -40,7 +40,7 @@ class Users::ListOfProceduresController < Users::BaseController
   end
 
   def destroy
-    log_event if list_of_procedures.destroy
+    log_event if list_of_procedure.destroy
     redirect_to users_form_answer_audit_certificate_url(form_answer)
   end
 
@@ -48,15 +48,15 @@ class Users::ListOfProceduresController < Users::BaseController
 
   def list_of_procedures_params
     # Handle situation where user hasn't attached anything through the file picker
-    if params[:list_of_procedures].blank?
+    if params[:list_of_procedure].blank?
       params.merge!(
-        list_of_procedures: {
+        list_of_procedure: {
           attachment: ""
         }
       )
     end
 
-    params.require(:list_of_procedures).permit(:attachment)
+    params.require(:list_of_procedure).permit(:attachment)
   end
 
   def action_type
@@ -71,7 +71,7 @@ class Users::ListOfProceduresController < Users::BaseController
   end
 
   def humanized_errors
-    list_of_procedures.errors
+    list_of_procedure.errors
                      .full_messages
                      .reject { |m| m == "Attachment This field cannot be blank" }
                      .join(", ")

--- a/app/controllers/users/list_of_procedures_controller.rb
+++ b/app/controllers/users/list_of_procedures_controller.rb
@@ -19,7 +19,7 @@ class Users::ListOfProceduresController < Users::BaseController
     respond_to do |format|
       format.html do
         if saved
-          redirect_to users_form_answer_audit_certificate_url(form_answer),
+          redirect_to users_form_answer_list_of_procedure_url(form_answer),
                       notice: "List of procedures successfully uploaded!"
         else
           render :show
@@ -41,7 +41,7 @@ class Users::ListOfProceduresController < Users::BaseController
 
   def destroy
     log_event if list_of_procedure.destroy
-    redirect_to users_form_answer_audit_certificate_url(form_answer)
+    redirect_to users_form_answer_list_of_procedure_url(form_answer)
   end
 
   private

--- a/app/mailers/assessors/general_mailer.rb
+++ b/app/mailers/assessors/general_mailer.rb
@@ -9,7 +9,14 @@ class Assessors::GeneralMailer < ApplicationMailer
   def audit_certificate_uploaded(form_answer_id)
     @form_answer = FormAnswer.find(form_answer_id)
     @assessor = @form_answer.assessors.primary
-    @subject = "Application Ref: #{@form_answer.urn} Verification of Commercial Figures submitted"
+    @subject = "Application Ref: #{@form_answer.urn} External Accountant's Report submitted"
+    send_mail_if_not_bounces ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @assessor.email, subject: subject_with_env_prefix(@subject)
+  end
+
+  def list_of_procedure_uploaded(form_answer_id)
+    @form_answer = FormAnswer.find(form_answer_id)
+    @assessor = @form_answer.assessors.primary
+    @subject = "Application Ref: #{@form_answer.urn} list of procedures submitted"
     send_mail_if_not_bounces ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @assessor.email, subject: subject_with_env_prefix(@subject)
   end
 end

--- a/app/models/audit_certificates/external_accountants_report.rb
+++ b/app/models/audit_certificates/external_accountants_report.rb
@@ -1,2 +1,0 @@
-class ExternalAccountantsReport < AuditCertificate
-end

--- a/app/models/audit_certificates/external_accountants_report.rb
+++ b/app/models/audit_certificates/external_accountants_report.rb
@@ -1,0 +1,2 @@
+class ExternalAccountantsReport < AuditCertificate
+end

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -69,7 +69,7 @@ class FormAnswer < ApplicationRecord
     has_one :mobility_eligibility, class_name: 'Eligibility::Mobility', dependent: :destroy
     has_one :promotion_eligibility, class_name: 'Eligibility::Promotion', dependent: :destroy
     has_one :audit_certificate, dependent: :destroy
-    has_one :list_of_procedures, dependent: :destroy
+    has_one :list_of_procedure, dependent: :destroy
     has_one :feedback, dependent: :destroy
     has_one :press_summary, dependent: :destroy
     has_one :draft_note, as: :notable, dependent: :destroy

--- a/app/models/list_of_procedure.rb
+++ b/app/models/list_of_procedure.rb
@@ -16,8 +16,8 @@ class ListOfProcedure < ApplicationRecord
     validates :attachment, presence: true,
                            on: :create,
                            file_size: {
-                             maximum: 5.megabytes.to_i
-                           }
+                           maximum: 5.megabytes.to_i
+                             }
     validates :reviewable_type,
               :reviewable_id,
               :reviewed_at,

--- a/app/models/list_of_procedure.rb
+++ b/app/models/list_of_procedure.rb
@@ -1,4 +1,4 @@
-class ListOfProcedures < ApplicationRecord
+class ListOfProcedure < ApplicationRecord
   mount_uploader :attachment, ListOfProceduresUploader
   scan_file      :attachment
 

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -101,13 +101,13 @@ class FormAnswerPolicy < ApplicationPolicy
 
   def download_list_of_procedures_pdf?
     (admin? || subject.lead_or_assigned?(record)) &&
-    record.list_of_procedures.present? &&
-    record.list_of_procedures.attachment.present? &&
-    (Rails.env.development? || record.list_of_procedures.clean?)
+    record.list_of_procedure.present? &&
+    record.list_of_procedure.attachment.present? &&
+    (Rails.env.development? || record.list_of_procedure.clean?)
   end
 
   def remove_list_of_procedures?
-    admin? && record.list_of_procedures.present?
+    admin? && record.list_of_procedure.present?
   end
 
   def has_access_to_post_shortlisting_docs?
@@ -148,6 +148,6 @@ class FormAnswerPolicy < ApplicationPolicy
   end
 
   def list_of_procedures_available?
-    record.list_of_procedures.present? && record.list_of_procedures.attachment.present?
+    record.list_of_procedure.present? && record.list_of_procedure.attachment.present?
   end
 end

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -106,6 +106,11 @@ class FormAnswerPolicy < ApplicationPolicy
     (Rails.env.development? || record.list_of_procedure.clean?)
   end
 
+  def create_list_of_procedures_pdf?
+    admin? || subject.lead_or_assigned?(record)
+    (record.list_of_procedure.nil? || record.list_of_procedure.attachment.nil?)
+  end
+
   def remove_list_of_procedures?
     admin? && record.list_of_procedure.present?
   end

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -90,13 +90,6 @@ class FormAnswerPolicy < ApplicationPolicy
     (Rails.env.development? || record.audit_certificate.clean?)
   end
 
-  def download_list_of_procedures_pdf?
-    (admin? || subject.lead_or_assigned?(record)) &&
-    record.list_of_procedures.present? &&
-    record.list_of_procedures.attachment.present? &&
-    (Rails.env.development? || record.list_of_procedures.clean?)
-  end
-
   def create_audit_certificate_pdf?
     admin? || subject.lead_or_assigned?(record)
     (record.audit_certificate.nil? || record.audit_certificate.attachment.nil?)
@@ -104,6 +97,17 @@ class FormAnswerPolicy < ApplicationPolicy
 
   def remove_audit_certificate?
     admin? && record.audit_certificate.present?
+  end
+
+  def download_list_of_procedures_pdf?
+    (admin? || subject.lead_or_assigned?(record)) &&
+    record.list_of_procedures.present? &&
+    record.list_of_procedures.attachment.present? &&
+    (Rails.env.development? || record.list_of_procedures.clean?)
+  end
+
+  def remove_list_of_procedures?
+    admin? && record.list_of_procedures.present?
   end
 
   def has_access_to_post_shortlisting_docs?

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -96,7 +96,7 @@ class Notifiers::EmailNotificationService
     collaborator_data = []
 
     award_year.form_answers.business.shortlisted.each do |form_answer|
-      next if form_answer.audit_certificate && form_answer.list_of_procedures
+      next if form_answer.audit_certificate && form_answer.list_of_procedure
 
       form_answer.collaborators.each do |collaborator|
         collaborator_data << { form_answer_id: form_answer.id, collaborator_id: collaborator.id }

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -30,11 +30,12 @@
         #audit-certificate-form
           = render "admin/audit_certificate/form", form_answer: @form_answer, audit_certificate: @form_answer.build_audit_certificate
 
-    - if @form_answer.list_of_procedure.blank?
+    - if @form_answer.list_of_procedure.blank? && Settings.after_shortlisting_stage?
       br
       .sidebar-section.no-margin-bottom
         #list-of-procedure-form
           = render "admin/list_of_procedures/form", form_answer: @form_answer, list_of_procedure: @form_answer.build_list_of_procedure
+          
   / TODO Only appears for EP but for now we need to think more on it
   /.sidebar-section
     h2.todo-placeholder

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -29,6 +29,10 @@
       #audit-certificate-form
         = render "admin/audit_certificate/form", form_answer: @form_answer, audit_certificate: @form_answer.build_audit_certificate
 
+    - if @form_answer.list_of_procedure.blank? && Settings.after_shortlisting_stage?
+      br
+      #list-of-procedure-form
+        = render "admin/list_of_procedures/form", form_answer: @form_answer, list_of_procedure: @form_answer.build_list_of_procedure
   / TODO Only appears for EP but for now we need to think more on it
   /.sidebar-section
     h2.todo-placeholder
@@ -50,4 +54,5 @@
 
 
 #audit-certificate-buffer
+#list-of-procedure-buffer
 #attachment-buffer

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -26,13 +26,15 @@
 
     - if @form_answer.audit_certificate.blank? && Settings.after_shortlisting_stage?
       br
-      #audit-certificate-form
-        = render "admin/audit_certificate/form", form_answer: @form_answer, audit_certificate: @form_answer.build_audit_certificate
+      .sidebar-section.no-margin-bottom
+        #audit-certificate-form
+          = render "admin/audit_certificate/form", form_answer: @form_answer, audit_certificate: @form_answer.build_audit_certificate
 
-    - if @form_answer.list_of_procedure.blank? && Settings.after_shortlisting_stage?
+    - if @form_answer.list_of_procedure.blank?
       br
-      #list-of-procedure-form
-        = render "admin/list_of_procedures/form", form_answer: @form_answer, list_of_procedure: @form_answer.build_list_of_procedure
+      .sidebar-section.no-margin-bottom
+        #list-of-procedure-form
+          = render "admin/list_of_procedures/form", form_answer: @form_answer, list_of_procedure: @form_answer.build_list_of_procedure
   / TODO Only appears for EP but for now we need to think more on it
   /.sidebar-section
     h2.todo-placeholder

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -24,6 +24,19 @@
     - if resource.object.list_of_procedures.present? && resource.object.list_of_procedures.clean?
       li
         = link_to "View/print list of procedures", [url_namespace, resource.object, resource.object.list_of_procedures], target: "_blank"
+
+        - if policy(resource).remove_list_of_procedures?
+          small.pull-right
+            = form_for(resource.object,
+                       url: remove_list_of_procedures_admin_form_answer_url(resource.object),
+                       html: { method: :patch, style: "display:inline-block;" }) do |f|
+
+              = f.submit 'Remove', class: 'if-js-hide'
+
+              = link_to "#", class: "text-danger if-no-js-hide js-remove-audit-certificate-link", data: {confirm: "Are you sure?"}
+                span.glyphicon.glyphicon-remove
+                span.visible-lg.visible-md
+
     - elsif resource.object.list_of_procedures.present? && resource.object.list_of_procedures.attachment_scan_results.blank?
       li style="color:green"
         ' Scanning list of procedures. You may need to refresh the page.

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -36,7 +36,7 @@
               = link_to "#", class: "text-danger if-no-js-hide js-remove-audit-certificate-link", data: {confirm: "Are you sure?"}
                 span.glyphicon.glyphicon-remove
                 span.visible-lg.visible-md
-
+                  ' Remove
     - elsif resource.object.list_of_procedures.present? && resource.object.list_of_procedures.attachment_scan_results.blank?
       li style="color:green"
         ' Scanning list of procedures. You may need to refresh the page.

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -21,9 +21,9 @@
       li style="color:green"
         ' Scanning audit certificate. You may need to refresh the page.
 
-    - if resource.object.list_of_procedures.present? && resource.object.list_of_procedures.clean?
+    - if resource.object.list_of_procedure.present? && resource.object.list_of_procedure.clean?
       li
-        = link_to "View/print list of procedures", [url_namespace, resource.object, resource.object.list_of_procedures], target: "_blank"
+        = link_to "View/print list of procedures", [url_namespace, resource.object, resource.object.list_of_procedure], target: "_blank"
 
         - if policy(resource).remove_list_of_procedures?
           small.pull-right
@@ -37,7 +37,7 @@
                 span.glyphicon.glyphicon-remove
                 span.visible-lg.visible-md
                   ' Remove
-    - elsif resource.object.list_of_procedures.present? && resource.object.list_of_procedures.attachment_scan_results.blank?
+    - elsif resource.object.list_of_procedure.present? && resource.object.list_of_procedure.attachment_scan_results.blank?
       li style="color:green"
         ' Scanning list of procedures. You may need to refresh the page.
 

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -36,8 +36,13 @@
               = link_to "#", class: "text-danger if-no-js-hide js-remove-audit-certificate-link", data: {confirm: "Are you sure?"}
                 span.glyphicon.glyphicon-remove
                 span.visible-lg.visible-md
+<<<<<<< HEAD
                   ' Remove
     - elsif resource.object.list_of_procedure.present? && resource.object.list_of_procedure.attachment_scan_results.blank?
+=======
+
+    - elsif resource.object.list_of_procedures.present? && resource.object.list_of_procedures.attachment_scan_results.blank?
+>>>>>>> Adds a remove link to list of procedures attachment
       li style="color:green"
         ' Scanning list of procedures. You may need to refresh the page.
 

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -3,7 +3,7 @@
   ul.list-unstyled.list-actions
     - if resource.object.audit_certificate.present? && resource.object.audit_certificate.clean?
       li
-        = link_to "View/print Verification of Commercial Figures", [url_namespace, resource.object, resource.object.audit_certificate], target: "_blank"
+        = link_to "View/print External Accountant's Report", [url_namespace, resource.object, resource.object.audit_certificate], target: "_blank"
 
         - if policy(resource).remove_audit_certificate?
           small.pull-right

--- a/app/views/admin/list_of_procedures/_form.html.slim
+++ b/app/views/admin/list_of_procedures/_form.html.slim
@@ -2,8 +2,8 @@
 / we search for this input in success callback to determine
 / whether file was saved or not
 .span
-  = hidden_field_tag "valid", "false", id: "form-audit_certificate-valid"
-= form_for [namespace_name, form_answer, audit_certificate], html: { multipart: true } do |form|
+  = hidden_field_tag "valid", "false", id: "form-list_of_procedure-valid"
+= form_for [namespace_name, form_answer, list_of_procedure], html: { multipart: true } do |form|
   .well.js-attachment-form
     h3 Attach document
 
@@ -21,4 +21,4 @@
 
     .form-actions.text-right
       = link_to "Cancel", "#", class: "btn btn-default btn-cancel"
-      = form.submit "Attach accountant's report", class: "btn btn-primary btn-submit"
+      = form.submit "Attach list of procedures", class: "btn btn-primary btn-submit"

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -1,5 +1,5 @@
 - cert_exists = form_answer.audit_certificate.present? && form_answer.audit_certificate.persisted?
-- list_exists = form_answer.list_of_procedures.present? && form_answer.list_of_procedures.persisted?
+- list_exists = form_answer.list_of_procedure.present? && form_answer.list_of_procedure.persisted?
 
 header.page-header.group class=('page-header-wider')
   div

--- a/app/views/users/list_of_procedures/_file.html.slim
+++ b/app/views/users/list_of_procedures/_file.html.slim
@@ -1,5 +1,5 @@
 - if list_exists
-  - att_record = award.list_of_procedures
+  - att_record = award.list_of_procedure
 
   - if att_record.attachment_scan_results.present?
     - if att_record.clean?
@@ -20,7 +20,7 @@
             target: "_blank", class: "js-audit-certificate-title download-link"
 
 small.pull-right.remove-verification-document
-  = form_for(:list_of_procedures, url: users_form_answer_list_of_procedures_path(form_answer), html: { class: "js-remove-verification-document-form", method: :delete, style: "display:inline-block;"}) do |f|
+  = form_for(:list_of_procedure, url: users_form_answer_list_of_procedure_path(form_answer), html: { class: "js-remove-verification-document-form", method: :delete, style: "display:inline-block;"}) do |f|
 
     = f.submit 'Remove', class: 'if-js-hide'
 

--- a/app/views/users/list_of_procedures/_form.html.slim
+++ b/app/views/users/list_of_procedures/_form.html.slim
@@ -1,6 +1,6 @@
-= simple_form_for (list_of_procedures || form_answer.build_list_of_procedures),
-                  as: :list_of_procedures,
-                  url: users_form_answer_list_of_procedures_path(form_answer),
+= simple_form_for (list_of_procedure || form_answer.build_list_of_procedure),
+                  as: :list_of_procedure,
+                  url: users_form_answer_list_of_procedure_path(form_answer),
                   html: {class: "qae-form audit-certificate-upload-form #{"hidden" if list_exists}", method: :post} do |f|
   .errors-container
   .clear

--- a/app/views/users/list_of_procedures/_non_js_form.html.slim
+++ b/app/views/users/list_of_procedures/_non_js_form.html.slim
@@ -1,6 +1,6 @@
-= simple_form_for (list_of_procedures || form_answer.build_list_of_procedures),
-                  as: :list_of_procedures,
-                  url: users_form_answer_list_of_procedures_path(form_answer),
+= simple_form_for (list_of_procedure || form_answer.build_list_of_procedure),
+                  as: :list_of_procedure,
+                  url: users_form_answer_list_of_procedure_path(form_answer),
                   html: {class: "qae-form", method: :post} do |f|
   ul.list-add
     li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,7 @@ Rails.application.routes.draw do
       end
 
       resource :audit_certificate, only: [:show, :create, :destroy]
-      resource :list_of_procedures, only: [:create, :destroy]
+      resource :list_of_procedure, only: [:create, :destroy]
       resource :support_letter_attachments, only: :create
       resources :supporters, only: [:create, :destroy]
       resources :support_letters, only: [:create, :show, :destroy]
@@ -268,7 +268,7 @@ Rails.application.routes.draw do
       resources :audit_certificates, only: [:show, :create] do
         get :download_initial_pdf, on: :collection
       end
-      resources :list_of_procedures, only: [:show]
+      resources :list_of_procedures, only: [:show, :create]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,7 @@ Rails.application.routes.draw do
 
       member do
         patch :remove_audit_certificate
+        patch :remove_list_of_procedures
         patch :update_financials
         get :review
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,7 +163,7 @@ Rails.application.routes.draw do
       resources :form_answer_attachments, only: [:create, :show, :destroy]
       resources :support_letters, only: [:show]
       resources :audit_certificates, only: [:show, :create]
-      resources :list_of_procedures, only: [:show]
+      resources :list_of_procedures, only: [:show, :create]
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit
@@ -268,7 +268,9 @@ Rails.application.routes.draw do
       resources :audit_certificates, only: [:show, :create] do
         get :download_initial_pdf, on: :collection
       end
-      resources :list_of_procedures, only: [:show, :create]
+      resources :list_of_procedures, only: [:show, :create] do
+        get :download_initial_pdf, on: :collection
+      end
       resources :feedbacks, only: [:create, :update] do
         member do
           post :submit

--- a/spec/controllers/admin/list_of_procedures_controller_spec.rb
+++ b/spec/controllers/admin/list_of_procedures_controller_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+include Warden::Test::Helpers
+
+RSpec.describe Admin::ListOfProceduresController do
+  let!(:admin) { create(:admin, superadmin: true) }
+  let!(:form_answer) { create(:form_answer) }
+
+  before do
+    sign_in admin
+  end
+
+  describe "GET download_initial_pdf" do
+    it "assigns @resources" do
+      allow_any_instance_of(FormAnswer).to receive(:promotion?) { false }
+      allow_any_instance_of(FormAnswer).to receive(:shortlisted?) { true }
+      get :download_initial_pdf, params: { form_answer_id: form_answer.id }, format: "pdf"
+      expect(response.content_type).to eq("application/pdf")
+    end
+  end
+end

--- a/spec/controllers/list_or_procedures_context_concern_spec.rb
+++ b/spec/controllers/list_or_procedures_context_concern_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe ListOfProceduresContext, type: :controller do
+  described_class.tap do |mod|
+    controller(ActionController::Base) do
+      include mod
+      include Pundit
+    end
+  end
+
+  let!(:admin) { create(:admin, superadmin: true) }
+  before do
+    sign_in admin
+    routes.draw { get "show" => "anonymous#show" }
+  end
+
+  describe "GET show" do
+    it "should redirect to attachment_url" do
+      allow(controller).to receive(:authorize).and_return(true)
+      form_answer = build(:form_answer)
+      list_of_procedure = build(:list_of_procedure)
+
+      allow(FormAnswer).to receive(:find) {form_answer}
+      allow_any_instance_of(FormAnswer).to receive(:list_of_procedure).and_return(list_of_procedure)
+      get :show, params: { form_answer_id: form_answer.id }
+      expect(response).to redirect_to list_of_procedure.attachment_url
+    end
+  end
+end

--- a/spec/factories/form_answer_factory.rb
+++ b/spec/factories/form_answer_factory.rb
@@ -107,5 +107,19 @@ FactoryBot.define do
       state { "submitted" }
       submitted_at { Time.current }
     end
+
+    trait :with_list_of_procedure do
+      document do
+        FormAnswer::DocumentParser.parse_json_document(
+          JSON.parse(
+            File.read(Rails.root.join("spec/fixtures/form_answer_development.json"))
+          )
+        )
+      end
+      list_of_procedure
+      award_type { "development" }
+      state { "submitted" }
+      submitted_at { Time.current }
+    end
   end
 end

--- a/spec/factories/list_of_procedures.rb
+++ b/spec/factories/list_of_procedures.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :list_of_procedures do
+  factory :list_of_procedure do
     association :form_answer, factory: :form_answer
     attachment_scan_results { "clean" }
     attachment do

--- a/spec/features/admin/form_answers/remove_list_of_procedures_spec.rb
+++ b/spec/features/admin/form_answers/remove_list_of_procedures_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+include Warden::Test::Helpers
+
+describe "Admin: ability to remove list of procedures attachment", %q{
+As an Admin
+I want to have ability to delete the list of procedures in case the user has uploaded it in error
+So that User can re-upload list of procedures
+} do
+
+  let!(:form_answer) do
+    create(:form_answer, :development, :submitted, :with_list_of_procedure)
+  end
+
+  describe "Policies" do
+    let(:target_url) do
+      assessor_form_answer_path(form_answer)
+    end
+
+    describe "Lead Assessor" do
+      let!(:lead_assessor) { create(:assessor, :lead_for_all) }
+
+      before do
+        login_as(lead_assessor, scope: :assessor)
+        visit target_url
+      end
+
+      it "should not allow to remove list of procedures" do
+        expect(page).to_not have_selector(:css, "a.js-remove-audit-certificate-link")
+      end
+    end
+
+    describe "Primary Assessor" do
+      let!(:primary_assessor) { create(:assessor, :regular_for_all) }
+      let!(:primary) { form_answer.assessor_assignments.primary }
+
+      before do
+        primary.assessor = primary_assessor
+        primary.save!
+
+        login_as(primary_assessor, scope: :assessor)
+        visit target_url
+      end
+
+      it "should not allow to remove list of procedures" do
+        expect(page).to_not have_selector(:css, "a.js-remove-audit-certificate-link")
+      end
+    end
+  end
+
+  describe "Removing", js: true do
+    let!(:admin) { create(:admin) }
+
+    before do
+      login_admin(admin)
+
+      visit admin_form_answer_path(form_answer)
+    end
+
+    it "should remove list of procedures" do
+      expect(form_answer.list_of_procedure.present?).to be_truthy
+
+      wait_for_ajax
+
+      expect {
+        find(".js-remove-audit-certificate-link").click
+        page.driver.browser.switch_to.alert.accept
+
+        wait_for_ajax
+      }.to change {
+        form_answer.reload.list_of_procedure
+      }
+    end
+  end
+end

--- a/spec/models/list_of_procedure_spec.rb
+++ b/spec/models/list_of_procedure_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ListOfProcedure, type: :model do
+  describe "associations" do
+    it { should belong_to(:form_answer) }
+  end
+
+  describe "validations" do
+    %w[form_answer_id attachment].each do |field_name|
+      it { should validate_presence_of field_name }
+    end
+
+    describe "Form answer should have just one list of procedure" do
+      let!(:form_answer) { create(:form_answer) }
+      let!(:list_of_procedure) { create(:list_of_procedure, form_answer: form_answer) }
+
+      subject { build(:list_of_procedure, form_answer: form_answer) }
+      it {
+        should validate_uniqueness_of(:form_answer_id)
+      }
+    end
+  end
+
+  describe "save" do
+    it "should set changes_description" do
+      list_of_procedure = create(:list_of_procedure, changes_description: "test")
+      list_of_procedure.update(status: "no_changes_necessary")
+      expect(list_of_procedure.changes_description).to be_nil
+    end
+  end
+end

--- a/spec/services/notifiers/email_notification_service_spec.rb
+++ b/spec/services/notifiers/email_notification_service_spec.rb
@@ -138,7 +138,7 @@ describe Notifiers::EmailNotificationService do
 
     context "with a submitted audit certificate and submitted list of procedures" do
       let!(:certificate) { create(:audit_certificate, form_answer: form_answer) }
-      let!(:list_of_procedures) { create(:list_of_procedures, form_answer: form_answer) }
+      let!(:list_of_procedure) { create(:list_of_procedure, form_answer: form_answer) }
 
       it "does not trigger a notification" do
         expect(Users::AuditCertificateRequestMailer).not_to receive(:notify).with(


### PR DESCRIPTION
This commit further separates the list of procedures attachment from the audit certificate attachment. It allows admins to upload, remove and download the list of procedures attachment separately, and renames the original audit certificate to External Auditor's Report.

Renames instances of 'audit certificate' to 'External Auditor's Report'
Adds a remove link to list of procedure attachments
![Screenshot 2021-04-19 at 09 28 44](https://user-images.githubusercontent.com/65811538/115221421-90203080-a101-11eb-857d-3390ecf5f9fd.png)
Adds a link to upload list of procedures if it has been removed
![Screenshot 2021-04-19 at 09 46 41](https://user-images.githubusercontent.com/65811538/115222070-3e2bda80-a102-11eb-8529-477cc7ed341d.png)

The ListOfProcedures model has been renamed and routes added for create list of procedure.
Routes for list of procedures added to the assessors path to fix failing feature tests.

https://app.asana.com/0/1199190913173550/1200207581184831