### PR TITLE
Fixing select question validations + fixing date fields UI

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -69,11 +69,11 @@ window.FormValidation =
     if question.find("input").hasClass("not-required")
       return true
     else
-      if @isTextishQuestion(question)
-        return question.find("input[type='text'], input[type='number'], input[type='password'], input[type='email'], input[type='url'], textarea").val().toString().trim().length
-
       if @isSelectQuestion(question)
         return question.find("select").val()
+
+      if @isTextishQuestion(question)
+        return question.find("input[type='text'], input[type='number'], input[type='password'], input[type='email'], input[type='url'], textarea").val().toString().trim().length
 
       if @isOptionsQuestion(question)
         return question.find("input[type='radio']").filter(":checked").length

--- a/app/views/qae_form/_by_years_label_question.html.slim
+++ b/app/views/qae_form/_by_years_label_question.html.slim
@@ -8,7 +8,7 @@ div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label
               = "If you had growth in the last #{c.years} years"
         .row
           - (1..c.years).each do |y|
-            .span-4.js-fy-entries class="#{'fy-latest' if y == c.years}"
+            .span-6.js-fy-entries class="#{'fy-latest' if y == c.years}"
               span.js-year-end.show-default data-year="#{y}of#{c.years}"
                 span.js-year-default
                   = question.format_label(y)

--- a/app/views/qae_form/_one_option_by_years_label_question.html.slim
+++ b/app/views/qae_form/_one_option_by_years_label_question.html.slim
@@ -6,7 +6,7 @@
           = "If you had growth in the last 3 years"
     .row
       - (1..3).each do |y|
-        .span-4.js-fy-entries class="#{'fy-latest' if y == 3}"
+        .span-6.js-fy-entries class="#{'fy-latest' if y == 3}"
           span.js-year-end.show-default data-year="#{y}of3"
             span.js-year-default
               = question.format_label(y)


### PR DESCRIPTION
Since we are using a select replacement with an input search, the select validations were being overriden by the normal text field validations.

Date fields dont fit in 1/3 of page, thus increasing the container 1/2 page .

Card: https://app.asana.com/0/1199190913173559/1200170254453839/f