### PR TITLE
👷 updates cf buildpack to 1.8.50

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -904,4 +904,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.28
+   2.3.4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Pre-requisites
 
 * Ruby 2.7.4
-* `gem install bundler -v 2.2.28`
+* `gem install bundler -v 2.3.4`
 * Rails 6.1
 * Postgresql 9.5+
 * Redis 2.8

--- a/bin/deploy
+++ b/bin/deploy
@@ -10,7 +10,7 @@ curl -X POST \
 $SLACK_WEBHOOK
 
 # Pin ruby buildpack
-export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.46"
+export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.50"
 
 cf create-app-manifest "$CF_APP"-worker
 cf push -f "$CF_APP"-worker_manifest.yml -b $CF_BUILDPACK


### PR DESCRIPTION
- updates the deployment config to use the latest Cloud Foundry buildpack. Current Ruby version 2.7.4.
https://github.com/cloudfoundry/ruby-buildpack/releases
https://app.asana.com/0/1200504523179343/1201618493576140