### PR TITLE
Fixing radios in book page and upload button in verification page

### DIFF
--- a/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
+++ b/app/assets/javascripts/frontend/audit_certificates_upload.js.coffee
@@ -16,15 +16,15 @@ window.AuditCertificatesUpload =
 
     upload_started = (e, data) ->
       # Show `Uploading...`
-      form.addClass("hidden")
+      form.addClass("govuk-!-display-none")
       new_el = $("<li class='js-uploading'>")
       div = $("<div>")
       label = $("<label class='govuk-body'>").text("Uploading...")
       div.append(label)
       new_el.append(div)
       list.append(new_el)
-      list.removeClass("hidden")
-      list.find(".li-audit-upload").addClass("hidden")
+      list.removeClass("govuk-!-display-none")
+      list.find(".li-audit-upload").addClass("govuk-!-display-none")
 
     upload_done = (e, data, link) ->
       # Immediately show a link to download the uploaded file
@@ -34,22 +34,22 @@ window.AuditCertificatesUpload =
       list.find(".js-audit-certificate-title").text(filename)
       list.find(".js-audit-certificate-title").attr("download", filename)
       list.find(".js-audit-certificate-title").attr("title", filename)
-      list.removeClass("hidden")
+      list.removeClass("govuk-!-display-none")
 
       # Remove `Uploading...`
       list.find(".js-uploading").remove()
-      list.find(".li-audit-upload").removeClass("hidden")
-      list.find(".js-remove-verification-document-form").removeClass("hidden")
+      list.find(".li-audit-upload").removeClass("govuk-!-display-none")
+      list.find(".js-remove-verification-document-form").removeClass("govuk-!-display-none")
       $(".js-audit-certificate-status-message").remove()
 
     failed = (error_message) ->
       parent.find(".govuk-error-message").html(error_message)
-      list.addClass("hidden")
-      form.removeClass("hidden")
+      list.addClass("govuk-!-display-none")
+      form.removeClass("govuk-!-display-none")
 
       # Remove `Uploading...`
       list.find(".js-uploading").remove()
-      list.removeClass("hidden")
+      list.removeClass("govuk-!-display-none")
 
     success_or_error = (e, data) ->
       errors = data.result.errors

--- a/app/assets/stylesheets/frontend/attachment.scss
+++ b/app/assets/stylesheets/frontend/attachment.scss
@@ -3,6 +3,10 @@
 
 $thumbnail-width: 99px;
 
+.audit_certificate_attachment {
+  margin-bottom: 0 !important;
+}
+
 .attachment {
   position: relative;
   margin: $gutter 0;

--- a/app/views/users/audit_certificates/_form.html.slim
+++ b/app/views/users/audit_certificates/_form.html.slim
@@ -1,7 +1,7 @@
 = simple_form_for (audit_certificate || form_answer.build_audit_certificate),
                   as: :audit_certificate,
                   url: users_form_answer_audit_certificate_path(form_answer),
-                  html: {class: "qae-form audit-certificate-upload-form #{"hidden" if cert_exists}", method: :post} do |f|
+                  html: {class: "qae-form audit-certificate-upload-form #{"govuk-!-display-none" if cert_exists}", method: :post} do |f|
   .errors-container
   .clear
   span.button-add.govuk-button role="button"

--- a/app/views/users/audit_certificates/_upload_block.html.slim
+++ b/app/views/users/audit_certificates/_upload_block.html.slim
@@ -1,5 +1,5 @@
 .js-upload-wrapper data-max-attachments=1 data-form-name="audit-cert-form" data-name="audit-cert-name" data-filename="Uploaded Verification of Commercial Figures"
-  ul.js-uploaded-list.no-bullets class=("hidden" unless cert_exists)
+  ul.js-uploaded-list.no-bullets class=("govuk-!-display-none" unless cert_exists)
     li.li-audit-upload
       div
         = render "users/audit_certificates/file", cert_exists: cert_exists,

--- a/app/views/users/press_summaries/show.html.slim
+++ b/app/views/users/press_summaries/show.html.slim
@@ -32,7 +32,7 @@ div
             ul.errors-container
             .clear
             .question-group
-              = f.input :correct, as: :radio_buttons, item_wrapper_class: 'selectable', label: false
+              = f.input :correct, as: :radio_buttons, item_wrapper_class: 'govuk-radios__item', wrapper_class: 'govuk-radios govuk-radios--inline', label: false
               span.clear
 
           br


### PR DESCRIPTION
This PR fixes two things:

- radio buttons in press notes page
- upload/download/remove interaction on verification of commercial numbers page

Card: https://app.asana.com/0/1200504523179345/1200553019764968/f

---

Screenshots

![Screenshot from 2021-11-17 06-04-36](https://user-images.githubusercontent.com/758001/142177584-9c264380-65af-48f4-919f-82bd8c263921.png)
![Screenshot from 2021-11-17 06-48-43](https://user-images.githubusercontent.com/758001/142177591-cba19be3-fe8b-48c9-87af-0be2d1a1e00b.png)
