### PR TITLE
Corrected missing errors on C 2.2 Social Mobility

### DIFF
--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step3.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step3.rb
@@ -76,7 +76,7 @@ class AwardYears::V2022::QAEForms
         end
 
         one_option_by_years_label :financial_year_changed_dates, "Enter your year-end dates for each financial year." do
-          classes "sub-question"
+          classes "sub-question one-option-by-years"
           sub_ref "C 2.2"
           required
           context %(


### PR DESCRIPTION
Added 'one-option-by-years' class to C2.2 question on social mobility form

![image](https://user-images.githubusercontent.com/84323332/142829307-bca25bd9-1c33-4ddd-9d6c-f1e856292d3a.png)
