### PR TITLE
Further accessibility tweaks

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -104,6 +104,10 @@ table .ellipsis {
   color: black;
 }
 
+.paginate-links a {
+  color: $blue-link-colour;
+}
+
 .btn {
   border-radius: 0;
 

--- a/app/forms/award_years/v2022/innovation/innovation_step1.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step1.rb
@@ -135,7 +135,11 @@ class AwardYears::V2022::QAEForms
 
         header :business_division_header, "" do
           classes "application-notice help-notice"
-          form_hint "Where we refer to 'your organisation' in the form, enter the details of your division, branch or subsidiary."
+          context %(
+            <p class="govuk-body">
+              "Where we refer to 'your organisation' in the form, enter the details of your division, branch or subsidiary."
+            </p>
+          )
           conditional :applying_for, "division branch subsidiary"
         end
 

--- a/app/forms/award_years/v2022/innovation/innovation_step2.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step2.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def innovation_step2
       @innovation_step2 ||= proc do
         header :innovation_b_section_header, "" do
+          section_info
           context %(
             <h3 class='govuk-heading-m'>About this section</h3>
             <p class='govuk-body'>

--- a/app/forms/award_years/v2022/innovation/innovation_step3.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step3.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def innovation_step3
       @innovation_step3 ||= proc do
         header :commercial_success_info_block, "" do
+          section_info
           context %(
             <h3 class="govuk-heading-m">About this section</h3>
             <p class="govuk-body">

--- a/app/forms/award_years/v2022/innovation/innovation_step4.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step4.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def innovation_step4
       @innovation_step4 ||= proc do
         header :complete_now_header, "" do
+          section_info
           context %(
             <h3 class="govuk-heading-m">About this section</h3>
             <p class="govuk-body">

--- a/app/forms/award_years/v2022/international_trade/international_trade_step1.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step1.rb
@@ -135,7 +135,11 @@ class AwardYears::V2022::QAEForms
 
         header :business_division_header, "" do
           classes "application-notice help-notice"
-          form_hint "Where the form refers to your organisation, enter the details of your division, branch or subsidiary."
+          context %(
+            <p class="govuk-body">
+              "Where the form refers to your organisation, enter the details of your division, branch or subsidiary."
+            </p>
+          )
           conditional :applying_for, "division branch subsidiary"
         end
 

--- a/app/forms/award_years/v2022/international_trade/international_trade_step2.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step2.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def trade_step2
       @trade_step2 ||= proc do
         header :your_internation_trade_header, "" do
+          section_info
           context %(
             <h3 class='govuk-heading-m'>About this section</h3>
             <p class='govuk-body'>

--- a/app/forms/award_years/v2022/international_trade/international_trade_step3.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step3.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def trade_step3
       @trade_step3 ||= proc do
         header :commercial_success_info_block, "" do
+          section_info
           context %(
             <h3 class="govuk-heading-m">About this section</h3>
             <p class="govuk-body">

--- a/app/forms/award_years/v2022/international_trade/international_trade_step4.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step4.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def trade_step4
       @trade_step4 ||= proc do
         header :complete_now_header, "" do
+          section_info
           context %(
             <h3 class="govuk-heading-m">About this section</h3>
             <p class="govuk-body">

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step2.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step2.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def mobility_step2
       @mobility_step2 ||= proc do
         header :mobility_b_section_header, "" do
+          section_info
           context %(
             <h3 class='govuk-heading-m'>About this section</h3>
             <p class='govuk-body'>

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step3.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step3.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def mobility_step3
       @mobility_step3 ||= proc do
         header :commercial_success_info_block, "" do
+          section_info
           context %(
             <h3 class="govuk-heading-m">About this section</h3>
             <p class="govuk-body">

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step4.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step4.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def mobility_step4
       @mobility_step4 ||= proc do
         header :complete_now_header, "" do
+          section_info
           context %(
             <h3 class="govuk-heading-m">About this section</h3>
             <p class="govuk-body">

--- a/app/forms/award_years/v2022/sustainable_development/sustainable_development_step2.rb
+++ b/app/forms/award_years/v2022/sustainable_development/sustainable_development_step2.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def development_step2
       @development_step2 ||= proc do
         header :development_b_section_header, "" do
+          section_info
           context %(
             <h3 class='govuk-heading-m'>About this section</h3>
             <p class='govuk-body'>

--- a/app/forms/award_years/v2022/sustainable_development/sustainable_development_step3.rb
+++ b/app/forms/award_years/v2022/sustainable_development/sustainable_development_step3.rb
@@ -4,6 +4,7 @@ class AwardYears::V2022::QAEForms
     def development_step3
       @development_step3 ||= proc do
         header :commercial_success_info_block, "" do
+          section_info
           context %(
             <h3 class="govuk-heading-m">About this section</h3>
             <p class="govuk-body">

--- a/app/views/admin/audit_logs/index.html.slim
+++ b/app/views/admin/audit_logs/index.html.slim
@@ -41,6 +41,6 @@
 
 
   .row
-    .col-xs-12.text-right
+    .col-xs-12.text-right.paginate-links
       = paginate @audit_logs
       .clear

--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -27,6 +27,6 @@ h1.admin-page-heading
     .col-xs-12
       = render("admin/form_answers/list_components/table", f: f)
   .row
-    .col-xs-12.text-right
+    .col-xs-12.text-right.paginate-links
       = paginate @form_answers
       .clear

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -27,6 +27,6 @@
     = render 'list', resources: @resources, f: f
 
     .row
-      .col-xs-12.text-right
+      .col-xs-12.text-right.paginate-links
         = paginate @resources
         .clear

--- a/app/views/admin/users_feedbacks/show.html.slim
+++ b/app/views/admin/users_feedbacks/show.html.slim
@@ -42,6 +42,6 @@
                       = feedback.comment
 
   .row
-    .col-xs-12.text-right
+    .col-xs-12.text-right.paginate-links
       = paginate @feedbacks
       .clear

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -79,6 +79,6 @@ h1.admin-page-heading
               = sort_link f, "Last updated", @search, :audit_updated_at, disabled: @search.query?
           = render(partial: "assessor/form_answers/list_body")
   .row
-  .col-xs-12.text-right
+  .col-xs-12.text-right.paginate-links
     = paginate @form_answers
     .clear

--- a/app/views/content_only/past_applications/_unsuccessful.html.slim
+++ b/app/views/content_only/past_applications/_unsuccessful.html.slim
@@ -30,7 +30,7 @@
       - elsif award.not_submitted?
         p.govuk-body The application was not submitted on time.
       - else
-        h4 Feedback
+        h4.govuk-heading-s Feedback
         - if award.feedback.try(:submitted?)
           p.govuk-body
             ' Please

--- a/app/views/content_only/past_applications/_winners.html.slim
+++ b/app/views/content_only/past_applications/_winners.html.slim
@@ -51,7 +51,7 @@
 br
 .container-split
   .content-right
-    p
+    p.govuk-body
       = link_to "Visit Winners' Resources",
                 award_winners_section_path(award_year_id: award_year.id)
       '  to download media for websites and advertisements.

--- a/app/views/form_award_eligibilities/questions/_any_dips_over_the_last_three_years.html.slim
+++ b/app/views/form_award_eligibilities/questions/_any_dips_over_the_last_three_years.html.slim
@@ -6,5 +6,5 @@
   ul.govuk-hint
     li Outstanding year on year growth in the last 3 years with no dips
     li Continuous year on year growth in the last 6 years with no dips
-  = f.input :any_dips_over_the_last_three_years, as: :radio_buttons, wrapper_html: { role: "radiogroup", id: "eligibility_#{question}", "aria-labelledby" => "eligibility_#{question}_label" }, label_html: { class: 'visuallyhidden' }
+  = f.input :any_dips_over_the_last_three_years, as: :radio_buttons, wrapper_html: { role: "radiogroup", id: "eligibility_#{question}", "aria-labelledby" => "eligibility_#{question}_label" }, label: false
 span.clear

--- a/app/views/form_award_eligibilities/questions/_any_dips_over_the_last_three_years.html.slim
+++ b/app/views/form_award_eligibilities/questions/_any_dips_over_the_last_three_years.html.slim
@@ -6,5 +6,5 @@
   ul.govuk-hint
     li Outstanding year on year growth in the last 3 years with no dips
     li Continuous year on year growth in the last 6 years with no dips
-  = f.input :any_dips_over_the_last_three_years, as: :radio_buttons, wrapper_html: { role: "radiogroup", id: "eligibility_#{question}", "aria-labelledby" => "eligibility_#{question}_label" }
+  = f.input :any_dips_over_the_last_three_years, as: :radio_buttons, wrapper_html: { role: "radiogroup", id: "eligibility_#{question}", "aria-labelledby" => "eligibility_#{question}_label" }, label_html: { class: 'visuallyhidden' }
 span.clear

--- a/app/views/users/press_summaries/show.html.slim
+++ b/app/views/users/press_summaries/show.html.slim
@@ -28,11 +28,10 @@ div
 
         = simple_form_for @press_summary, url: users_form_answer_press_summary_path(form_answer, token: params[:token]), html: { class: "qae-form" } do |f|
           .question-block.sub-question.js-press-comment-correct
-            h2 = f.label :correct, label: "Do you have any comments on the Press Book Notes or organisation details?"
             ul.errors-container
             .clear
             .question-group
-              = f.input :correct, as: :radio_buttons, item_wrapper_class: 'govuk-radios__item', wrapper_class: 'govuk-radios govuk-radios--inline', label: false
+              = f.input :correct, as: :radio_buttons, label: 'Do you have any comments on the Press Book Notes or organisation details?', item_wrapper_class: 'govuk-radios__item', wrapper_class: 'govuk-radios govuk-radios--inline', label_html: { class: 'govuk-label--s govuk-!-font-weight-regular' }
               span.clear
 
           br

--- a/app/views/users/press_summaries/show.html.slim
+++ b/app/views/users/press_summaries/show.html.slim
@@ -61,14 +61,13 @@ div
           footer
             nav.pagination.no-border aria-label="Pagination" role="navigation"
               ul.group
-                li.previous.previous-alternate
-                  = link_to dashboard_path, class: "govuk-back-link govuk-!-font-size-19"
-                    span.pagination-label Go back to previous page
                 li.submit
-                  = f.submit "Save", class: "govuk-button save-press-summary-button",
+                  = f.submit "Save", class: "govuk-button govuk-button--secondary",
                                      name: "save"
                   span.press-summary-action-devider.govuk-body
-                    ' OR
+
                   = f.submit "Submit", class: "govuk-button",
                                        rel: "next",
                                        name: "submit"
+              = link_to dashboard_path, class: "govuk-back-link govuk-!-font-size-19"
+                span.pagination-label Go back to previous page

--- a/app/views/users/press_summaries/show.html.slim
+++ b/app/views/users/press_summaries/show.html.slim
@@ -37,10 +37,8 @@ div
           br
 
           .question-block.regular-question.js-press-comment-feeback
-            h2
-              = f.label :comment, label: "How are the Press Book Notes and/or organisation details factually incorrect"
             .question-group
-              = f.input :comment, as: :text, input_html: { class: "js-char-count", rows: "5", data: { word_max: "300" } }, label: false
+              = f.input :comment, as: :text, label: "How are the Press Book Notes and/or organisation details factually incorrect", input_html: { class: "js-char-count", rows: "5", data: { word_max: "300" } }
               .clear
 
           br


### PR DESCRIPTION
Card: https://app.asana.com/0/1200504523179345/1200504476655848

- Changed colour of pagination links (1, 2, Next page, etc) to meet contrast ratio criteria
<img width="474" alt="Screenshot 2021-11-19 at 09 23 25" src="https://user-images.githubusercontent.com/84323332/142598415-0292b915-e5dc-4fc4-8ef9-3138dc8414d5.png">

- Correctly associated labels with inputs on press summary page (radio buttons and text input)
- Added govuk styling classes to past applications page
- Added section_info attribute to remaining form sections (so these aren't rendered as fieldsets)
- Styled press summaries footer buttons to match form footer buttons
<img width="677" alt="Screenshot 2021-11-18 at 14 41 26" src="https://user-images.githubusercontent.com/84323332/142597992-953ed9cb-64ca-4638-ab3d-510aad8832e2.png">

- Hid additional label on any_dips_over_the_last_three_years question
<img width="909" alt="Screenshot 2021-11-19 at 09 21 38" src="https://user-images.githubusercontent.com/84323332/142598196-735971db-e152-46b4-92e2-569ba69e923e.png">

- Changed A1 form_hint to context as per main branch (the text overlaps with the "!" icon when form_hint is used)
<img width="637" alt="Screenshot 2021-11-19 at 09 19 37" src="https://user-images.githubusercontent.com/84323332/142597924-bc8aaf6d-456b-476b-9fc7-fa0c64efb0c4.png">
