### PR TITLE
Removed aria-labels from legends

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -241,10 +241,6 @@ jQuery ->
     $(this).prop('required', true)
     $(this).attr('aria-required', 'true')
 
-  $('.qae-form').find('input[type="number"]').each -> 
-    $(this).attr('pattern', '[0-9]*')
-    $(this).attr('inputmode', 'decimal')
-
   # Calculates the UK Sales for Sus Dev form
   # UK sales = turnover - exports
   updateTurnoverExportCalculation = ->

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -237,6 +237,14 @@ jQuery ->
   $(".js-financial-year-latest").closest(".question-block").next().find("input").change () ->
     updateYearEnd()
 
+  $('.question-required').find('input,select,textarea').each ->
+    $(this).prop('required', true)
+    $(this).attr('aria-required', 'true')
+
+  $('.qae-form').find('input[type="number"]').each -> 
+    $(this).attr('pattern', '[0-9]*')
+    $(this).attr('inputmode', 'decimal')
+
   # Calculates the UK Sales for Sus Dev form
   # UK sales = turnover - exports
   updateTurnoverExportCalculation = ->

--- a/app/assets/stylesheets/admin/_variables.scss
+++ b/app/assets/stylesheets/admin/_variables.scss
@@ -30,4 +30,4 @@ $pagination-border: #adadad;
 $header-hover: #444;
 
 $blue-link-colour: #1A66A8;
-$govuk-light-blue: #5694ca
+$govuk-light-blue: #5694ca;

