### PR TITLE
Adds a confirm deletion page when deleting only collaborator

### DIFF
--- a/app/assets/stylesheets/frontend/views/collaborators.scss
+++ b/app/assets/stylesheets/frontend/views/collaborators.scss
@@ -41,7 +41,7 @@ details {
 .remove-link-right {
   @media (min-width: 992px) {
     position: relative;
-    
+
     h2 {
       max-width: calc(100% - 200px);
     }
@@ -50,6 +50,7 @@ details {
 
 .collaborator-remove-link {
   @media (min-width: 768px) {
+    color: 	#d4351c;
     position: absolute;
     right: 0;
     top: 12px;

--- a/app/controllers/account/collaborators_controller.rb
+++ b/app/controllers/account/collaborators_controller.rb
@@ -66,20 +66,20 @@ class Account::CollaboratorsController < Account::BaseController
     end
   end
 
+  def confirm_deletion
+  end
+
   def destroy
+    form_id = params[:form_id].presence
+
     collaborator.account_id = Account.create(owner: collaborator).id
     collaborator.role = "account_admin"
     collaborator.save!
     collaborator.form_answers
                 .update_all(user_id: account.owner_id)
 
-    if params.has_key? :form_id
-      redirect_to account_collaborators_path(form_id: params[:form_id]),
-                  notice: "#{collaborator.email} successfully removed from Collaborators!"
-    else
-      redirect_to account_collaborators_path,
-                  notice: "#{collaborator.email} successfully removed from Collaborators!"
-    end
+    redirect_to account_collaborators_path(form_id: form_id),
+                notice: "#{collaborator.email} successfully removed from Collaborators!"
   end
 
   def set_form_answer

--- a/app/views/account/collaborators/confirm_deletion.html.slim
+++ b/app/views/account/collaborators/confirm_deletion.html.slim
@@ -1,0 +1,24 @@
+- title "Confirm removal of collaborator"
+
+- provide(:page_content_class, "multi-page page-account")
+
+.article-container
+  article.group role="article"
+    h1.govuk-heading-l
+      ' Are you sure you want remove this collaborator?
+
+    p.govuk-body
+      ' You need to have at least one collaborator added to your account. If you remove this collaborator, please add another one; otherwise, you won't be able to:
+    ul.govuk-list.govuk-list--bullet
+      li access or submit your applications;
+      li access the winners' dashboard if you win the award.
+
+    .govuk-button-group
+      - form_id = params[:form_id].presence
+
+      = link_to "Remove collaborator", account_collaborator_path(collaborator, form_id: form_id),
+                method: :delete,
+                class: "govuk-button govuk-button--warning"
+
+      = link_to "Cancel", edit_account_collaborator_path(collaborator, form_id: form_id),
+                  class: "govuk-button govuk-button--secondary"

--- a/app/views/account/collaborators/edit.html.slim
+++ b/app/views/account/collaborators/edit.html.slim
@@ -11,15 +11,15 @@ h1.govuk-heading-xl
       div.remove-link-right
         h2.govuk-heading-l
           ' Edit collaborator details
-        - if params.has_key? :form_id
-          = link_to "Remove collaborator", account_collaborator_path(collaborator, form_id: params[:form_id]),
-                              method: :delete,
-                              class: "collaborator-remove-link govuk-link"
-        - else
-          = link_to "Remove collaborator", account_collaborator_path(collaborator),
-                              method: :delete,
-                              class: "collaborator-remove-link govuk-link"
 
+        - form_id = params[:form_id].presence
+        - if collaborators.count == 1
+          = link_to "Remove collaborator", confirm_deletion_account_collaborator_path(collaborator, form_id: form_id),
+                    class: "collaborator-remove-link govuk-link"
+        - else
+          = link_to "Remove collaborator", account_collaborator_path(collaborator, form_id: form_id),
+                    method: :delete,
+                    class: "collaborator-remove-link govuk-link"
 
     .article-container
       article.group role="article"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -317,7 +317,11 @@ Rails.application.routes.draw do
   end
 
   namespace :account do
-    resources :collaborators, except: [:show]
+    resources :collaborators, except: [:show] do
+      member do
+        get :confirm_deletion
+      end
+    end
   end
 
   namespace :judge do

--- a/spec/features/account/collaborators_spec.rb
+++ b/spec/features/account/collaborators_spec.rb
@@ -220,6 +220,25 @@ So that they can collaborate form answers
 
           expect_to_see "#{collaborator.email} successfully removed from Collaborators!"
         end
+
+        it "should redirect to an confirmation page if the only collaborator" do
+          regular_user.delete
+          another_account_admin.delete
+
+          within(".collaborators-list #user_#{collaborator.id}") do
+            expect_to_see collaborator.email
+            click_on "Edit details"
+          end
+
+          click_link "Remove collaborator"
+          expect_to_see "Are you sure you want remove this collaborator?"
+
+          expect {
+            click_link "Remove collaborator"
+          }.to change {
+            account.reload.users.count
+          }.by(-1)
+        end
       end
 
       describe "I'm logged in as regular user and I can access the Collaborators section" do

--- a/spec/requests/account/collaborators_spec.rb
+++ b/spec/requests/account/collaborators_spec.rb
@@ -39,6 +39,7 @@ describe 'API' do
                                                  account: account
   end
 
+
   before do
     login_as account_admin
   end
@@ -97,14 +98,22 @@ describe 'API' do
                                 role: "regular"
     end
 
+    let!(:another_account_admin) do
+      create :user,
+             :completed_profile,
+             first_name: "Another Account Admin Mike",
+             account: account,
+             role: "account_admin"
+    end
+
     before do
       clear_enqueued_jobs
       delete account_collaborator_path(existing_collaborator), xhr: true
     end
 
     it "should remove user from collaborators, but do not remove user account" do
-      expect(User.count).to be_eql 2
-      expect(account.reload.users.count).to be_eql 1
+      expect(User.count).to be_eql 3
+      expect(account.reload.users.count).to be_eql 2
 
       expect(enqueued_jobs.size).to be_eql(0)
     end


### PR DESCRIPTION
https://app.asana.com/0/1200504523179345/1202087036595965/f

Account owners need a collaborator to be able to create and edit applications so a confirm deletion page is introduced to highlight the restrictions users may face when deleting the last collaborator.

- If there is only 1 collaborator, the 'Remove Collaborator' link takes the user to an interim page where they will confirm they wish to delete. 
- Changes the link colour to red
- Original feature tests confirm deletion with multiple collaborators, feature test added to confirm redirection when user has only one collaborator.

![Screenshot 2022-05-13 at 13 08 05](https://user-images.githubusercontent.com/65811538/168284996-26386f57-6996-4c3c-8933-43a1b28f545e.png)

