### PR TITLE
Hot fix on contact details styling

### DIFF
--- a/app/forms/award_years/v2022/innovation/innovation_step6.rb
+++ b/app/forms/award_years/v2022/innovation/innovation_step6.rb
@@ -9,6 +9,7 @@ class AwardYears::V2022::QAEForms
         text :head_of_bussines_title, "Title" do
           required
           classes "sub-question"
+          excluded_header_questions
           style "tiny"
         end
 
@@ -22,6 +23,7 @@ class AwardYears::V2022::QAEForms
 
         text :head_job_title, "Job title/role in the organisation" do
           classes "sub-question"
+          excluded_header_questions
           required
           form_hint %(
             e.g. CEO, Managing Director, Founder
@@ -30,6 +32,7 @@ class AwardYears::V2022::QAEForms
 
         text :head_email, "Email address" do
           classes "sub-question"
+          excluded_header_questions
           style "large"
           required
           type "email"

--- a/app/forms/qae_form_builder/question.rb
+++ b/app/forms/qae_form_builder/question.rb
@@ -190,6 +190,10 @@ class QAEFormBuilder
       delegate_obj.section_info
     end
 
+    def excluded_header_questions?
+      delegate_obj.excluded_header_questions
+    end
+
     def have_conditional_parent?
       delegate_obj.conditions.any?
     end
@@ -411,6 +415,10 @@ class QAEFormBuilder
       @q.section_info = true
     end
 
+    def excluded_header_questions
+      @q.excluded_header_questions = true
+    end
+
     def help title, text
       @q.help << QuestionHelp.new(title, text)
     end
@@ -489,7 +497,8 @@ class QAEFormBuilder
                   :drop_condition,
                   :drop_condition_parent,
                   :drop_block_condition,
-                  :section_info
+                  :section_info,
+                  :excluded_header_questions
 
     def initialize step, key, title, opts={}
       @step = step

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -84,8 +84,12 @@
                 span.todo
                   = ref.to_s
             - unless question.title.blank?
-              span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
-                == question.title
+              - if question.excluded_header_questions?
+                span.govuk-label
+                  == question.title
+              - else
+                span class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold govuk-!-display-block"
+                  == question.title
 
             = render "qae_form/question_sub_title", question: question
 


### PR DESCRIPTION
- The fields for '_Title_', '_Job title_' and '_Email address_' were styled differently to the other fields within the 'Head of business' question because they are not subquestions.
- There is a PR that converts all 'Head of business' questions into subquestions (#1877) but it involves a lot of changes, because in addition to making them into subfields, spelling and formatting had to be corrected to '_head_of_business__[field]'. (previously '_head_of_bussines_title_' or '_head_email_')

This PR provides an alternative. Excluding questions with `excluded_header_questions` attribute from having `govuk-!-font-size-24 govuk-!-font-weight-bold` classes applied by the `_question.html.erb` template.

Before:
<img width="647" alt="Screenshot 2021-12-16 at 16 15 32" src="https://user-images.githubusercontent.com/84323332/146410030-39538bc9-ea20-4e70-89fb-45d9bd4f75e5.png">
After:
<img width="657" alt="Screenshot 2021-12-16 at 16 14 46" src="https://user-images.githubusercontent.com/84323332/146410008-ef07f117-3e27-4cba-8c89-16ba061fccca.png">