### PR TITLE
[QAE0421] Increases min height for innovation side-menu

### DIFF
--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -503,6 +503,10 @@ header.page-header aside .inner {
     min-height: 800px;
   }
 
+  &.min-height-1300 {
+    min-height: 1300px;
+  }
+
   .steps-progress-bar {
     margin-top: 0.5em;
   }

--- a/app/views/content_only/award_info_innovation.html.slim
+++ b/app/views/content_only/award_info_innovation.html.slim
@@ -4,7 +4,7 @@ h1.govuk-heading-xl
   ' Innovation Award Application
 
 .application-info-page
-  .steps-progress-container.min-height-800
+  .steps-progress-container.min-height-1300
     = render "steps_progress_bar", cant_access_future: true
     .steps-progress-content
       .article-related-positioning-container

--- a/app/views/qae_form/show.html.slim
+++ b/app/views/qae_form/show.html.slim
@@ -15,9 +15,10 @@ form.qae-form.award-form data-autosave-url=save_form_url(@form_answer) action=sa
   h1.govuk-heading-xl
     = @form.title
 
-  .steps-progress-container.min-height-800
+  - side_bar_menu_height = @form_answer.award_type == "innovation" ? "min-height-1300" : "min-height-800"
+  div[class="steps-progress-container #{side_bar_menu_height}"]
     = render "qae_form/steps_progress_bar", current_step: params[:step]
-    
+
     .steps-progress-content
       - if @form_answer.promotion? && @form_answer.validator_errors && @form_answer.validator_errors["supporters"].present?
         .govuk-error-summary aria-labelledby="letters-of-support-error-title" role="alert" tabindex="-1" data-module="govuk-error-summary"


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1W62dDbbK5hkuJHQAz4zxWxvPphfjHHVr7btGUhDtyQU/edit#gid=0
Issue 12 - In section E, the sidebar overlaps with "Need help? Ring us on 020 7215 6880. Alternatively, email us at queensawards@beis.gov.uk" text.

Increases the min-height class for the side bar menu for innovation forms only. Other forms will remain with a smaller minimum side bar height.

![Screenshot 2022-04-11 at 13 32 28](https://user-images.githubusercontent.com/65811538/162740028-20ab4881-35f7-4dbd-8216-fe39c9ac4611.png)
