### PR TITLE
Updates CF buildpack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,14 @@ jobs:
           ruby-version: 2.7.6
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install -g yarn
       - uses: nanasess/setup-chromedriver@master
       - name: Build and run tests
         env:
           DISPLAY_SOCIAL_MOBILITY_AWARD: true
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/qae_test"
-          BUNDLER_VERSION: 2.1.4
+          BUNDLER_VERSION: 2.3.15
           DOCKER_TLS_CERTDIR: ""
         run: |
           sudo apt update
@@ -84,7 +84,7 @@ jobs:
           ruby-version: 2.7.6
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
       - name: "Deploy dev"
         env:
           name: dev
@@ -125,7 +125,7 @@ jobs:
           ruby-version: 2.7.6
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '12'
+          node-version: '16'
       - name: "Deploy staging"
         env:
           name: staging

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -19,7 +19,7 @@ jobs:
           ruby-version: 2.7.6
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '12'
+          node-version: '16'
       - name: "Deploy dev"
         env:
           name: dev

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -20,7 +20,7 @@ jobs:
           ruby-version: 2.7.6
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '12'
+          node-version: '16'
       - name: "Deploy production"
         env:
           name: production

--- a/bin/deploy
+++ b/bin/deploy
@@ -10,7 +10,7 @@ curl -X POST \
 $SLACK_WEBHOOK
 
 # Pin ruby buildpack
-export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.54"
+export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.55"
 
 cf create-app-manifest "$CF_APP"-worker
 cf push -f "$CF_APP"-worker_manifest.yml -b $CF_BUILDPACK

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sass-loader": "^12.1.0",
     "webpack": "^5.11.0",
     "webpack-cli": "^4.2.0",
-    "yarn": "^1.22.17"
+    "yarn": "^1.22.19"
   },
   "devDependencies": {
     "@webpack-cli/serve": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,10 +5174,10 @@ yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yarn@^1.22.17:
-  version "1.22.17"
-  resolved "https://registry.npmjs.org/yarn/-/yarn-1.22.17.tgz"
-  integrity sha512-H0p241BXaH0UN9IeH//RT82tl5PfNraVpSpEoW+ET7lmopNC61eZ+A+IDvU8FM6Go5vx162SncDL8J1ZjRBriQ==
+yarn@^1.22.19:
+  version "1.22.19"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
https://app.asana.com/0/1200504523179343/1202553703997103/

- updates buildpack to v1.8.55
- ruby v2.7.6. No change
- updates CI node and bundler versions to ensure compatibility with buildpack version
- updates yarn to ensure compatibility when deploying to production