### PR TITLE
Add aria-describedby to inputs where error message appears

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -20,25 +20,22 @@ window.FormValidation =
 
   addErrorMessage: (question, message) ->
     @appendMessage(question, message)
+    @addAriaDescribedByToInput(question)
     @addErrorClass(question)
-    @addErrorAriaLabel(question)
-    @addAriaInvalid(question)
 
     @validates = false
 
   appendMessage: (container, message) ->
     container.find(".govuk-error-message").first().append(message)
-    console.log(container)
     @validates = false
 
-  addErrorAriaLabel: (container, message) ->
-    input = container.find("textarea, select, input").attr('name')
-    container.find(".govuk-error-message").first().attr("aria-describedby", input);
-    @validates = false
-
-  addAriaInvalid: (container) ->
-    container.find("textarea, select, input").attr("aria-invalid", "true")
-    @validates = false
+  addAriaDescribedByToInput: (container, message) ->
+    input = container.find('input,textarea,select').filter(':visible')
+    input_id = input.attr('id')
+    error = container.find(".govuk-error-message").first()
+    error.attr("id", "error_for_#{input_id}");
+    error_id = error.attr('id')
+    input.attr("aria-describedby", error_id);
 
   addErrorClass: (container) ->
     container.addClass("govuk-form-group--error")

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -18,6 +18,9 @@ window.FormValidation =
       container.closest(".question-block").find(".govuk-error-message").empty()
     container.closest(".govuk-form-group--error").removeClass("govuk-form-group--error")
 
+  clearAriaDescribedby: (container) ->
+    container.closest('input,textarea,select').filter(':visible').removeAttr("aria-describedby")
+
   addErrorMessage: (question, message) ->
     @appendMessage(question, message)
     @addAriaDescribedByToInput(question)
@@ -524,6 +527,7 @@ window.FormValidation =
 
     $(document).on "change", ".question-block input, .question-block select, .question-block textarea", ->
       self.clearErrors $(this)
+      self.clearAriaDescribedby $(this)
       self.validateIndividualQuestion($(@).closest(".question-block"), $(@))
 
   validateIndividualQuestion: (question, triggeringElement) ->

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -21,11 +21,23 @@ window.FormValidation =
   addErrorMessage: (question, message) ->
     @appendMessage(question, message)
     @addErrorClass(question)
+    @addErrorAriaLabel(question)
+    @addAriaInvalid(question)
 
     @validates = false
 
   appendMessage: (container, message) ->
     container.find(".govuk-error-message").first().append(message)
+    console.log(container)
+    @validates = false
+
+  addErrorAriaLabel: (container, message) ->
+    input = container.find("textarea, select, input").attr('name')
+    container.find(".govuk-error-message").first().attr("aria-describedby", input);
+    @validates = false
+
+  addAriaInvalid: (container) ->
+    container.find("textarea, select, input").attr("aria-invalid", "true")
     @validates = false
 
   addErrorClass: (container) ->


### PR DESCRIPTION
Card: https://app.asana.com/0/1200504523179345/1200504476655848

- Assigns each error message a unique id
- Assigns each input with an error message an aria-describedby that references the error's id

<img width="877" alt="Screenshot 2021-11-03 at 10 33 51" src="https://user-images.githubusercontent.com/84323332/140045490-775d44a2-baf7-4d2d-8a55-cacc93f1444d.png">

Updated:
Removes aria-describedby when error is cleared
<img width="753" alt="Screenshot 2021-11-03 at 13 29 17" src="https://user-images.githubusercontent.com/84323332/140069159-e3c91376-1271-4175-84b4-39674331515a.png">

Adds aria-describedby when error appears
<img width="806" alt="Screenshot 2021-11-03 at 13 29 26" src="https://user-images.githubusercontent.com/84323332/140069291-43f0173c-9d6a-4e6b-b860-df1681488401.png">
