### PR TITLE
remove list of procedures from copy

### DIFF
--- a/app/views/account_mailers/notify_shortlisted_mailer/notify.text.erb
+++ b/app/views/account_mailers/notify_shortlisted_mailer/notify.text.erb
@@ -12,16 +12,16 @@ Please follow the following steps:
      <%= users_form_answer_audit_certificate_url(@form_answer) %>
   2. We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
   3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
-  4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
-  5. Log in and upload the External Accountant's Report as well as the accompanying list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
+  4. Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report.
+  5. Log in and upload the External Accountant's Report to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
      <%= users_form_answer_audit_certificate_url(@form_answer) %>
 
 
 Please note:
 
-  1. The External Accountants Report and the accompanying list of procedures document must be submitted by noon on <%= @deadline_date %>. We cannot extend this deadline.
+  1. The External Accountants Report must be submitted by noon on <%= @deadline_date %>. We cannot extend this deadline.
   2. Failure to provide this return on time will mean we do not have sufficient information to complete the assessment of your application, and it will not be considered at the next stage.
-  3. Do not make any public announcement of your shortlisted status as the assessment process is ongoing, and reaching this stage is not a guarantee of success.
+  3. Please do not make any public announcement of your shortlisted status now or at any time in the future. The assessment process is ongoing, and reaching this stage is not a guarantee of success.
 
 
 Furthermore, as stipulated in (Section F4 Confirmation of Entry) on the application, the Queen's Awards Office will undertake due diligence checks with a range of government departments, agencies and public bodies. If you require further information on this, please contact us.

--- a/app/views/account_mailers/notify_shortlisted_mailer/preview/notify.html.slim
+++ b/app/views/account_mailers/notify_shortlisted_mailer/preview/notify.html.slim
@@ -25,10 +25,10 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | 3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 4. Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
+  | 4. Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 5. Log in and upload the External Accountant's Report as well as the accompanying list of procedures document to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>
+  | 5. Log in and upload the External Accountant's Report to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>
   = link_to(users_form_answer_audit_certificate_url(@form_answer), users_form_answer_audit_certificate_url(@form_answer))
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
@@ -41,7 +41,7 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | 2. Failure to provide this return on time will mean we do not have sufficient information to complete the assessment of your application, and it will not be considered at the next stage.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 3. Do not make any public announcement of your shortlisted status as the assessment process is ongoing, and reaching this stage is not a guarantee of success.
+  | 3. Please do not make any public announcement of your shortlisted status now or at any time in the future. The assessment process is ongoing, and reaching this stage is not a guarantee of success.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | Furthermore, as stipulated in (Section F4 Confirmation of Entry) on the application, the Queen's Awards Office will undertake due diligence checks with a range of government departments, agencies and public bodies. If you require further information on this, please contact us.

--- a/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
@@ -14,7 +14,7 @@ p
     li Follow the "Verification of Commercial Figures" link next to your Shortlisted entries below to download the External Accountant's Report form.
     li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
     li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
-    li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report.
+    li Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report.
     li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
 
 p Please note, we are unable to accept late reports due to the strict assessment and judging timetable.

--- a/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
@@ -13,9 +13,9 @@ p
   ol
     li Follow the "Verification of Commercial Figures" link next to your Shortlisted entries below to download the External Accountant's Report form.
     li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
-    li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.revisions, you have to sign the Applicant's Management's Statement section in the report.
-    li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
-    li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report as well as the accompanying list of procedures document, provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
+    li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
+    li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report.
+    li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
 
 p Please note, we are unable to accept late reports due to the strict assessment and judging timetable.
 

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -17,8 +17,8 @@ header.page-header.group class=('page-header-wider')
             li = link_to("Download the External Accountant's Report form.", users_form_answer_audit_certificate_url(form_answer, format: :pdf))
             li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
             li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.revisions, you have to sign the Applicant's Management's Statement section in the report.
-            li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report. Additionally, the accountant will give you a document that lists the procedures that they have performed to verify the figures. Please note, there is no template for the list of procedures document - accountants can use their preferred format for it.
-            li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report as well as the accompanying list of procedures document, provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
+            li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report.
+            li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
       br
 
       = render "users/audit_certificates/upload_block", award: form_answer,

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -23,8 +23,6 @@ header.page-header.group class=('page-header-wider')
 
       = render "users/audit_certificates/upload_block", award: form_answer,
                                                         cert_exists: cert_exists
