### PR TITLE
Accessibility updates 4

### DIFF
--- a/app/views/admin/audit_logs/index.html.slim
+++ b/app/views/admin/audit_logs/index.html.slim
@@ -1,41 +1,44 @@
-.row
-  .col-xs-12
-    .table-overflow-container
-      table.table.audit-log-table
-        colgroup
-          col width="100"
-          col width="100"
-          col width="400"
-        thead
-          tr
-            th.sortable
-              ' Date
-            th.sortable
-              ' User
-            th.sortable
-              ' Data Exported
-        tbody
-          - if @audit_logs.none?
+.dashboard
+  h1.dashboard__heading
+    | Data Export Log
+  .row
+    .col-xs-12
+      .table-overflow-container
+        table.table.audit-log-table
+          colgroup
+            col width="100"
+            col width="100"
+            col width="400"
+          thead
             tr
-              td.text-center colspan=100
-                br
-                p.p-empty No audit logs.
-                br
-          - else
-            - @audit_logs.each do |audit_log|
+              th.sortable
+                ' Date
+              th.sortable
+                ' User
+              th.sortable
+                ' Data Exported
+          tbody
+            - if @audit_logs.none?
               tr
-                td
-                  = audit_log.created_at.strftime("%d/%m/%Y %-l:%M%P")
-                td
-                  = audit_log.subject.email
-                td
-                  - if audit_log.action_type != "download_form_answer"
-                    = t("audit_logs.action_types.#{audit_log.action_type.gsub(/-/, '_')}")
-                  - else
-                    = link_to t("audit_logs.action_types.#{audit_log.action_type}"), admin_form_answers_path(audit_log.auditable)
+                td.text-center colspan=100
+                  br
+                  p.p-empty No audit logs.
+                  br
+            - else
+              - @audit_logs.each do |audit_log|
+                tr
+                  td
+                    = audit_log.created_at.strftime("%d/%m/%Y %-l:%M%P")
+                  td
+                    = audit_log.subject.email
+                  td
+                    - if audit_log.action_type != "download_form_answer"
+                      = t("audit_logs.action_types.#{audit_log.action_type.gsub(/-/, '_')}")
+                    - else
+                      = link_to t("audit_logs.action_types.#{audit_log.action_type}"), admin_form_answers_path(audit_log.auditable)
 
 
-.row
-  .col-xs-12.text-right
-    = paginate @audit_logs
-    .clear
+  .row
+    .col-xs-12.text-right
+      = paginate @audit_logs
+      .clear

--- a/app/views/admin/feedbacks/_submit_block.html.slim
+++ b/app/views/admin/feedbacks/_submit_block.html.slim
@@ -1,3 +1,6 @@
+.dashboard
+  h1.dashboard__heading
+    | Feedback
 - if policy(feedback).can_be_submitted? || policy(feedback).can_be_re_submitted?
   - if feedback.persisted?
     = form_tag(polymorphic_url([:submit, namespace_name, form_answer, feedback]), authenticity_token: true, class: "submit-feedback", "data-type" => "json")

--- a/app/views/admin/form_answers/list_components/_table_body.html.slim
+++ b/app/views/admin/form_answers/list_components/_table_body.html.slim
@@ -3,18 +3,16 @@
   tr
     td.td-title
       - unless obj.company_or_nominee_name.nil?
-        = link_to polymorphic_url([namespace_name, obj], search: params[:search], award_type: params[:award_type]),  aria: { label: "View submitted application, for #{obj.company_or_nominee_name}" } do
-          = obj.company_or_nominee_name
+        = obj.company_or_nominee_name
       - else
-        = link_to polymorphic_url([namespace_name, obj], search: params[:search], award_type: params[:award_type]) ,  aria: { label: "View submitted application, company or nominee name not found" }do
-          em
-            ' Not found
+        em
+          ' Not yet specified
     td
