### PR TITLE
UI changes after toolkit implementation

### DIFF
--- a/app/views/content_only/_steps_progress_bar.html.slim
+++ b/app/views/content_only/_steps_progress_bar.html.slim
@@ -4,7 +4,7 @@
   ol
     = step_link_to "Eligibility", form_award_eligibility_path(form_id: @form_answer.id), index: 1, active: 2, index_name: "",  cant_access_future: false
 
-    li.js-step-condition.step-current
+    li.js-step-condition.step-current.govuk-body
       span
         = link_to [:award_info, @form_answer.award_type.to_sym, form_id: @form_answer.id] do
           span.step-number

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -68,11 +68,14 @@ title = content_for?(:title) ? yield(:title)  + " - Queen's Awards for Enterpris
       .govuk-width-container
         main#content.group class="govuk-main-wrapper app-main-class #{yield :page_content_class}"
           - if !content_for?(:flash_disabled) && [:alert, :notice].any? { |kind| flash[kind].presence }
-            .flash
-              .flash-inner
-                - [:alert, :notice].each do |kind|
-                  - if flash[kind]
-                    div class="#{kind}"
+            - [:alert, :notice].each do |kind|
+              - if flash[kind]
+                .govuk-notification-banner class="govuk-notification-banner--#{ kind }" role="region" aria-labelledby="flash-message-#{kind}-title" data-module="govuk-notification-banner"
+                  .govuk-notification-banner__header
+                    h2.govuk-notification-banner__title id="flash-message-#{kind}-title"
+                      = kind.to_s.titleize
+                  .govuk-notification-banner__content
+                    .govuk-notification-banner__heading
                       = flash[kind]
 
           - if params[:session_expired].present?

--- a/app/views/qae_form/_address_question.html.slim
+++ b/app/views/qae_form/_address_question.html.slim
@@ -5,46 +5,29 @@ div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label
 
     - case sub_field_key
     - when :building
-      .govuk-form-group
+      .govuk-form-group.question-required
         label.govuk-label for="q_#{question.key}_line_1"
           ' Building
-        - if @form_answer.validator_errors&.dig(question.hash_key(suffix: "building"))
-          span.govuk-error-message
-            span.govuk-visually-hidden
-              | Error:
-            = @form_answer.validator_errors[question.hash_key(suffix: "building")]
-
+        span.govuk-error-message
         input.govuk-input.govuk-input--width-10.js-trigger-autosave.required type="text" name=question.input_name(suffix: 'building') value=question.input_value(suffix: 'building') autocomplete="off"  id="q_#{question.key}_line_1" *possible_read_only_ops
-      .govuk-form-group
+      .govuk-form-group.question-required
         label.govuk-label for="q_#{question.key}_line_2"
           ' Street
-        - if @form_answer.validator_errors&.dig(question.hash_key(suffix: "street"))
-          span.govuk-error-message
-            span.govuk-visually-hidden
-              | Error:
-            = @form_answer.validator_errors[question.hash_key(suffix: "street")]
+        span.govuk-error-message
         input.govuk-input.govuk-input--width-10.js-trigger-autosave type="text" name=question.input_name(suffix: 'street') value=question.input_value(suffix: 'street') autocomplete="off" id="q_#{question.key}_line_2" *possible_read_only_ops
     - when :country
-      .govuk-form-group
+      .govuk-form-group.question-required
         label.govuk-label for="#{question.key}_country"
           ' Country
         = country_select(question.step.form.form_name, "#{question.key}_country", {priority_countries: ["GB", "US"], selected: question.input_value(suffix: 'country')}, possible_read_only_ops.merge({name: question.input_name(suffix: 'country'), class: 'js-trigger-autosave required govuk-select'}))
-        - if @form_answer.validator_errors&.dig(question.hash_key(suffix: sub_field_key))
-          span.govuk-error-message
-            span.govuk-visually-hidden
-              | Error:
-            =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
+        span.govuk-error-message
         .clear
 
     - when :county
       .govuk-form-group.question-required
         label.govuk-label id="#{question.key}_region_label" for="#{question.key}_county" aria-describedby="#{question.key}_county_hint"
           ' County
-        - if @form_answer.validator_errors&.dig(question.hash_key(suffix: sub_field_key))
-          span.govuk-error-message
-            span.govuk-visually-hidden
-              | Error:
-            =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
+        span.govuk-error-message
         .clear
 
         - if question.county_context.present?
@@ -54,14 +37,10 @@ div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label
         = select_tag("#{question.key}_county", options_for_select(question.counties, question.input_value(suffix: "county")), possible_read_only_ops.merge({name: question.input_name(suffix: 'county'), class: "js-trigger-autosave required custom-select govuk-select", include_blank: true}))
 
     - else
-      .govuk-form-group
+      .govuk-form-group.question-required
         label.govuk-label for=question.input_name(suffix: sub_field_key) value=question.input_value(suffix: sub_field_key)
           = sub_field_title
