### PR TITLE
Added excluded_header_questions to other form categories

### DIFF
--- a/app/forms/award_years/v2022/international_trade/international_trade_step6.rb
+++ b/app/forms/award_years/v2022/international_trade/international_trade_step6.rb
@@ -9,6 +9,7 @@ class AwardYears::V2022::QAEForms
         text :head_of_bussines_title, "Title" do
           required
           classes "sub-question"
+          excluded_header_questions
           style "tiny"
         end
 
@@ -22,6 +23,7 @@ class AwardYears::V2022::QAEForms
 
         text :head_job_title, "Job title / role in the organisation" do
           classes "sub-question"
+          excluded_header_questions
           required
           form_hint %(
             e.g. CEO, Managing Director, Founder
@@ -30,6 +32,7 @@ class AwardYears::V2022::QAEForms
 
         text :head_email, "Email address" do
           classes "sub-question"
+          excluded_header_questions
           style "large"
           required
           type "email"

--- a/app/forms/award_years/v2022/social_mobility/social_mobility_step6.rb
+++ b/app/forms/award_years/v2022/social_mobility/social_mobility_step6.rb
@@ -9,6 +9,7 @@ class AwardYears::V2022::QAEForms
         text :head_of_bussines_title, "Title" do
           required
           classes "sub-question"
+          excluded_header_questions
           style "tiny"
         end
 
@@ -22,6 +23,7 @@ class AwardYears::V2022::QAEForms
 
         text :head_job_title, "Job title / role in the organisation" do
           classes "sub-question"
+          excluded_header_questions
           required
           form_hint %(
             e.g. CEO, Managing Director, Founder
@@ -30,6 +32,7 @@ class AwardYears::V2022::QAEForms
 
         text :head_email, "Email address" do
           classes "sub-question"
+          excluded_header_questions
           style "large"
           required
           type "email"

--- a/app/forms/award_years/v2022/sustainable_development/sustainable_development_step5.rb
+++ b/app/forms/award_years/v2022/sustainable_development/sustainable_development_step5.rb
@@ -9,6 +9,7 @@ class AwardYears::V2022::QAEForms
         text :head_of_bussines_title, "Title" do
           required
           classes "sub-question"
+          excluded_header_questions
           style "tiny"
         end
 
@@ -22,6 +23,7 @@ class AwardYears::V2022::QAEForms
 
         text :head_job_title, "Job title/role in the organisation" do
           classes "sub-question"
+          excluded_header_questions
           required
           form_hint %(
             e.g. CEO, Managing Director, Founder
@@ -30,6 +32,7 @@ class AwardYears::V2022::QAEForms
 
         text :head_email, "Email address" do
           classes "sub-question"
+          excluded_header_questions
           style "large"
           required
           type "email"


### PR DESCRIPTION
Related to PR #1930 

`excluded_header_questions` added to all other form categories as well as innovation.