### PR TITLE
UI changes after toolkit implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,9 +471,6 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.4.3)
-      nokogiri (~> 1)
-      rake
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
@@ -488,7 +485,7 @@ GEM
       activerecord (>= 4.0.0)
       activesupport (>= 4.0.0)
     nio4r (2.5.8)
-    nokogiri (1.12.4)
+    nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     nokogumbo (2.0.5)
@@ -845,7 +842,6 @@ DEPENDENCIES
   lograge
   mail-notify (~> 1.0)
   meta_request
-  mimemagic (>= 0.3.9)
   nilify_blanks
   nokogiri
   paper_trail (~> 10.3)

--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -474,7 +474,6 @@ article .form-download {
     font-weight: 600;
     background: image-url("icon-file-download.png") no-repeat scroll 0 0;
     min-height: 2.5em;
-    padding:0 0 0 2.5em;
 
     @include device-pixel-ratio() {
       background-image: image-url("icon-file-download-2x.png");

--- a/app/views/content_only/_dashboard_pre_submission.html.slim
+++ b/app/views/content_only/_dashboard_pre_submission.html.slim
@@ -26,10 +26,12 @@
 
   - if submission_deadline && submission_deadline.trigger_at
     .related-positioning.related-positioning-no-header
-      .related-container
-        .related#related
-          .highlighted-event
-            p.govuk-body
-              ' Submission deadline
-              em class="govuk-!-font-size-36 govuk-!-font-weight-bold"
-                = submission_deadline.decorate.formatted_trigger_time
+      .related
+        .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+          .govuk-notification-banner__header
+            h2.govuk-notification-banner__title#govuk-notification-banner-title
+              | Important
+          .govuk-notification-banner__content
+            p.govuk-notification-banner__heading
+              | Submission deadline is
+              =< submission_deadline.decorate.formatted_trigger_time

--- a/app/views/content_only/_dashboard_pre_submission.html.slim
+++ b/app/views/content_only/_dashboard_pre_submission.html.slim
@@ -29,7 +29,7 @@
       .related
         .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
           .govuk-notification-banner__header
-            h2.govuk-notification-banner__title#govuk-notification-banner-title
+            .govuk-notification-banner__title#govuk-notification-banner-title
               | Important
           .govuk-notification-banner__content
             p.govuk-notification-banner__heading

--- a/app/views/content_only/_steps_progress_bar.html.slim
+++ b/app/views/content_only/_steps_progress_bar.html.slim
@@ -27,9 +27,11 @@
       = link_to "queensawards@beis.gov.uk", "mailto:queensawards@beis.gov.uk"
 
     - if submission_deadline && submission_deadline.trigger_at
-      li
-        .highlighted-event
-          p.govuk-body
-            ' Submission deadline
-            em class="govuk-!-font-size-36 govuk-!-font-weight-bold"
-              = submission_deadline.decorate.formatted_trigger_time
+      .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+        .govuk-notification-banner__header
+          h2.govuk-notification-banner__title#govuk-notification-banner-title
+            | Important
+        .govuk-notification-banner__content
+          p.govuk-notification-banner__heading
+            | Submission deadline is
+            =< submission_deadline.decorate.formatted_trigger_time

--- a/app/views/content_only/_submitted_applications.html.slim
+++ b/app/views/content_only/_submitted_applications.html.slim
@@ -1,6 +1,6 @@
 - if award_applications.none?
   .application-notice.help-notice
-    p.govuk-body You did not submit any applications.
+    <p class="govuk-body govuk-!-margin-top-3"> You did not submit any applications.</p>
 - else
   - if Settings.winners_stage?
     = render("content_only/post_submission/winners", award_applications: award_applications)

--- a/app/views/form_award_eligibilities/_steps_progress_bar.html.slim
+++ b/app/views/form_award_eligibilities/_steps_progress_bar.html.slim
@@ -30,9 +30,11 @@
       ' Alternatively, email us at
       = link_to "queensawards@beis.gov.uk", "mailto:queensawards@beis.gov.uk", class: 'govuk-link'
     - if submission_deadline && submission_deadline.trigger_at
-      li.govuk-body
-        .highlighted-event
-          p.govuk-body
-            ' Submission deadline
-            em class="govuk-!-font-size-36 govuk-!-font-weight-bold"
-              = submission_deadline.decorate.formatted_trigger_time
+      .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+        .govuk-notification-banner__header
+          h2.govuk-notification-banner__title#govuk-notification-banner-title
+            | Important
+        .govuk-notification-banner__content
+          p.govuk-notification-banner__heading
+            | Submission deadline is
+            =< submission_deadline.decorate.formatted_trigger_time

--- a/app/views/qae_form/_pdf_link.html.slim
+++ b/app/views/qae_form/_pdf_link.html.slim
@@ -1,6 +1,8 @@
 - unless QAE.hide_pdf_links?
-  = link_to users_form_answer_path(@form_answer, format: :pdf), class: 'govuk-link'
-    - if @form_answer.award_type == "promotion"
-      ' Download your nomination
-    - else
-      ' Download your application
+  .download-pdf-link
+    = link_to users_form_answer_path(@form_answer, format: :pdf), class: 'govuk-link'
+      = render "content_only/download_icon"
+      - if @form_answer.award_type == "promotion"
+        ' Download your nomination
+      - else
+        ' Download your application (PDF)

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -3,7 +3,6 @@
     = question.header
   - if question.header_context
     == question.header_context
-- is_sub_question = question.fieldset_classes.include?('sub-question')
 fieldset class=question.fieldset_classes data=question.fieldset_data_hash
   = condition_divs question do
     .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
@@ -16,11 +15,8 @@ fieldset class=question.fieldset_classes data=question.fieldset_data_hash
                 span.todo
                   = ref.to_s
             - unless question.title.blank?
-              - if is_sub_question
+              span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
                 == question.title
-              - else
-                span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
-                  == question.title
 
             = render "qae_form/question_sub_title", question: question
 
@@ -31,11 +27,8 @@ fieldset class=question.fieldset_classes data=question.fieldset_data_hash
                 span.todo
                   = ref.to_s
             - unless question.title.blank? 
-              - if is_sub_question
+              span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
                 == question.title
-              - else
-                span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
-                  == question.title
 
             = render "qae_form/question_sub_title", question: question
 

--- a/app/views/qae_form/_steps_progress_bar.html.slim
+++ b/app/views/qae_form/_steps_progress_bar.html.slim
@@ -53,9 +53,11 @@
       = link_to "queensawards@beis.gov.uk", "mailto:queensawards@beis.gov.uk", class: 'govuk-link'
 
     - if submission_deadline && submission_deadline.trigger_at
-      li.govuk-body
-        .highlighted-event
-          p.govuk-body
-            ' Submission deadline
-            em class="govuk-!-font-size-36 govuk-!-font-weight-bold"
-              = submission_deadline.decorate.formatted_trigger_time
+      .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+        .govuk-notification-banner__header
+          h2.govuk-notification-banner__title#govuk-notification-banner-title
+            | Important
+        .govuk-notification-banner__content
+          p.govuk-notification-banner__heading
+            | Submission deadline is
+            =< submission_deadline.decorate.formatted_trigger_time

--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -44,15 +44,15 @@
               | Remove
 
   span.govuk-error-message
-  .if-no-js-hide
+  .if-no-js-hide.govuk-button-group
     span.govuk-button.govuk-button--secondary.button-add aria-label="Upload" data-entity="file" *possible_read_only_ops
       span
-        | + Upload
+        | Upload
       input.fileinput-button.js-file-upload type="file" name="form[file]" id="q_#{question.key}" *possible_read_only_ops data-question-key=question.key
     - if question.links
       | &nbsp;
       a.govuk-button.govuk-button--secondary.button-add.js-file-upload data-add-link="1" href="#" aria-label="Add website address" data-entity="website address" *possible_read_only_ops
-        | + Add website address
+        | Add website address
 
   - if question.key == :org_chart && @form_answer.document["org_chart"].blank?
     .if-js-hide


### PR DESCRIPTION
Card: https://app.asana.com/0/1200504523179345/1200553019764968/f

- Cherry-picked dependabot commit to update nokogiri to 1.12.5 (previous PR was failing security test)
- Added download icon in front of 'Download your application' link, and added '(PDF)' in the end of the link
- Left-aligned 'Download your application' link by removing `padding:0 0 0 2.5em` on article .form-download.a
- Adjusted spacing between 'Upload' and 'Add website address' buttons by adding `govuk-button-group` class. Also removed '+' symbol prefix.
- Change deadline notification as per QAVS notification
<img width="780" alt="Screenshot 2021-09-29 at 11 32 57" src="https://user-images.githubusercontent.com/84323332/135252708-d80cf99e-ec91-466b-aed2-31886322a001.png">
<img width="802" alt="Screenshot 2021-09-30 at 11 18 40" src="https://user-images.githubusercontent.com/84323332/135437553-6e515ab5-8ea0-4bb2-88fe-3b3dd16eae5a.png">

- Vertically align th '!' icon with the 'You did not submit any applications.' message.
- Moved the sub-question number labels above the questions.