### PR TITLE
Adds all years param for csv reports

### DIFF
--- a/app/models/reports/admin_report.rb
+++ b/app/models/reports/admin_report.rb
@@ -10,17 +10,17 @@ class Reports::AdminReport
   def as_csv
     case id
     when "registered-users"
-      Reports::RegisteredUsers.new(year).build
+      Reports::RegisteredUsers.new(year, params).build
     when "press-book-list"
-      Reports::PressBookList.new(year).build
+      Reports::PressBookList.new(year, params).build
     when "cases-status"
-      Reports::CasesStatusReport.new(year).build
+      Reports::CasesStatusReport.new(year, params).build
     when "entries-report"
-      Reports::AllEntries.new(year).build
+      Reports::AllEntries.new(year, params).build
     when "discrepancies_between_primary_and_secondary_appraisals"
       Reports::DiscrepanciesBetweenPrimaryAndSecondaryAppraisals.new(year, params[:category]).build
     when "reception-buckingham-palace"
-      Reports::ReceptionBuckinghamPalaceReport.new(year).build
+      Reports::ReceptionBuckinghamPalaceReport.new(year, params).build
     when /assessors-progress/
       if FormAnswer::AWARD_TYPE_FULL_NAMES.keys.include?(params[:category])
         Reports::AssessorsProgressReport.new(year, params[:category]).build
@@ -33,7 +33,7 @@ class Reports::AdminReport
   def as_xlsx
     case id
     when "compiled-press-book"
-      Reports::CompiledPressBook.new(year).build
+      Reports::CompiledPressBook.new(year, params).build
     end
   end
 

--- a/app/models/reports/all_entries.rb
+++ b/app/models/reports/all_entries.rb
@@ -185,13 +185,14 @@ class Reports::AllEntries
     }
   ]
 
-  def initialize(year)
+  def initialize(year, params)
     @year = year
+    @params = params
   end
 
   def build
     rows = []
-    f_ids = @year.form_answers.order(:id).pluck(:id)
+    f_ids = filtered_scope(@year, @params).order(:id).pluck(:id)
 
     f_ids.in_groups_of(1000, false) do |batch_of_ids|
       form_answers = ::FormAnswer.where(id: batch_of_ids)

--- a/app/models/reports/assessor_report.rb
+++ b/app/models/reports/assessor_report.rb
@@ -11,7 +11,7 @@ class Reports::AssessorReport
   def as_csv
     case id
     when "cases-status"
-      Reports::CasesStatusReport.new(year).build_for_lead(@current_subject)
+      Reports::CasesStatusReport.new(year, @params).build_for_lead(@current_subject)
     when "discrepancies_between_primary_and_secondary_appraisals"
       Reports::DiscrepanciesBetweenPrimaryAndSecondaryAppraisals.new(year, params[:category], @current_subject).build
     when /assessors-progress/

--- a/app/models/reports/cases_status_report.rb
+++ b/app/models/reports/cases_status_report.rb
@@ -92,14 +92,15 @@ class Reports::CasesStatusReport
     }
   ]
 
-  def initialize(year)
+  def initialize(year, params)
     @year = year
+    @params = params
   end
 
   def build
     rows = []
-
-    scope = @year.form_answers.submitted.order(:id)
+    scope = filtered_scope(@year, @params).submitted.order(:id)
+    
     scope.find_in_batches do |batch|
       form_answers = FormAnswer.where(id: batch.map(&:id))
                      .order(:id)
@@ -123,8 +124,8 @@ class Reports::CasesStatusReport
 
   def build_for_lead(current_subject)
     rows = []
+    scope = filtered_scope(@year, @params).submitted.where(award_type: current_subject.categories_as_lead).order(:id)
 
-    scope = @year.form_answers.submitted.where(award_type: current_subject.categories_as_lead).order(:id)
     scope.find_in_batches do |batch|
       form_answers = FormAnswer.where(id: batch.map(&:id))
                      .order(:id)

--- a/app/models/reports/compiled_press_book.rb
+++ b/app/models/reports/compiled_press_book.rb
@@ -7,6 +7,7 @@ require 'rubyXL/convenience_methods/worksheet'
 
 class Reports::CompiledPressBook
   attr_reader :groupped_form_answers, :scope