-      = link_to polymorphic_url([namespace_name, obj], search: params[:search], award_type: params[:award_type]),  aria: { label: "View submitted application, reference #{obj.urn.presence || 'Not generated'}" }
+      = link_to polymorphic_url([namespace_name, obj], search: params[:search], award_type: params[:award_type]),  aria: { label: "Open submitted application page, for #{obj.company_or_nominee_name.presence || "company not yet specified"} application #{ obj.urn.presence ||  obj.id}" }
         - if obj.urn.present?
           = obj.urn
         - else
-          span.urn-not-generated Not generated
+          span.urn-not-generated Draft id: #{obj.id}
     td = obj.award_type_short_name
     td = obj.dashboard_status(current_admin.class.name)
     td = obj.sic_code
@@ -32,4 +30,4 @@
       br
       span.muted
         = obj.last_updated_by
-    td = link_to "View", review_admin_form_answer_path(obj), target: "_blank", class: "icon-view", aria: { label: "View application form, reference #{obj.urn.presence || 'Not generated'}" }
+    td = link_to "View", review_admin_form_answer_path(obj), target: "_blank", class: "icon-view", aria: { label: "Open application form, for #{obj.company_or_nominee_name.presence || "company not yet specified"} application #{ obj.urn.presence ||  obj.id}" }

--- a/app/views/admin/form_answers/show.html.slim
+++ b/app/views/admin/form_answers/show.html.slim
@@ -10,12 +10,12 @@
         .clear
 .row.inline-form-view
   .show-sidebar-container
-    .show-sidebar aria-label="Application summary"
+    aside.show-sidebar aria-label="Application summary"
       = render("applicant_details")
       = render("applicant_status")
       = render("section_documents")
       = render("admin/form_answers/assessors_section")
       = render("admin/form_answers/previous_applications_section")
 
-  .show-main-content.submitted-view aria-label="Additional application details"
+  .show-main-content.submitted-view
     = render partial: "submitted_view"

--- a/app/views/admin/settings/show.html.slim
+++ b/app/views/admin/settings/show.html.slim
@@ -1,14 +1,17 @@
-.row
-  = render "layouts/admin_award_year"
+.dashboard
+  h1.dashboard__heading
+    | Settings
+  .row
+    = render "layouts/admin_award_year"
 
-  - if ::ServerEnvironment.local_or_dev_or_staging_server?
-    = link_to "Run Notifications", run_notifications_admin_settings_email_notifications_url, method: :post,
-    class: "btn btn-primary"
-.clear
-br
+    - if ::ServerEnvironment.local_or_dev_or_staging_server?
+      = link_to "Run Notifications", run_notifications_admin_settings_email_notifications_url, method: :post,
+      class: "btn btn-primary"
+  .clear
+  br
 
-.panel-group#admin-settings-parent role="tablist" aria-multiselectable="true"
-  = render "admin/settings/stages/registration_stage"
-  = render "admin/settings/stages/application_submission_stage"
-  = render "admin/settings/stages/shortlisted_stage"
-  = render "admin/settings/stages/final_stage"
+  .panel-group#admin-settings-parent role="tablist" aria-multiselectable="true"
+    = render "admin/settings/stages/registration_stage"
+    = render "admin/settings/stages/application_submission_stage"
+    = render "admin/settings/stages/shortlisted_stage"
+    = render "admin/settings/stages/final_stage"

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,27 +1,30 @@
-= simple_form_for @search, url: "#", method: :get, as: :search, html: { class: "search-form" } do |f|
-  = render 'admin/users/navigation'
+.dashboard
+  h1.dashboard__heading
+    | Users
+  = simple_form_for @search, url: "#", method: :get, as: :search, html: { class: "search-form" } do |f|
+    = render 'admin/users/navigation'
 
