### PR TITLE
Changed heading and button text on edit password page depending on user type

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -7,8 +7,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
       token, encoded_token = Devise.token_generator.generate(resource.class, :reset_password_token)
       resource.update(reset_password_token: encoded_token,
                       reset_password_sent_at: Time.current)
-
-      edit_user_password_path(reset_password_token: token)
+      edit_user_password_path(reset_password_token: token, locals: { password_not_set: true })
     else
       super(resource_name, resource)
     end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -7,6 +7,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
       token, encoded_token = Devise.token_generator.generate(resource.class, :reset_password_token)
       resource.update(reset_password_token: encoded_token,
                       reset_password_sent_at: Time.current)
+
       edit_user_password_path(reset_password_token: token, locals: { password_not_set: true })
     else
       super(resource_name, resource)

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -5,8 +5,8 @@
 .article-related-positioning-container
   header.page-header.group
     div
-      h1 Change your password
-
+      h1
+        = params[:locals] && params[:locals][:password_not_set] ? "Create a password" : "Change your password"
   .article-container.group
     article.group role="article"
       .inner
@@ -57,6 +57,6 @@
                     p#password-confirmation-match The confirmation must match the password
 
           .form-actions
-            = f.button :submit, "Change my password", class: "button large"
+            = f.button :submit, class: "button large", params[:locals] && params[:locals][:password_not_set] ? "Create a password" : "Change your password"
 
         = render "users/shared/links"

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -57,6 +57,6 @@
                     p#password-confirmation-match The confirmation must match the password
 
           .form-actions
-            = f.button :submit, class: "button large", params[:locals] && params[:locals][:password_not_set] ? "Create a password" : "Change your password"
+            = f.button :submit, params[:locals] && params[:locals][:password_not_set] ? "Create a password" : "Change your password", class: "button large"
 
         = render "users/shared/links"


### PR DESCRIPTION
Card: https://app.asana.com/0/1200504523179345/1200504476655848

- Passed in `password_not_set` variable from confirmations_controller to differentiate between users directed to the same page from the passwords_controller edit method
- Added ternary operator to view to display different heading and button text accordingly 