-      = render "users/list_of_procedures/upload_block", award: form_answer,
-                                                        list_exists: list_exists
 
       footer
         nav.pagination.no-border aria-label="Pagination" role="navigation"

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -1,7 +1,6 @@
 - title "Verification of Commercial Figures"
 
 - cert_exists = form_answer.audit_certificate.present? && form_answer.audit_certificate.persisted?
-- list_exists = form_answer.list_of_procedure.present? && form_answer.list_of_procedure.persisted?
 
 header.page-header.group class=('page-header-wider')
   div

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -15,7 +15,7 @@ header.page-header.group class=('page-header-wider')
           ol
             li = link_to("Download the External Accountant's Report form.", users_form_answer_audit_certificate_url(form_answer, format: :pdf))
             li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
-            li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.revisions, you have to sign the Applicant's Management's Statement section in the report.
+            li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
             li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report.
             li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
       br

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -16,7 +16,7 @@ header.page-header.group class=('page-header-wider')
             li = link_to("Download the External Accountant's Report form.", users_form_answer_audit_certificate_url(form_answer, format: :pdf))
             li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
             li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
-            li Once you make the revisions (if any), the accountant will perform relevant procedures and will return the completed External Accountant's Report.
+            li Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report.
             li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report provided by the accountant, by <strong>noon on #{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_date}</strong>.".html_safe
       br
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,7 +141,7 @@ en:
     buckingham_palace_confirm_press_book_notes: Press Book Entry confirmation due by
     buckingham_palace_reception_attendee_information_due_by: Buckingham Palace reception attendee information due by
     buckingham_palace_attendees_invite: Buckingham Palace Reception on
-    audit_certificates: Verification of Commercial Figures (External Accountant's Report & list of procedures) due by
+    audit_certificates: Verification of Commercial Figures (External Accountant's Report) due by
 
   deadline_help_messages:
     award_year_switch: "This date marks the start of the new award year, and will update the website accordingly. Users will not yet be able to start any applications"
@@ -184,8 +184,8 @@ en:
     buckingham_palace_invite: "WINNERS : Buckingham Palace Invite - to heads of winning organisations only."
     unsuccessful_notification: "UNSUCCESSFUL: Email notification to unsuccessful Business categories Registered Account holder."
     unsuccessful_ep_notification: "UNSUCCESSFUL: Email notification of unsuccessful QAEP nominations."
-    shortlisted_notifier: "SHORTLISTED : Email notifying shortlisted applicants of their success, including Verification of Commercial Figures (External Accountant's Report & list of procedures) instructions."
-    shortlisted_audit_certificate_reminder: "SHORTLISTED : Reminder to submit Verification of Commercial Figures (External Accountant's Report & list of procedures) for shortlisted applicants who have not yet done so."
+    shortlisted_notifier: "SHORTLISTED : Email notifying shortlisted applicants of their success, including Verification of Commercial Figures (External Accountant's Report) instructions."
+    shortlisted_audit_certificate_reminder: "SHORTLISTED : Reminder to submit Verification of Commercial Figures (External Accountant's Report) for shortlisted applicants who have not yet done so."
     not_shortlisted_notifier: "NOT SHORTLISTED : Email notifying unsuccessful applicants."
 
   custom_login_messages:


### PR DESCRIPTION
removes references to the List of Procedures which will not form part of the verification of commercial figures in the shortlisted stage this year.
https://app.asana.com/0/1200504523179343/1201302850200796

## Admin settings
- updates mailer and mail preview copy
<img width="862" alt="Screenshot 2021-11-02 at 09 41 01" src="https://user-images.githubusercontent.com/65811538/139823074-f1255a7d-6226-4ad5-940d-42e959b42963.png">

- updates settings page to remove list of procedures from headers and help copy
<img width="1198" alt="Screenshot 2021-11-02 at 09 40 44" src="https://user-images.githubusercontent.com/65811538/139823163-a144c616-2e8b-45a2-a1ce-aa822ab8c3d9.png">

## Users verification of commercial figures
- removes list of procedures from the verification of commercial figures steps
- removes the list of procedures upload button
<img width="781" alt="Screenshot 2021-11-02 at 09 40 16" src="https://user-images.githubusercontent.com/65811538/139823244-a05a8c74-6f55-44b8-b3c4-69b4b892cd0c.png">

## Users shortlisted dashboard
- removes list of procedures from the verification of commercial figures step
<img width="1075" alt="Screenshot 2021-11-02 at 09 39 43" src="https://user-images.githubusercontent.com/65811538/139823511-5f2c512b-03da-4842-8827-35d25d4741ff.png">
s
