### PR TITLE
allow enabling vigilion active_job config using env vars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem 'carrierwave', '~> 1.3'
 gem 'fog', "1.42.1"
 gem "fog-aws"
 gem 'vigilion', '~> 1.0.4'
-gem 'vigilion-rails'
+gem 'vigilion-rails', '~> 2.1.0'
 
 # Background jobs
 gem "sidekiq", "~> 6.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,8 +772,8 @@ GEM
       faraday
       faraday-detailed_logger
       faraday_middleware
-    vigilion-rails (2.0.0)
-      rails (>= 4.2.0)
+    vigilion-rails (2.1.0)
+      rails (>= 6.0.3.7)
       vigilion (~> 1.0.4)
     virtus (2.0.0)
       axiom-types (~> 0.1)
@@ -901,7 +901,7 @@ DEPENDENCIES
   turnip (~> 4.2.0)
   uglifier (>= 2.7.2)
   vigilion (~> 1.0.4)
-  vigilion-rails
+  vigilion-rails (~> 2.1.0)
   virtus
   webmock (= 3.5.0)
   webpacker (= 6.0.0.beta.7)

--- a/app/views/shared/_attachment_with_virus_check_status.html.slim
+++ b/app/views/shared/_attachment_with_virus_check_status.html.slim
@@ -1,11 +1,11 @@
-p.govuk-body 
+p.govuk-body
   - if item.send(mount_name)
     - scan_results = item.send("#{mount_name}_scan_results")
     - if item.clean?
       = link_to item.try(:original_filename),
                 item.send(mount_name).url,
                 target: "_blank"
-    - elsif scan_results == "scanning"
+    - elsif scan_results == "scanning" || scan_results == "pending"
       = item.try(:original_filename)
       |  (scanning on viruses)
     - elsif scan_results == "infected"

--- a/config/initializers/vigilion.rb
+++ b/config/initializers/vigilion.rb
@@ -15,4 +15,5 @@ Vigilion.configure do |config|
   # Specify different loopback_response (default is 'clean')
   # config.loopback_response = 'infected'
   config.debug = ENV["DEBUG_VIRUS_SCANNER"] == "true"
+  config.active_job = ENV["VIRUS_SCANNER_ACTIVE_JOB"] == "true"
 end


### PR DESCRIPTION
- set VIRUS_SCANNER_ACTIVE_JOB=true for prod-like environments
- handle pending status on scans; which is before API responds file scanning. enhances copytext message in UI which used to tell user scan was unsuccessful when it is pending

https://app.asana.com/0/1201340677821043/1201853404384060/f