--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -862,7 +862,6 @@ details {
 
   summary {
     display: inline-block;
-    color: #005ea5;
     cursor: pointer;
     position: relative;
     margin-bottom: 0.26316em;
@@ -884,6 +883,10 @@ details {
   .arrow {
     margin-right: .35em;
     font-style: normal;
+  }
+
+  span {
+    color: $dark-blue-link-colour;
   }
 }
 

--- a/app/assets/stylesheets/styleguide/_palette.scss
+++ b/app/assets/stylesheets/styleguide/_palette.scss
@@ -2,6 +2,7 @@
 $govuk-blue: #005ea5;
 $govuk-input-border-colour: #0b0c0c;
 $blue-link-colour: #1A66A8;
+$dark-blue-link-colour: #1B68AC;
 $mainstream-brand: $govuk-blue;
 
 // Standard palette, colours

--- a/app/forms/award_years/v2022/innovation/innovation_step4.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step4.rb
@@ -38,10 +38,10 @@ class AwardYears::V2022::QAEForms
         header :declaration_and_corporate_responsibility_intro, "" do
           classes "application-notice help-notice"
           context %(
-            <p>
+            <p class="govuk-body">
               You may have answered some of the questions in this section in other parts of the form. If you believe this is the case, you do not need to repeat the information, but make it clear by referencing other parts of the form.
             </p>
-            <p>
+            <p class="govuk-body">
               Please use this section to give us additional information about corporate responsibility that you have not covered elsewhere in the form and would like us to see.
             </p>
           )

--- a/app/forms/award_years/v2022/international_trade/international_trade_step4.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step4.rb
@@ -38,10 +38,10 @@ class AwardYears::V2022::QAEForms
         header :declaration_and_corporate_responsibility_intro, "" do
           classes "application-notice help-notice"
           context %(
-            <p>
+            <p class="govuk-body">
               You may have answered some of the questions in this section in other parts of the form. If you believe this is the case, you do not need to repeat the information, but make it clear by referencing other parts of the form.
             </p>
-            <p>
+            <p class="govuk-body">
               Please use this section to give us additional information about corporate responsibility that you have not covered elsewhere in the form and would like us to see.
             </p>
           )

--- a/app/forms/qae_form_builder/question.rb
+++ b/app/forms/qae_form_builder/question.rb
@@ -124,7 +124,8 @@ class QAEFormBuilder
         "one_option_by_years_label_question",
         "by_years_question",
         "by_years_label_question",
-        "matrix_question"
+        "matrix_question",
+        "press_contact_details_question"
       ]
 
       legend_types.include?(type)

--- a/app/views/qae_form/_queen_award_applications_question.html.slim
+++ b/app/views/qae_form/_queen_award_applications_question.html.slim
@@ -33,7 +33,7 @@ div role="group" id="q_#{question.key}"
                 | Category
               span.govuk-error-message
               span.if-no-js-hide
-                select.govuk-select.js-trigger-autosave id="form[applied_for_queen_awards_details][#{index}][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+                select.govuk-select.js-trigger-autosave name="form[applied_for_queen_awards_details][#{index}][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops id="form[applied_for_queen_awards_details][#{index}][category]"
                   option value=""
                     ' Category
                   - question.categories.each do |category|
@@ -49,7 +49,7 @@ div role="group" id="q_#{question.key}"
                 | Year
               span.govuk-error-message
               span.if-no-js-hide
-                select.govuk-select.js-trigger-autosave id="form[applied_for_queen_awards_details][#{index}][year]" data-dependable-option-siffix="year" data-parent-option-dependable-key=question.key class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+                select.govuk-select.js-trigger-autosave name="form[applied_for_queen_awards_details][#{index}][year]" data-dependable-option-siffix="year" data-parent-option-dependable-key=question.key class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops id="form[applied_for_queen_awards_details][#{index}][year]"
                   option value=""
                     ' Year
                   - question.years.each do |year|
@@ -65,7 +65,7 @@ div role="group" id="q_#{question.key}"
                 | Outcome (Won/Did not win)
               span.govuk-error-message
               span.if-no-js-hide
-                select.govuk-select.js-trigger-autosave id="form[applied_for_queen_awards_details][#{index}][outcome]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="outcome" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+                select.govuk-select.js-trigger-autosave name="form[applied_for_queen_awards_details][#{index}][outcome]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="outcome" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops id="form[applied_for_queen_awards_details][#{index}][outcome]"
                   option value=""
                     ' Outcome (Won/Did not win)
                   - question.outcomes.each do |outcome|

--- a/app/views/qae_form/_queen_award_applications_question.html.slim
+++ b/app/views/qae_form/_queen_award_applications_question.html.slim
@@ -29,11 +29,11 @@ div role="group" id="q_#{question.key}"
         .govuk-grid-row
           .govuk-grid-column-one-quarter
             .govuk-form-group
-              label.govuk-label
+              label.govuk-label for="form[applied_for_queen_awards_details][#{index}][category]"
                 | Category
               span.govuk-error-message
               span.if-no-js-hide
-                select.govuk-select.js-trigger-autosave name="form[applied_for_queen_awards_details][#{index}][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+                select.govuk-select.js-trigger-autosave id="form[applied_for_queen_awards_details][#{index}][category]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="category" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
                   option value=""
                     ' Category
                   - question.categories.each do |category|
@@ -45,11 +45,11 @@ div role="group" id="q_#{question.key}"
             
           .govuk-grid-column-one-quarter
             .govuk-form-group
-              label.govuk-label
+              label.govuk-label for="form[applied_for_queen_awards_details][#{index}][year]"
                 | Year
               span.govuk-error-message
               span.if-no-js-hide
-                select.govuk-select.js-trigger-autosave name="form[applied_for_queen_awards_details][#{index}][year]" data-dependable-option-siffix="year" data-parent-option-dependable-key=question.key class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+                select.govuk-select.js-trigger-autosave id="form[applied_for_queen_awards_details][#{index}][year]" data-dependable-option-siffix="year" data-parent-option-dependable-key=question.key class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
                   option value=""
                     ' Year
                   - question.years.each do |year|
@@ -61,11 +61,11 @@ div role="group" id="q_#{question.key}"
 
           .govuk-grid-column-one-half
             .govuk-form-group
-              label.govuk-label
+              label.govuk-label for="form[applied_for_queen_awards_details][#{index}][outcome]"
                 | Outcome (Won/Did not win)
               span.govuk-error-message
               span.if-no-js-hide
-                select.govuk-select.js-trigger-autosave name="form[applied_for_queen_awards_details][#{index}][outcome]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="outcome" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
+                select.govuk-select.js-trigger-autosave id="form[applied_for_queen_awards_details][#{index}][outcome]" data-dependable-values=dependable_values data-parent-option-dependable-key=question.key data-dependable-option-siffix="outcome" class=("js-options-with-dependent-child-select" if children_depends_on.present?) *possible_read_only_ops
                   option value=""
                     ' Outcome (Won/Did not win)
                   - question.outcomes.each do |outcome|

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -12,7 +12,7 @@
       .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
         - ref = question.ref ? question.ref : question.sub_ref
         - if question.title != "" || question.show_ref_always.present?
-          legend.govuk-label
+          legend.govuk-fieldset__legend
             - if question.ref || question.sub_ref
               span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
                 span.todo
@@ -77,7 +77,6 @@
       .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
         - ref = question.ref ? question.ref : question.sub_ref
         - if question.title != "" || question.show_ref_always.present?
-          legend.govuk-label
           label.govuk-label for="q_#{question.key}" id="q_#{question.key}_label" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
             - if question.ref || question.sub_ref
               span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -13,7 +13,7 @@
         - ref = question.ref ? question.ref : question.sub_ref
         - if question.title != "" || question.show_ref_always.present?
           - if question.label_as_legend?
-            legend.govuk-label aria-label="#{ref.to_s.gsub(' ', '-')} #{question.title.blank? ? '' : ':' + question.title}"
+            legend.govuk-label
               - if question.ref || question.sub_ref
                 span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
                   span.todo
@@ -25,7 +25,7 @@
               = render "qae_form/question_sub_title", question: question
 
           - else
-            legend.govuk-label aria-label="#{ref.to_s.gsub(' ', '-')} #{question.title.blank? ? '' : ':' + question.title}"
+            legend.govuk-label
             label.govuk-label for="q_#{question.key}" id="q_#{question.key}_label" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
               - if question.ref || question.sub_ref
                 span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -72,7 +72,7 @@
           = render "qae_form/conditional_hints/list", question: question
 
 - else
-  . class=question.fieldset_classes data=question.fieldset_data_hash
+  div class=question.fieldset_classes data=question.fieldset_data_hash
     = condition_divs question do
       .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
         - ref = question.ref ? question.ref : question.sub_ref

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -6,36 +6,22 @@
 - if !question.ref && !question.sub_ref
   .govuk-form-group
     == question.context
-- else
+- elsif question.label_as_legend?
   fieldset class=question.fieldset_classes data=question.fieldset_data_hash
     = condition_divs question do
       .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
         - ref = question.ref ? question.ref : question.sub_ref
         - if question.title != "" || question.show_ref_always.present?
-          - if question.label_as_legend?
-            legend.govuk-label
-              - if question.ref || question.sub_ref
-                span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
-                  span.todo
-                    = ref.to_s
-              - unless question.title.blank?
-                span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
-                  == question.title
+          legend.govuk-label
+            - if question.ref || question.sub_ref
+              span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                span.todo
+                  = ref.to_s
+            - unless question.title.blank?
+              span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
+                == question.title
 
-              = render "qae_form/question_sub_title", question: question
-
-          - else
-            legend.govuk-label
-            label.govuk-label for="q_#{question.key}" id="q_#{question.key}_label" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
-              - if question.ref || question.sub_ref
-                span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
-                  span.todo
-                    = ref.to_s
-              - unless question.title.blank? 
-                span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
-                  == question.title
-
-              = render "qae_form/question_sub_title", question: question
+            = render "qae_form/question_sub_title", question: question
 
         - else
           - if question.ref || question.sub_ref
@@ -71,7 +57,7 @@
                   = help.title.html_safe
             .govuk-details__text
               == help.text
-        
+
         span.govuk-error-message
           - if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key].present? && @form_answer.validator_errors[question.hash_key].is_a?(String)
             span.govuk-visually-hidden
@@ -80,7 +66,73 @@
         - unless question.form_hint.blank?
           span.govuk-hint = question.form_hint
         = render partial: "qae_form/#{question.delegate_obj.class.name.demodulize.underscore}", object: question, as: 'question', locals: {answers: answers, attachments: attachments}
-        
+
+        / Conditional hints
+        - if question.can_have_conditional_hints?
+          = render "qae_form/conditional_hints/list", question: question
+
+- else
+  . class=question.fieldset_classes data=question.fieldset_data_hash
+    = condition_divs question do
+      .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
+        - ref = question.ref ? question.ref : question.sub_ref
+        - if question.title != "" || question.show_ref_always.present?
+          legend.govuk-label
+          label.govuk-label for="q_#{question.key}" id="q_#{question.key}_label" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
+            - if question.ref || question.sub_ref
+              span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                span.todo
+                  = ref.to_s
+            - unless question.title.blank?
+              span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
+                == question.title
+
+            = render "qae_form/question_sub_title", question: question
+
+        - else
+          - if question.ref || question.sub_ref
+            .if-js-hide
+              label.govuk-label for="q_#{question.key}" aria-label="#{ref.to_s.gsub(' ', '-')}: #{question.title}"
+                span class="steps step-#{ref.to_s.parameterize} #{'if-js-hide' if question.sub_ref && !question.display_sub_ref_on_js_form}"
+                  span.visuallyhidden
+                    = ref.to_s
+                  span.todo
+                    = ref.to_s
+
+        - if question.delegate_obj.is_a?(QAEFormBuilder::HeaderQuestion)
+          - if question.ref || question.sub_ref
+              span.question-context.question-debug.govuk-hint
+                = "Please note #{(question.ref || question.sub_ref).delete(" ")} is just a heading for the following sub-questions."
+          - if question.context
+            == question.context
+          - for help in question.help
+            == help.text
+        - else
+          - if question.context
+            span.question-context.question-debug.govuk-hint
+              == question.context
+          - for help in question.help
+            span.question-context.question-debug.govuk-hint
+              == help.text
+
+        - question.hint.each_with_index do |help, index|
+          details.govuk-details data-module='govuk-details'
+            - if help.title.present?
+              summary.govuk-details__summary
+                span.govuk-details__summary-text
+                  = help.title.html_safe
+            .govuk-details__text
+              == help.text
+
+        span.govuk-error-message
+          - if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key].present? && @form_answer.validator_errors[question.hash_key].is_a?(String)
+            span.govuk-visually-hidden
+              | Error:
+            =< @form_answer.validator_errors[question.hash_key]
+        - unless question.form_hint.blank?
+          span.govuk-hint = question.form_hint
+        = render partial: "qae_form/#{question.delegate_obj.class.name.demodulize.underscore}", object: question, as: 'question', locals: {answers: answers, attachments: attachments}
+
         / Conditional hints
         - if question.can_have_conditional_hints?
           = render "qae_form/conditional_hints/list", question: question


### PR DESCRIPTION
Aria-labels are not accepted attributes on legends, and were raising the issue below on Axe: 

<img width="1010" alt="Screenshot 2021-10-28 at 16 38 54" src="https://user-images.githubusercontent.com/84323332/139289657-e5066875-3136-4d07-be0f-5fe808b00795.png">

"Elements must only use allowed ARIA attributes" is a MUST requirement for WCAG 2.0 (A) ([ref](https://dequeuniversity.com/rules/axe/4.3/aria-allowed-attr?application=AxeChrome)). This layout of `legend`, then `label` is replicated from the QAVS question template, where some legends were empty but used to satisfy fieldset + legend relationship. @mauricioac what are you thoughts on this solution vs reworking `_question.html slim` to remove some questions from fieldsets altogether?


UPDATED: 
- Added aria-required attribute to required questions
- Removed aria-labels from legends
- Only questions listed within `legend_types` in `qae_form_builder/question.rb` are rendered as fieldsets with legend, all other questions are within divs with the same classes
- Added a dark govuk blue to meet contrast ratio against blue background on confirmation questions
- Added govuk styling to intro text in step 4