### PR TITLE
🔧  fixes upload organisational chart feature

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -572,7 +572,7 @@ jQuery ->
 
     upload_started = (e, data) ->
       # Show `Uploading...`
-      button.addClass("visuallyhidden")
+      govuk_button.addClass("visuallyhidden")
       new_el = $("<li class='js-uploading'>")
       div = $("<div>")
       uid = '_' + Math.random().toString(36).substr(2, 9);
@@ -600,7 +600,7 @@ jQuery ->
       # Remove `Uploading...`
       list.find(".js-uploading").remove()
       list.removeClass("visuallyhidden")
-      button.removeClass("visuallyhidden")
+      govuk_button.removeClass("visuallyhidden")
 
     upload_done = (e, data, link) ->
       # Remove `Uploading...`
@@ -658,7 +658,7 @@ jQuery ->
       reindexUploadListInputs(list)
       new_el.find('input,textarea,select').filter(':visible').first().focus()
 
-    updateUploadListVisiblity(list, button, max)
+    updateUploadListVisiblity(list, govuk_button, max)
 
     if is_link
       $el.click (e) ->

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -693,7 +693,7 @@ jQuery ->
       li = $(this).closest 'li'
       list = li.closest(".js-uploaded-list")
       wrapper = list.closest(".js-upload-wrapper")
-      button = wrapper.find(".js-button-add")
+      button = wrapper.find(".button-add")
       max = wrapper.data('max-attachments')
 
       li.remove()

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -632,7 +632,7 @@ jQuery ->
             filename = data.result['original_filename']
           else
             filename = "File uploaded"
-        div = $("<div>").text(filename)
+        div = $("<div><p class='govuk-body'>#{filename}</p></div>")
 
         hidden_input = $("<input type='hidden' name='#{form_name}[#{name}][][file]' value='#{data.result['id']}' />")
 


### PR DESCRIPTION
this PR fixes some classes lost in the toolkit upgrade.
- upon adding an organisational chart file the styling was not correct. This is fixed by adding the html to the JS function adding the attachment display.
- upon adding an organisational chart file the upload button was still showing. This is fixed by adding the visually hidden class to the correct element (govuk_button instead of button).
- upon removing an organisational chart file the upload button was not showing. This is fixed by find the correct element (searching for .button_add instead of .js-button-add)