### PR TITLE
UI changes after toolkit implementation

### DIFF
--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -474,7 +474,6 @@ article .form-download {
     font-weight: 600;
     background: image-url("icon-file-download.png") no-repeat scroll 0 0;
     min-height: 2.5em;
-    padding:0 0 0 2.5em;
 
     @include device-pixel-ratio() {
       background-image: image-url("icon-file-download-2x.png");

--- a/app/views/qae_form/_pdf_link.html.slim
+++ b/app/views/qae_form/_pdf_link.html.slim
@@ -1,6 +1,8 @@
 - unless QAE.hide_pdf_links?
-  = link_to users_form_answer_path(@form_answer, format: :pdf), class: 'govuk-link'
-    - if @form_answer.award_type == "promotion"
-      ' Download your nomination
-    - else
-      ' Download your application
+  .download-pdf-link
+    = link_to users_form_answer_path(@form_answer, format: :pdf), class: 'govuk-link'
+      = render "content_only/download_icon"
+      - if @form_answer.award_type == "promotion"
+        ' Download your nomination
+      - else
+        ' Download your application (PDF)

--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -44,15 +44,15 @@
               | Remove
 
   span.govuk-error-message
-  .if-no-js-hide
+  .if-no-js-hide.govuk-button-group
     span.govuk-button.govuk-button--secondary.button-add aria-label="Upload" data-entity="file" *possible_read_only_ops
       span
-        | + Upload
+        | Upload
       input.fileinput-button.js-file-upload type="file" name="form[file]" id="q_#{question.key}" *possible_read_only_ops data-question-key=question.key
     - if question.links
       | &nbsp;
       a.govuk-button.govuk-button--secondary.button-add.js-file-upload data-add-link="1" href="#" aria-label="Add website address" data-entity="website address" *possible_read_only_ops
-        | + Add website address
+        | Add website address
 
   - if question.key == :org_chart && @form_answer.document["org_chart"].blank?
     .if-js-hide


### PR DESCRIPTION
Card: https://app.asana.com/0/1200504523179345/1200553019764968/f

- Added download icon in front of 'Download your application' link, and added '(PDF)' in the end of the link
- Left-aligned 'Download your application' link by removing `padding:0 0 0 2.5em` on article .form-download.a
- Adjusted spacing between 'Upload' and 'Add website address' buttons by adding `govuk-button-group` class. Also removed '+' symbol prefix.