-        - if @form_answer.validator_errors&.dig(question.hash_key(suffix: sub_field_key))
-          span.govuk-error-message
-            span.govuk-visually-hidden
-              | Error:
-            =< @form_answer.validator_errors[question.hash_key(suffix: sub_field_key)]
+        span.govuk-error-message
         .clear
 
         - klass = "#{sub_field_title.parameterize == 'postcode' ? 'govuk-input--width-10' : 'govuk-input--width-20'}"

--- a/app/views/qae_form/_date_question.html.slim
+++ b/app/views/qae_form/_date_question.html.slim
@@ -1,4 +1,5 @@
-.govuk-date-input role="group" aria-labelledby="q_#{question.key}_label" id="q_#{question.key}"
+.govuk-date-input.govuk-form-group role="group" aria-labelledby="q_#{question.key}_label" id="q_#{question.key}"
+  span.govuk-error-message
   .govuk-date-input__item
     .govuk-form-group
       label.govuk-label.govuk-date-input__label for=question.input_name(suffix: 'day')

--- a/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
+++ b/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
@@ -15,7 +15,8 @@ div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label
 
           span.govuk-grid-column-one-third
             label.govuk-label
-              .govuk-form-group
+              .govuk-form-group.question-required
+                span.govuk-error-message
                 .if-no-js-hide
                   ' Name of subsidiary
                   input.govuk-input.medium.js-trigger-autosave type="text" name="#{question.input_name}[#{index}][name]" value=subsidiary["name"] autocomplete="off" *possible_read_only_ops
@@ -29,7 +30,8 @@ div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label
                     ' -
           span.govuk-grid-column-one-third
             label.govuk-label
-              .govuk-form-group
+              .govuk-form-group.question-required
+                span.govuk-error-message
                 .if-no-js-hide
                   ' Location
                   input.govuk-input.medium.js-trigger-autosave type="text" name="#{question.input_name}[#{index}][location]" value=subsidiary["location"]  autocomplete="off" *possible_read_only_ops
@@ -42,7 +44,8 @@ div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label
                     ' -
           span.govuk-grid-column-one-third
             label.govuk-label
-              .govuk-form-group
+              .govuk-form-group.question-required
+                span.govuk-error-message
                 .if-no-js-hide
                   ' Amount of UK employees
                   input.govuk-input.small.js-trigger-autosave type="text" name="#{question.input_name}[#{index}][employees]" value=subsidiary["employees"]  autocomplete="off" *possible_read_only_ops
@@ -57,7 +60,8 @@ div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label
 
         .govuk-grid-row
           .govuk-grid-column-full
-            label.govuk-label
+            label.govuk-label.question-required
+              span.govuk-error-message
               .if-no-js-hide
                 ' Specify the reason why you are including it.
                 textarea.govuk-textarea.award-textarea.js-char-count.js-trigger-autosave rows="2" name="#{question.input_name}[#{index}][description]" autocomplete="off" data-word-max=question.details_words_max *possible_read_only_ops

--- a/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
+++ b/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
@@ -60,8 +60,7 @@ div role="group" id="q_#{question.key}" aria-labelledby="q_#{question.key}_label
 
         .govuk-grid-row
           .govuk-grid-column-full
-            label.govuk-label.question-required
-              span.govuk-error-message
+            label.govuk-label
               .if-no-js-hide
                 ' Specify the reason why you are including it.
                 textarea.govuk-textarea.award-textarea.js-char-count.js-trigger-autosave rows="2" name="#{question.input_name}[#{index}][description]" autocomplete="off" data-word-max=question.details_words_max *possible_read_only_ops


### PR DESCRIPTION
Card: https://app.asana.com/0/1200504523179345/1200553019764968/f

- Changed error messages to match QAVS notification banners
<img width="836" alt="Screenshot 2021-10-04 at 09 19 55" src="https://user-images.githubusercontent.com/84323332/135817844-9487650a-67c3-4ea6-a09c-ab95ba9f9c25.png">

- Display an error message if fields left empty after users click on the 'Save and continue' button at the bottom of the page
<img width="935" alt="Screenshot 2021-09-30 at 18 28 16" src="https://user-images.githubusercontent.com/84323332/135503916-ae40d325-9aa8-4481-b7ca-0b3b9592cc40.png">

- Display error messages if no values were entered for subsidiaries question
<img width="821" alt="Screenshot 2021-09-30 at 19 47 24" src="https://user-images.githubusercontent.com/84323332/135514255-a8e4e8b2-1d39-4aeb-9179-48b50f726fd3.png">

Display one red line on the left-hand-side of Date started trading question
<img width="697" alt="Screenshot 2021-10-01 at 09 44 13" src="https://user-images.githubusercontent.com/84323332/135591877-f1f938ba-0a39-4957-abe6-458fffdc0924.png">

Display 'Useful application info' option is not displayed in the side nav (this was previously disappearing when clicked)
<img width="817" alt="Screenshot 2021-10-04 at 12 09 55" src="https://user-images.githubusercontent.com/84323332/135841533-7d1431a8-f2e5-4e61-8db7-58405bb716db.png">
