### PR TITLE
🔧  fixes margins on description label

### DIFF
--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -34,8 +34,7 @@
           - if question.description
             .govuk-form-group
               label.govuk-label class="govuk-!-margin-top-5" for=question.input_name(suffix: 'description', index: idx)
-                span.label-char-count-reposition
-                  ' Description
+                ' Description
                 / (optional)
               textarea.govuk-textarea.js-char-count.js-trigger-autosave rows="2" maxlength="600" data-word-max="100" name=question.input_name(suffix: 'description', index: idx) id=question.input_name(suffix: 'description', index: idx)  *possible_read_only_ops
                 = question.input_value(suffix: 'description', index: idx)


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1xuNsQ2Ab1e-aBogkotUyJMUGl71fZRTe2uN5yQVPXGE/edit#gid=1776260699
ID 9 - the label has a margin applied which hides the label behind the textarea input field. This PR removes the class which is not needed on this label.
![Screenshot 2021-12-20 at 12 36 34](https://user-images.githubusercontent.com/65811538/146768430-699a537f-bcf9-4b98-a784-9dd6a412522a.png)

