### PR TITLE
Uploads tweaks

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -674,7 +674,7 @@ jQuery ->
       new_el.find("textarea").val("")
       new_el.find('.js-char-count').charcount()
       list.removeClass('visuallyhidden')
-      updateUploadListVisiblity(list, button, max)
+      updateUploadListVisiblity(list, govuk_button, max)
       reindexUploadListInputs(list)
       new_el.find('input,textarea,select').filter(':visible').first().focus()
 

--- a/app/forms/award_years/v2023/social_mobility/social_mobility_step3.rb
+++ b/app/forms/award_years/v2023/social_mobility/social_mobility_step3.rb
@@ -96,7 +96,7 @@ class AwardYears::V2023::QAEForms
           label ->(y) { "Financial year #{y}" }
         end
 
-        upload :supporting_materials, "To support your figures, please upload your financial statements for the years entered in question C2.2." do
+        upload :supporting_financials, "To support your figures, please upload your financial statements for the years entered in question C2.2." do
           classes "sub-question"
           sub_ref "C 2.3"
           context %(

--- a/app/forms/award_years/v2023/sustainable_development/sustainable_development_step3.rb
+++ b/app/forms/award_years/v2023/sustainable_development/sustainable_development_step3.rb
@@ -108,7 +108,7 @@ class AwardYears::V2023::QAEForms
           label ->(y) { "Financial year #{y}" }
         end
 
-        upload :supporting_materials, "To support your figures, please upload your financial statements for the years entered in question C2.2." do
+        upload :supporting_financials, "To support your figures, please upload your financial statements for the years entered in question C2.2." do
           classes "sub-question"
           sub_ref "C 2.3"
           context %(

--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -38,7 +38,7 @@
                 / (optional)
               textarea.govuk-textarea.js-char-count.js-trigger-autosave rows="2" maxlength="600" data-word-max="100" name=question.input_name(suffix: 'description', index: idx) id=question.input_name(suffix: 'description', index: idx)  *possible_read_only_ops
                 = question.input_value(suffix: 'description', index: idx)
-          - unless admin_in_read_only_mode? || question.key == :org_chart
+          - unless admin_in_read_only_mode? || question.key == :org_chart || :supporting_financials
             a.govuk-button.govuk-button--warning.remove-link class="govuk-!-margin-bottom-3" href="#" *possible_read_only_ops
               | Remove website address
 


### PR DESCRIPTION
- changes key name for supporting financials uploads to be more descriptive
- adds conditional to not show 'Remove website' button for the supporting financials questions
- JS fix to continue to show the upload button when a file is added. The page would previously have to be refreshed in order to see the button