### PR TITLE
fix error when generating report when financial data is nil

### DIFF
--- a/app/models/reports/compiled_press_book.rb
+++ b/app/models/reports/compiled_press_book.rb
@@ -19,12 +19,13 @@ class Reports::CompiledPressBook
   class PressBookFormAnswer
     include Reports::DataPickers::FormDocumentPicker
 
-    attr_reader :obj
+    attr_reader :obj, :financial_data
     def initialize(obj)
       @obj = obj
+      @financial_data = obj.financial_data || {}
     end
 
-    delegate :company_or_nominee_name, :mobility?, :development?, :financial_data, to: :obj
+    delegate :company_or_nominee_name, :mobility?, :development?, to: :obj
 
     def principal_address
       [


### PR DESCRIPTION
Use the same logic as in form financial pointer with a blank default value

https://app.asana.com/0/1200504523179345/1201854576173342
https://appsignal.com/bit-zesty/sites/601bfb8714ad665fb298effe/exceptions/incidents/48