-  .row
-    .col-md-4.col-sm-5.col-xs-12
-      .form-group.search-input
-        = f.input :query, label: false, input_html: { class: "form-control", placeholder: "Search...", type: "search" }
-        = submit_tag :submit, class: 'search-submit'
+    .row
+      .col-md-4.col-sm-5.col-xs-12
+        .form-group.search-input
+          = f.input :query, label: false, input_html: { class: "form-control", placeholder: "Search...", type: "search" }
+          = submit_tag :submit, class: 'search-submit'
 
-    .col-md-3.col-sm-4.col-xs-12.pull-right.text-right
-      = link_to public_send("new_admin_#{controller_name.singularize}_path"), class: 'new-user btn btn-secondary btn-md' do
-        = "+ Add #{controller_name == "users" ? "applicant" : controller_name.singularize}"
-  .clear
+      .col-md-3.col-sm-4.col-xs-12.pull-right.text-right
+        = link_to public_send("new_admin_#{controller_name.singularize}_path"), class: 'new-user btn btn-secondary btn-md' do
+          = "+ Add #{controller_name == "users" ? "applicant" : controller_name.singularize}"
+    .clear
 
-  - if @search.query?
-    .well.search-text
-      p
-        = "Search results for '#{@search.query}'"
-        small
-          = link_to "(Clear search)", [:admin, controller_name.to_sym], class: "btn btn-link"
+    - if @search.query?
+      .well.search-text
+        p
+          = "Search results for '#{@search.query}'"
+          small
+            = link_to "(Clear search)", [:admin, controller_name.to_sym], class: "btn btn-link"
 
-  = render 'list', resources: @resources, f: f
+    = render 'list', resources: @resources, f: f
 
-  .row
-    .col-xs-12.text-right
-      = paginate @resources
-      .clear
+    .row
+      .col-xs-12.text-right
+        = paginate @resources
+        .clear

--- a/app/views/admin/users_feedbacks/show.html.slim
+++ b/app/views/admin/users_feedbacks/show.html.slim
@@ -1,42 +1,45 @@
-.row
-  .col-xs-12
-    .table-overflow-container
-      table.table.feedback-table
-        colgroup
-          col width="100"
-          col width="100"
-          col width="400"
-        thead
-          tr
-            th.sortable
-              ' Date
-            th.sortable
-              ' Rating
-            th.sortable
-              ' Feedback
-        tbody
-          - if @feedbacks.none?
+.dashboard
+  h1.dashboard__heading
+    | Feedback
+  .row
+    .col-xs-12
+      .table-overflow-container
+        table.table.feedback-table
+          colgroup
+            col width="100"
+            col width="100"
+            col width="400"
+          thead
             tr
-              td.text-center colspan=100
-                br
-                p.p-empty No feedback received.
-                br
-          - else
-            - @feedbacks.each do |feedback|
+              th.sortable
+                ' Date
+              th.sortable
+                ' Rating
+              th.sortable
+                ' Feedback
+          tbody
+            - if @feedbacks.none?
               tr
-                td
-                  = feedback.created_at.strftime("%d/%m/%Y %-l:%M%P")
-                td
-                  span.feedback-stars alt=feedback.rating.text title=feedback.rating.text
-                    - feedback.rating.value.times do
-                      span.glyphicon.glyphicon-star
-                    - (5 - feedback.rating.value).times do
-                      span.glyphicon.glyphicon-star-empty
-                td
-                  .feedback-description
-                    = feedback.comment
+                td.text-center colspan=100
+                  br
+                  p.p-empty No feedback received.
+                  br
+            - else
+              - @feedbacks.each do |feedback|
+                tr
+                  td
+                    = feedback.created_at.strftime("%d/%m/%Y %-l:%M%P")
+                  td
+                    span.feedback-stars alt=feedback.rating.text title=feedback.rating.text
+                      - feedback.rating.value.times do
+                        span.glyphicon.glyphicon-star
+                      - (5 - feedback.rating.value).times do
+                        span.glyphicon.glyphicon-star-empty
+                  td
+                    .feedback-description
+                      = feedback.comment
 
