### PR TITLE
Specified award year in form_answer_factory.rb, so 2023 is not generated in 'form_answer' used in specs

### DIFF
--- a/spec/factories/form_answer_factory.rb
+++ b/spec/factories/form_answer_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :form_answer do
     award_type { "trade" }
     association :user, factory: [:user, :agreed_to_be_contacted]
-    award_year_id { AwardYear.where(year: 2020).first_or_create.id }
+    award_year_id { AwardYear.where(year: 2021).first_or_create.id }
 
     trait :submitted do
       submitted_at { Time.current }

--- a/spec/factories/form_answer_factory.rb
+++ b/spec/factories/form_answer_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :form_answer do
     award_type { "trade" }
     association :user, factory: [:user, :agreed_to_be_contacted]
-    award_year_id { AwardYear.current.id }
+    award_year_id { AwardYear.where(year: 2020).first_or_create.id }
 
     trait :submitted do
       submitted_at { Time.current }


### PR DESCRIPTION
Temporary fix until we create new applications for 2023 as done in PR #1641 