### PR TITLE
🐛  adds target to pdf download link

### DIFF
--- a/app/views/qae_form/_pdf_link.html.slim
+++ b/app/views/qae_form/_pdf_link.html.slim
@@ -1,6 +1,6 @@
 - unless QAE.hide_pdf_links?
   .download-pdf-link
-    = link_to users_form_answer_path(@form_answer, format: :pdf), class: 'govuk-link'
+    = link_to users_form_answer_path(@form_answer, format: :pdf), class: 'govuk-link', target: '_blank'
       = render "content_only/download_icon"
       - if @form_answer.award_type == "promotion"
         ' Download your nomination


### PR DESCRIPTION
UX15 https://docs.google.com/spreadsheets/d/1lUy4DPUmkua7tBmny0IgyGd59rDU6uEVBP6pUfFJa7w/edit#gid=524629233

When users have unsaved changes in an application and try to download the pdf version, a pop up is shown for the user to confirm to leave the site. As the users stays on the same form page, this can cause confusion. A target is added to the link to open the pdf in a new browser tab so users will not be leaving the form page.