-.row
-  .col-xs-12.text-right
-    = paginate @feedbacks
-    .clear
+  .row
+    .col-xs-12.text-right
+      = paginate @feedbacks
+      .clear

--- a/app/views/assessor/form_answers/_list_body.html.slim
+++ b/app/views/assessor/form_answers/_list_body.html.slim
@@ -6,17 +6,16 @@ tbody
 
       td.td-title
         - unless obj.company_or_nominee_name.nil?
-          = link_to polymorphic_url([namespace_name, obj], search: params.permit[:search]),  aria: { label: "View submitted application, for #{obj.company_or_nominee_name}" } do
-            = obj.company_or_nominee_name
+          = obj.company_or_nominee_name
         - else
-          = link_to polymorphic_url([namespace_name, obj], search: params.permit[:search]) ,  aria: { label: "View submitted application, company or nominee name not found" }do
-            em
-              ' Not found
+          em
+            ' Not yet specified
       td
-        - if obj.urn.present?
-          = link_to obj.urn, polymorphic_url([namespace_name, obj], search: params.permit[:search]),  aria: { label: "View submitted application, reference #{obj.urn}" }
-        - else
-          span.urn-not-generated Not yet generated
+        = link_to polymorphic_url([namespace_name, obj], search: params[:search], award_type: params[:award_type]),  aria: { label: "Open submitted application page, for #{obj.company_or_nominee_name.presence || "company not yet specified"} application #{ obj.urn.presence ||  obj.id}" }
+          - if obj.urn.present?
+            = obj.urn
+          - else
+            span.urn-not-generated Draft id: #{obj.id}
 
       td = obj.dashboard_status
       td = obj.sic_code

--- a/app/views/assessor/form_answers/show.html.slim
+++ b/app/views/assessor/form_answers/show.html.slim
@@ -10,7 +10,7 @@
         .clear
 .row.inline-form-view
   .show-sidebar-container
-    .show-sidebar aria-label="Application summary"
+    aside.show-sidebar aria-label="Application summary"
       = render("admin/form_answers/applicant_details")
 
       = render("admin/form_answers/applicant_status")
@@ -18,5 +18,5 @@
       = render("admin/form_answers/assessors_section")
       = render("admin/form_answers/previous_applications_section")
 
-  .show-main-content.submitted-view aria-label="Additional application details"
+  .show-main-content.submitted-view
     = render "submitted_view"

--- a/app/views/judge/case_summaries/_link.html.slim
+++ b/app/views/judge/case_summaries/_link.html.slim
@@ -8,4 +8,4 @@ li.download-item
     - else
       = value
 
-  = link_to "Download", download_judge_case_summaries_path(link_ops), class: "download-link"
+  = link_to "Download", download_judge_case_summaries_path(link_ops), class: "download-link", aria: { label: "Download #{ key == "trade"? "International Trade #{years_mode} years" : value }" }

--- a/app/views/qae_form/_textarea_question.html.slim
+++ b/app/views/qae_form/_textarea_question.html.slim
@@ -6,7 +6,7 @@
 
 .if-no-js-hide
   .js-ckeditor-spinner-block
-    = image_tag "textarea_spinner.gif"
+    = image_tag "textarea_spinner.gif", alt:""
     span
       | Loading Editor ...
 


### PR DESCRIPTION
- Removed aria-labels from divs and made left panel and aside element instead (Issue: 388)
- Removed link from company name in application index table, for admins and assessors. Also now showing 'Not yet specified' if company name is nil rather than 'Not found', and 'Draft id:' if reference is not yet generated instead of 'Not generated'
- Added aria-labels to download links on judges case summaries page (Issue: 69 & 397)
- Added alt:'' to textarea_spinner gif
- h1 to admin pages 'Users', Settings', 'Feedback' and 'Data Export Log'