### PR TITLE
New section_info attribute to questions and reverts head_of_business back to multiple questions

### DIFF
--- a/app/forms/award_years/v2022/innovation/innovation_step1.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step1.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def innovation_step1
       @innovation_step1 ||= proc do
         header :company_information_header, "" do
+          section_info
           context %(
             <h3 class='govuk-heading-m'>About this section</h3>
             <p class='govuk-body'>

--- a/app/forms/award_years/v2022/innovation/innovation_step6.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step6.rb
@@ -32,6 +32,7 @@ class AwardYears::V2022::QAEForms
           classes "sub-question"
           style "large"
           required
+          type "email"
         end
 
         # TODO Pull in info for A13

--- a/app/forms/award_years/v2022/innovation/innovation_step6.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step6.rb
@@ -6,15 +6,32 @@ class AwardYears::V2022::QAEForms
           ref "F 1"
         end
 
+        text :head_of_bussines_title, "Title" do
+          required
+          classes "sub-question"
+          style "tiny"
+        end
+
         head_of_business :head_of_business, "" do
           sub_fields([
-            { title: "Title" },
             { first_name: "First name" },
             { last_name: "Last name" },
-            { honours: "Personal Honours" },
-            { job_title: "Job title / role in the organisation" },
-            { email: "Email address" }
+            { honours: "Personal Honours" }
           ])
+        end
+
+        text :head_job_title, "Job title/role in the organisation" do
+          classes "sub-question"
+          required
+          form_hint %(
+            e.g. CEO, Managing Director, Founder
+          )
+        end
+
+        text :head_email, "Email address" do
+          classes "sub-question"
+          style "large"
+          required
         end
 
         # TODO Pull in info for A13

--- a/app/forms/award_years/v2022/international_trade/international_trade_step1.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step1.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def trade_step1
       @trade_step1 ||= proc do
         header :company_information_header, "" do
+          section_info
           context %(
             <h3 class='govuk-heading-m'>About this section</h3>
             <p class='govuk-body'>

--- a/app/forms/award_years/v2022/international_trade/international_trade_step6.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step6.rb
@@ -14,7 +14,6 @@ class AwardYears::V2022::QAEForms
 
         head_of_business :head_of_business, "" do
           sub_fields([
-            { title: "Title" },
             { first_name: "First name" },
             { last_name: "Last name" },
             { honours: "Personal Honours" }

--- a/app/forms/award_years/v2022/international_trade/international_trade_step6.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step6.rb
@@ -6,15 +6,33 @@ class AwardYears::V2022::QAEForms
           ref "F 1"
         end
 
+        text :head_of_bussines_title, "Title" do
+          required
+          classes "sub-question"
+          style "tiny"
+        end
+
         head_of_business :head_of_business, "" do
           sub_fields([
             { title: "Title" },
             { first_name: "First name" },
             { last_name: "Last name" },
-            { honours: "Personal Honours" },
-            { job_title: "Job title / role in the organisation" },
-            { email: "Email address" }
+            { honours: "Personal Honours" }
           ])
+        end
+
+        text :head_job_title, "Job title / role in the organisation" do
+          classes "sub-question"
+          required
+          form_hint %(
+            e.g. CEO, Managing Director, Founder
+          )
+        end
+
+        text :head_email, "Email address" do
+          classes "sub-question"
+          style "large"
+          required
         end
 
         confirm :confirmation_of_consent, "Confirmation of consent" do

--- a/app/forms/award_years/v2022/international_trade/international_trade_step6.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step6.rb
@@ -32,6 +32,7 @@ class AwardYears::V2022::QAEForms
           classes "sub-question"
           style "large"
           required
+          type "email"
         end
 
         confirm :confirmation_of_consent, "Confirmation of consent" do

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step1.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step1.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def mobility_step1
       @mobility_step1 ||= proc do
         header :company_information_header, "" do
+          section_info
           context %(
             <h3 class='govuk-heading-m'>About this section</h3>
             <p class='govuk-body'>

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step6.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step6.rb
@@ -14,7 +14,6 @@ class AwardYears::V2022::QAEForms
 
         head_of_business :head_of_business, "" do
           sub_fields([
-            { title: "Title" },
             { first_name: "First name" },
             { last_name: "Last name" },
             { honours: "Personal Honours" }

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step6.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step6.rb
@@ -6,15 +6,33 @@ class AwardYears::V2022::QAEForms
           ref "F 1"
         end
 
+        text :head_of_bussines_title, "Title" do
+          required
+          classes "sub-question"
+          style "tiny"
+        end
+
         head_of_business :head_of_business, "" do
           sub_fields([
             { title: "Title" },
             { first_name: "First name" },
             { last_name: "Last name" },
-            { honours: "Personal Honours" },
-            { job_title: "Job title / role in the organisation" },
-            { email: "Email address" }
+            { honours: "Personal Honours" }
           ])
+        end
+
+        text :head_job_title, "Job title / role in the organisation" do
+          classes "sub-question"
+          required
+          form_hint %(
+            e.g. CEO, Managing Director, Founder
+          )
+        end
+
+        text :head_email, "Email address" do
+          classes "sub-question"
+          style "large"
+          required
         end
 
         confirm :confirmation_of_consent, "Confirmation of consent" do

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step6.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step6.rb
@@ -32,6 +32,7 @@ class AwardYears::V2022::QAEForms
           classes "sub-question"
           style "large"
           required
+          type "email"
         end
 
         confirm :confirmation_of_consent, "Confirmation of consent" do

--- a/app/forms/award_years/v2022/sustainable_development/sustainable_development_step1.rb
+++ b/app/forms/award_years/v2022/sustainable_development/sustainable_development_step1.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def development_step1
       @development_step1 ||= proc do
         header :company_information_header, "" do
+          section_info
           context %(
             <p class='govuk-body'>
               We need some essential information about your organisation so that we can undertake due diligence checks with various agencies if your application is shortlisted.

--- a/app/forms/award_years/v2022/sustainable_development/sustainable_development_step5.rb
+++ b/app/forms/award_years/v2022/sustainable_development/sustainable_development_step5.rb
@@ -32,6 +32,7 @@ class AwardYears::V2022::QAEForms
           classes "sub-question"
           style "large"
           required
+          type "email"
         end
 
         confirm :confirmation_of_consent, "Confirmation of consent" do

--- a/app/forms/award_years/v2022/sustainable_development/sustainable_development_step5.rb
+++ b/app/forms/award_years/v2022/sustainable_development/sustainable_development_step5.rb
@@ -6,15 +6,32 @@ class AwardYears::V2022::QAEForms
           ref "E 1"
         end
 
+        text :head_of_bussines_title, "Title" do
+          required
+          classes "sub-question"
+          style "tiny"
+        end
+
         head_of_business :head_of_business, "" do
           sub_fields([
-            { title: "Title" },
             { first_name: "First name" },
             { last_name: "Last name" },
-            { honours: "Personal Honours" },
-            { job_title: "Job title / role in the organisation" },
-            { email: "Email address" }
+            { honours: "Personal Honours" }
           ])
+        end
+
+        text :head_job_title, "Job title/role in the organisation" do
+          classes "sub-question"
+          required
+          form_hint %(
+            e.g. CEO, Managing Director, Founder
+          )
+        end
+
+        text :head_email, "Email address" do
+          classes "sub-question"
+          style "large"
+          required
         end
 
         confirm :confirmation_of_consent, "Confirmation of consent" do

--- a/app/forms/qae_form_builder/question.rb
+++ b/app/forms/qae_form_builder/question.rb
@@ -186,6 +186,10 @@ class QAEFormBuilder
       delegate_obj.required
     end
 
+    def section_info?
+      delegate_obj.section_info
+    end
+
     def have_conditional_parent?
       delegate_obj.conditions.any?
     end
@@ -403,6 +407,10 @@ class QAEFormBuilder
       @q.required = true
     end
 
+    def section_info
+      @q.section_info = true
+    end
+
     def help title, text
       @q.help << QuestionHelp.new(title, text)
     end
@@ -480,7 +488,8 @@ class QAEFormBuilder
                   :classes,
                   :drop_condition,
                   :drop_condition_parent,
-                  :drop_block_condition
+                  :drop_block_condition,
+                  :section_info
 
     def initialize step, key, title, opts={}
       @step = step

--- a/app/views/qae_form/_head_of_business_question.html.slim
+++ b/app/views/qae_form/_head_of_business_question.html.slim
@@ -1,9 +1,4 @@
 .govuk-form-group.question-block.question-required
-  label.govuk-label for=question.input_name(suffix:'title')
-    ' Title
-  span.govuk-error-message
-  input.js-trigger-autosave.govuk-input.tiny type="text" name=question.input_name(suffix: 'title') value=question.input_value(suffix: 'title') autocomplete="off" *possible_read_only_ops id=question.input_name(suffix: 'title')
-.govuk-form-group.question-block.question-required
   label.govuk-label for=question.input_name(suffix:'first_name')
     ' First name
   span.govuk-error-message
@@ -20,15 +15,3 @@
   span.govuk-hint
     ' e.g. OBE (Not including educational qualifications or institutional memberships.)
   input.js-trigger-autosave.govuk-input.govuk-input--width-10.js-ignore-substitution type="text" name=question.input_name(suffix: 'honours') value=question.input_value(suffix: 'honours') autocomplete="off" *possible_read_only_ops id=question.input_name(suffix: 'honours')
-.govuk-form-group.question-block.question-required
-  label.govuk-label for=question.input_name(suffix:'job_title')
-    ' Job title / role in the organisation
-  span.govuk-error-message
-  span.govuk-hint
-    ' e.g. CEO, Managing Director, Founder
-  input.js-trigger-autosave.govuk-input.govuk-input--width-10.js-ignore-substitution type="text" name=question.input_name(suffix: 'job_title') value=question.input_value(suffix: 'job_title') autocomplete="off" *possible_read_only_ops id=question.input_name(suffix: 'job_title')
-.govuk-form-group.question-block.question-required
-  label.govuk-label for=question.input_name(suffix:'email')
-    ' Email address
-  span.govuk-error-message
-  input.js-trigger-autosave.govuk-input.govuk-input--width-10 type="text" name=question.input_name(suffix: 'email') value=question.input_value(suffix: 'email') autocomplete="off" *possible_read_only_ops id=question.input_name(suffix: 'email')

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -3,7 +3,7 @@
     = question.header
   - if question.header_context
     == question.header_context
-- if !question.ref && !question.sub_ref
+- if question.section_info?
   .govuk-form-group
     == question.context
 - elsif question.label_as_legend?


### PR DESCRIPTION
Previously 'About this section' text was rendered as a fieldset via `_question.html.erb`. A new conditional was added to render 'questions' without ref numbers (such as 'About this section' text) as divs with 'govuk-form-group' class. This excluded questions such as head_of_business, head_of_bussines_title,  head_job_title and head_email (which also did not have ref numbers) from rendering correctly. The condition has been updated to recognise `section_info` questions and render only these differently.

Changes to head_of_business subquestions have been reverted and will be kept as they originally were before PR #1842 
