### PR TITLE
[QAE0722] - Changes scope to include previously submitted applications

### DIFF
--- a/app/models/form_answer_statistics/picker.rb
+++ b/app/models/form_answer_statistics/picker.rb
@@ -140,7 +140,7 @@ class FormAnswerStatistics::Picker
     out << not_e
     eligibility_in_progress = scope.where(state: "eligibility_in_progress").count
     out << eligibility_in_progress
-    applications_in_progress = scope.where(state: "application_in_progress").where(submitted_at: nil)
+    applications_in_progress = scope.where(state: "application_in_progress")
     out << applications_in_progress.where(fill_progress: 0).count
     range2 = applications_in_progress.where("fill_progress > ? AND fill_progress < ?", 0, 0.25)
     out << range2.count
@@ -150,7 +150,7 @@ class FormAnswerStatistics::Picker
     out << range4.count
     range5 = applications_in_progress.where("fill_progress >= ? AND fill_progress <= ?", 0.75, 1)
     out << range5.count
-    total_in_progress = scope.in_progress.where(submitted_at: nil).count
+    total_in_progress = scope.in_progress.count
     out << total_in_progress
     out
   end


### PR DESCRIPTION
https://app.asana.com/0/1200504523179343/1202662076492444

During testing on staging the Applications In Progress and Summary tables show inconsistent totals due to the excluding applications which have been submitted. This commit removes the `submitted_at` scope.