+  include Reports::CSVHelper
 
   DARK_BG = "0C2050"
   LIGHT_BG = "2E497A"
@@ -93,11 +94,10 @@ class Reports::CompiledPressBook
     press_contact_notes: "Press Book Notes"
   }
 
-  def initialize(year)
-    @scope = year.form_answers
-              .where(state: "awarded")
-              .includes(:user, :palace_invite)
-              .order(Arel.sql("form_answers.document->>'organization_address_region', company_or_nominee_name"))
+  def initialize(year, params)
+    @scope = filtered_scope(year, params).where(state: "awarded")
+                                         .includes(:user, :palace_invite)
+                                         .order(Arel.sql("form_answers.document->>'organization_address_region', company_or_nominee_name"))
 
     @groupped_form_answers = group_form_answers(scope)
   end

--- a/app/models/reports/csv_helper.rb
+++ b/app/models/reports/csv_helper.rb
@@ -31,6 +31,10 @@ module Reports::CSVHelper
     end
   end
 
+  def filtered_scope(year, params)
+    params[:year] == "all_years" ? FormAnswer.all : year.form_answers
+  end
+
   private
 
     def headers

--- a/app/models/reports/press_book_list.rb
+++ b/app/models/reports/press_book_list.rb
@@ -100,8 +100,8 @@ class Reports::PressBookList
     }
   ]
 
-  def initialize(year)
-    @scope = year.form_answers.where(state: ["awarded", "recommended"]).order(:id).includes(:user, :palace_invite)
+  def initialize(year, params)
+    @scope = filtered_scope(year, params).where(state: ["awarded", "recommended"]).order(:id).includes(:user, :palace_invite)
   end
 
   private

--- a/app/models/reports/reception_buckingham_palace_report.rb
+++ b/app/models/reports/reception_buckingham_palace_report.rb
@@ -73,17 +73,23 @@ class Reports::ReceptionBuckinghamPalaceReport
 
   ]
 
-  def initialize(year)
+  def initialize(year, params)
     @year = year
+    @params = params
   end
 
   def build
     rows = []
-
-    scope = PalaceAttendee.includes(palace_invite: :form_answer)
-                          .where("form_answers.award_year_id = ?", @year.id)
-                          .where("palace_invites.submitted = ?", true)
-                          .order("palace_invites.form_answer_id ASC, palace_attendees.id ASC")
+    if @params[:year] == "all_years"
+      scope = PalaceAttendee.includes(palace_invite: :form_answer)
+                            .where("palace_invites.submitted = ?", true)
+                            .order("palace_invites.form_answer_id ASC, palace_attendees.id ASC")
+    else
+      scope = PalaceAttendee.includes(palace_invite: :form_answer)
+                            .where("form_answers.award_year_id = ?", @year.id)
+                            .where("palace_invites.submitted = ?", true)
+                            .order("palace_invites.form_answer_id ASC, palace_attendees.id ASC")
+    end
 
     scope.each do |attendee|
       attendee_pointer = Reports::PalaceAttendeePointer.new(attendee)

--- a/app/models/reports/registered_users.rb
+++ b/app/models/reports/registered_users.rb
@@ -104,14 +104,15 @@ class Reports::RegisteredUsers
     }
   ]
 
-  def initialize(year)
+  def initialize(year, params)
     @year = year
+    @params = params
   end
 
   def build
     rows = []
+    scope = filtered_scope(@year, @params).order(:id)
 
-    scope = @year.form_answers.order(:id)
     scope.find_in_batches do |batch|
       form_answers = FormAnswer.where(id: batch.map(&:id))
                      .order(:id)

--- a/app/views/admin/dashboard/downloads/_csv_reports.html.slim
+++ b/app/views/admin/dashboard/downloads/_csv_reports.html.slim
@@ -7,7 +7,7 @@ ul.download-list
     / p.download-item__description
       ' Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 
-    = link_to "Download", admin_report_path("registered-users", format: :csv, year: @award_year.year), class: "download-link", aria: { label: "Download Registered users entry" }
+    = link_to "Download", admin_report_path("registered-users", format: :csv, year: params[:year]), class: "download-link", aria: { label: "Download Registered users entry" }
 
 
   li.download-item
