### PR TITLE
🔧 replaces attach button

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -162,6 +162,8 @@ ready = ->
 
           $("#audit-certificate-buffer").empty()
 
+    moveAttachDocumentButton()
+
   $(document).on "click", ".js-attachment-form .btn-cancel", (e) ->
     e.preventDefault()
     $(this).closest(".sidebar-section").removeClass("show-attachment-form")


### PR DESCRIPTION
- reverts deleted javascript call for button to attach documents

<img width="345" alt="Screenshot 2021-11-04 at 13 23 34" src="https://user-images.githubusercontent.com/65811538/140321084-0f50d913-7c9c-4f7c-9160-3b2279e02767.png">
