### PR TITLE
Reworking the validation on matrix questions as they are currently lagging a lot

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -11,11 +11,11 @@ window.FormValidation =
 
   clearErrors: (container) ->
     if container.closest(".question-financial").size() > 0
-      if container.closest("label").find(".errors-container li").size() > 0
-        container.closest("label").find(".errors-container").empty()
+      container.closest("label").find(".errors-container").empty()
+    else if container.closest('.question-matrix').length > 0
+      container.closest("td").find(".errors-container").empty()
     else
-      if container.closest(".question-block").find(".errors-container li").size() > 0
-        container.closest(".question-block").find(".errors-container").empty()
+      container.closest(".question-block").find(".errors-container").empty()
     container.closest(".question-has-errors").removeClass("question-has-errors")
 
   addErrorMessage: (question, message) ->
@@ -285,7 +285,7 @@ window.FormValidation =
             @appendMessage(subq.closest(".span-financial"), "Minimum of #{employeeLimit} employees")
             @addErrorClass(question)
 
-  validateMatrix: (question) ->
+  validateMatrix: (question, input) ->
     # if it's a conditional question, but condition was not satisfied
     conditional = true
 
@@ -297,23 +297,27 @@ window.FormValidation =
       return
     # end of conditional validation
 
-    for subquestion in question.find("input")
+    subquestions = question.find("input")
+
+    if input
+      subquestions = [input]
+
+    for subquestion in subquestions
       subq = $(subquestion)
-      qParent = subq.parent()
+      qParent = subq.closest("td")
       val = subq.val().trim()
 
       if not val
         @appendMessage(qParent, "Required")
-        @addErrorClass(question)
+        @addErrorClass(qParent)
       else if isNaN(val)
         @appendMessage(qParent, "Only numbers")
-        @addErrorClass(question)
+        @addErrorClass(qParent)
       else
         t = parseInt(val, 10)
         if t < 0
           @appendMessage(qParent, "At least 0")
-          @addErrorClass(question)
-
+          @addErrorClass(qParent)
 
   validateCurrentAwards: (question) ->
     $(".errors-container", question).empty()
@@ -511,10 +515,10 @@ window.FormValidation =
 
     $(document).on "change", ".question-block input, .question-block select, .question-block textarea", ->
       self.clearErrors $(this)
-      self.validateIndividualQuestion($(@).closest(".question-block"))
+      self.validateIndividualQuestion($(@).closest(".question-block"), $(@))
 
-  validateIndividualQuestion: (question) ->
-    if question.hasClass("question-required") and not question.hasClass("question-date-by-years") and not question.hasClass("question-money-by-years")
+  validateIndividualQuestion: (question, triggeringElement) ->
+    if question.hasClass("question-required") and not question.hasClass("question-date-by-years") and not question.hasClass("question-money-by-years") and not question.hasClass("question-matrix")
       # console.log "validateRequiredQuestion"
       @validateRequiredQuestion(question)
 
@@ -527,7 +531,7 @@ window.FormValidation =
       @validateYear(question)
 
     if question.hasClass("question-matrix")
-      @validateMatrix(question)
+      @validateMatrix(question, triggeringElement)
 
     if question.hasClass("question-money-by-years")
       # console.log "validateMoneyByYears"

--- a/app/views/qae_form/_matrix_question.html.slim
+++ b/app/views/qae_form/_matrix_question.html.slim
@@ -12,7 +12,7 @@ table.matrix-question-table
         td
           = y_heading.label
         - question.x_headings.each do |x_heading|
-          td
+          td.question-group
             label.visuallyhidden for=question.input_name(suffix: "#{x_heading.key}_#{y_heading.key}")
               = "Number for #{x_heading.label} - #{y_heading.label}"
             input.js-trigger-autosave.matrix-question-input type="number" min="0" step="1" name=question.input_name(suffix: "#{x_heading.key}_#{y_heading.key}") value=question.input_value(suffix: "#{x_heading.key}_#{y_heading.key}") id=question.input_name(suffix: "#{x_heading.key}_#{y_heading.key}") autocomplete="off" *possible_read_only_ops
@@ -21,7 +21,7 @@ table.matrix-question-table
       th
         = question.totals_label
       - question.x_headings.each do |x_heading|
-        td
+        td.question-group
           label.visuallyhidden for=question.input_name(suffix: "#{x_heading.key}_total")
             = "Totals for #{x_heading.label}"
           input.js-trigger-autosave.matrix-question-input type="number" min="0" step="1" name=question.input_name(suffix: "#{x_heading.key}_total") value=question.input_value(suffix: "#{x_heading.key}_total") id=question.input_name(suffix: "#{x_heading.key}_total") autocomplete="off" *possible_read_only_ops


### PR DESCRIPTION
Vlidations by default validate the entire question.
Some question types do have some special treatment, though.
Since the introduction of the matrix question, this behaviour has caused a significant lag when filling the form quickly.
The matrix question does not have the same HTML as other questions, which would make it behave correctly and validate only the input changed, and this caused the issue.
Sometimes to the point of completely freezing the page.

This commit fixes the issue by validating only the input that has last been changed, and only validating the entire question when it is expected to do so.
This commit also opens up a new parameter that can be later extended to other questions to behave this same way.


card: https://app.asana.com/0/1199190913173559/1200170254453839