### PR TITLE
👷  upgrades buildpack to version 1.8.50

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -10,7 +10,7 @@ curl -X POST \
 $SLACK_WEBHOOK
 
 # Pin ruby buildpack
-export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.46"
+export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.50"
 
 cf create-app-manifest "$CF_APP"-worker
 cf push -f "$CF_APP"-worker_manifest.yml -b $CF_BUILDPACK


### PR DESCRIPTION
- updates the deployment config to use the latest cloud foundry buildpack. Current Ruby version 2.7.4.
https://app.asana.com/0/1200504523179343/1201618493576140/f
https://github.com/cloudfoundry/ruby-buildpack/releases