### PR TITLE
Fixing day and month validation

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -429,7 +429,7 @@ window.FormValidation =
 
     questionDay = parseInt(question.find(".innovation-day").val())
     questionMonth = parseInt(question.find(".innovation-month").val())
-    questionDate = "#{questionDay}/#{questionMonth}"
+    questionDate = "#{questionDay}/#{questionMonth}/#{moment().format('Y')}"
 
     if not @toDate(questionDate).isValid()
       @logThis(question, "validateMaxDate", "Not a valid date")


### PR DESCRIPTION
C2 question for financial end date is only day and month.
So adding an artificial year to make date validation work