### PR TITLE
count account owner as a collaborator

### DIFF
--- a/app/views/account/collaborators/index.html.slim
+++ b/app/views/account/collaborators/index.html.slim
@@ -76,7 +76,7 @@ h1.govuk-heading-xl
                   = link_to new_account_collaborator_path(form_id: @form_answer), class: "govuk-button", role: "button"
                     ' Add a collaborator
 
-              - if collaborators.any?
+              - if current_account.users.not_including(account_owner).any?
                   footer
                     nav.pagination.no-border role="navigation" aria-label="Pagination"
                       ul.group

--- a/spec/features/users/collaborator_registration_flow_spec.rb
+++ b/spec/features/users/collaborator_registration_flow_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+include Warden::Test::Helpers
+Warden.test_mode!
+
+describe "Collaborator registration flow" do
+  let!(:acc_admin) { create(:user, role: "account_admin") }
+
+  before do
+    create(:settings, :submission_deadlines)
+  end
+
+  it "creates and account and collaborator is able to collaborate" do
+    login_as(acc_admin, scope: :user)
+
+    visit new_account_collaborator_path
+
+    fill_in "Title", with: "Ms"
+    fill_in("First name", with: "First Name")
+    fill_in("Last name", with: "Last Name")
+    fill_in("Job title", with: "job title")
+    fill_in("Telephone number", with: "1231233214354235")
+    fill_in("Email", with: "collab@example.com")
+    first("input#collaborator_role_account_admin").set(true)
+
+    click_button "Add the collaborator"
+
+    collab = User.find_by_email("collab@example.com")
+    collab.confirmed_at = Time.now
+    collab.save!
+
+    click_link "Sign out"
+
+    login_as(collab.reload, scope: :user)
+    visit root_path
+
+    click_button("Save and continue")
+
+    expect(page).to have_content("Contact preferences")
+    click_button("Save and continue")
+
+    fill_in "Name of the organisation", with: "Disney"
+    fill_in "The organisation's main telephone number", with: "012312312"
+    click_button("Save and continue")
+
+    # collaborator page
+    click_button("Save and continue")
+
+    expect(page).to have_content("Applying for a Queen's Award for your organisation")
+  end
+end


### PR DESCRIPTION
https://app.asana.com/0/1200504523179343/1202504961108164/f

Inviting account admin as a first collaborator let them being stuck on collaborators page because account owner was excluded from collaborators. 

This should still work fine since we exclude current user from the scope, looks like it was just a legacy code.