@@ -16,7 +16,7 @@ ul.download-list
     / p.download-item__description
       ' Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 
-    = link_to "Download", admin_report_path("cases-status", format: :csv, year: @award_year.year), class: "download-link", aria: { label: "Download Case status" }
+    = link_to "Download", admin_report_path("cases-status", format: :csv, year: params[:year]), class: "download-link", aria: { label: "Download Case status" }
 
   li.download-item
     p.download-item__title
@@ -24,7 +24,7 @@ ul.download-list
     / p.download-item__description
       ' Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 
-    = link_to "Download", admin_report_path("entries-report", format: :csv, year: @award_year.year), class: "download-link", aria: { label: "Download Entries report" }
+    = link_to "Download", admin_report_path("entries-report", format: :csv, year: params[:year]), class: "download-link", aria: { label: "Download Entries report" }
 
   li.download-item
     p.download-item__title
@@ -32,12 +32,12 @@ ul.download-list
     / p.download-item__description
       ' Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 
-    = link_to "Download", admin_report_path("press-book-list", class: "action-title", format: :csv, year: @award_year.year), class: "download-link", aria: { label: "Download Press book list" }
+    = link_to "Download", admin_report_path("press-book-list", class: "action-title", format: :csv, year: params[:year]), class: "download-link", aria: { label: "Download Press book list" }
   li.download-item
     p.download-item__title
       ' Press book
 
-    = link_to "Download", admin_report_path("compiled-press-book", class: "action-title", format: :xlsx, year: @award_year.year), class: "download-link", aria: { label: "Download Press book" }
+    = link_to "Download", admin_report_path("compiled-press-book", class: "action-title", format: :xlsx, year: params[:year]), class: "download-link", aria: { label: "Download Press book" }
 
   li.download-item
     p.download-item__title
@@ -45,4 +45,4 @@ ul.download-list
     / p.download-item__description
       ' Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 
-    = link_to "Download", admin_report_path("reception-buckingham-palace", class: "action-title", format: :csv, year: @award_year.year), class: "download-link", aria: { label: "Download Reception Buckingham Palace" }
+    = link_to "Download", admin_report_path("reception-buckingham-palace", class: "action-title", format: :csv, year: params[:year]), class: "download-link", aria: { label: "Download Reception Buckingham Palace" }

--- a/spec/models/assessor_spec.rb
+++ b/spec/models/assessor_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Assessor, type: :model do
       year = create(:award_year)
       assessor =  create(:assessor, :regular_for_trade)
       allow_any_instance_of(Reports::CasesStatusReport).to receive(:as_csv) {"csv string"}
-      expect(Reports::CasesStatusReport.new(year).build_for_lead(assessor)).to eq "csv string"
+      expect(Reports::CasesStatusReport.new(year, params: { year: year }).build_for_lead(assessor)).to eq "csv string"
     end
 
     it 'AssessorsProgressReport should return csv' do
@@ -82,7 +82,7 @@ RSpec.describe Assessor, type: :model do
       assessor =  create(:assessor, :regular_for_trade)
 
       expect(Reports::CasesStatusReport).to receive_message_chain(:new, :build_for_lead)
-      Reports::AssessorReport.new("cases-status", year, assessor).as_csv
+      Reports::AssessorReport.new("cases-status", year, assessor, params: { year: year }).as_csv
 
       expect(Reports::AssessorsProgressReport).to receive_message_chain(:new, :build)
       Reports::AssessorReport.new("assessors-progress", year, assessor, category: 'trade').as_csv

--- a/spec/models/reports/registered_users_spec.rb
+++ b/spec/models/reports/registered_users_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Reports::RegisteredUsers do
   let!(:form_answer) { create(:form_answer) }
 
-  let(:output) { described_class.new(AwardYear.current).build }
+  let(:output) { described_class.new(AwardYear.current, params: { year: AwardYear.current }).build }
   it "creates the output with relevant data" do
     expect(output).to include(form_answer.user_id.to_s)
   end


### PR DESCRIPTION
https://app.asana.com/0/1200061634447616/1202697541255350

The award year can not be used when the All Years option is selected when downloading reports, as the 'all_years' param cannot be converted to an integer. Therefore the param is passed into the report builder methods and a check is done to use all FormAnswers if this param is found.