### PR TITLE
do not ask for actual figures if they were already provided

### DIFF
--- a/app/controllers/concerns/figures_authorisation_check.rb
+++ b/app/controllers/concerns/figures_authorisation_check.rb
@@ -1,0 +1,15 @@
+module FiguresAuthorisationCheck
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :check_if_figures_needed
+  end
+
+  private
+
+  def check_if_figures_needed
+    if form_answer.requires_vocf? || !form_answer.provided_estimates? || form_answer.shortlisted_documents_wrapper.try(:submitted?)
+      redirect_to dashboard_url
+    end
+  end
+end

--- a/app/controllers/users/actual_figures_controller.rb
+++ b/app/controllers/users/actual_figures_controller.rb
@@ -1,5 +1,7 @@
 class Users::ActualFiguresController < Users::BaseController
   include CommercialFiguresMixin
+  include FiguresAuthorisationCheck
+
   def new
     @form_answer = form_answer
     @actual_figures = figures_wrapper.build_commercial_figures_file

--- a/app/controllers/users/figures_and_vat_returns_controller.rb
+++ b/app/controllers/users/figures_and_vat_returns_controller.rb
@@ -1,4 +1,6 @@
 class Users::FiguresAndVatReturnsController < Users::BaseController
+  before_action :check_if_figures_needed
+
   def show
     @figures_form = form_answer.shortlisted_documents_wrapper || form_answer.build_shortlisted_documents_wrapper
     @figures_form.save! if !@figures_form.persisted?
@@ -28,5 +30,11 @@ class Users::FiguresAndVatReturnsController < Users::BaseController
     @form_answer ||= current_user.account.
                        form_answers.
                        find(params[:form_answer_id])
+  end
+
+  def check_if_figures_needed
+    if form_answer.requires_vocf? || !form_answer.provided_estimates? || form_answer.shortlisted_documents_wrapper.try(:submitted?)
+      redirect_to dashboard_url
+    end
   end
 end

--- a/app/controllers/users/figures_and_vat_returns_controller.rb
+++ b/app/controllers/users/figures_and_vat_returns_controller.rb
@@ -1,5 +1,5 @@
 class Users::FiguresAndVatReturnsController < Users::BaseController
-  before_action :check_if_figures_needed
+  include FiguresAuthorisationCheck
 
   def show
     @figures_form = form_answer.shortlisted_documents_wrapper || form_answer.build_shortlisted_documents_wrapper
@@ -30,11 +30,5 @@ class Users::FiguresAndVatReturnsController < Users::BaseController
     @form_answer ||= current_user.account.
                        form_answers.
                        find(params[:form_answer_id])
-  end
-
-  def check_if_figures_needed
-    if form_answer.requires_vocf? || !form_answer.provided_estimates? || form_answer.shortlisted_documents_wrapper.try(:submitted?)
-      redirect_to dashboard_url
-    end
   end
 end

--- a/app/controllers/users/vat_returns_controller.rb
+++ b/app/controllers/users/vat_returns_controller.rb
@@ -1,5 +1,6 @@
 class Users::VatReturnsController < Users::BaseController
   include CommercialFiguresMixin
+  include FiguresAuthorisationCheck
 
   def new
     @form_answer = form_answer

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -167,6 +167,7 @@ class FormAnswer < ApplicationRecord
 
     scope :require_vocf, -> { where(award_type: %w[trade innovation]) }
     scope :vocf_free, -> { where(award_type: %w[mobility development]) }
+    scope :provided_estimates, -> { where("document #>> '{product_estimated_figures}' = 'yes'") }
   end
 
   begin :callbacks
@@ -400,6 +401,10 @@ class FormAnswer < ApplicationRecord
     return true if award_year && award_year.before_vocf_switch?
 
     %w(trade innovation).include?(award_type)
+  end
+
+  def provided_estimates?
+    document["product_estimated_figures"] == "yes"
   end
 
   def shortlisted_documents_submitted?

--- a/app/models/form_answer_state_machine.rb
+++ b/app/models/form_answer_state_machine.rb
@@ -84,7 +84,7 @@ class FormAnswerStateMachine
         end
       end
 
-      current_year.form_answers.vocf_free.where(state: "assessment_in_progress").find_each do |fa|
+      current_year.form_answers.vocf_free.provided_estimates.where(state: "assessment_in_progress").find_each do |fa|
         if !fa.shortlisted_documents_wrapper || !fa.shortlisted_documents_wrapper.submitted?
           fa.state_machine.perform_transition("disqualified")
         end

--- a/app/services/notifiers/email_notification_service.rb
+++ b/app/services/notifiers/email_notification_service.rb
@@ -118,7 +118,7 @@ class Notifiers::EmailNotificationService
   def shortlisted_po_sd_reminder(award_year)
     collaborator_data = []
 
-    award_year.form_answers.where(award_type: %w(mobility development)).shortlisted.each do |form_answer|
+    award_year.form_answers.where(award_type: %w(mobility development)).shortlisted.provided_estimates.each do |form_answer|
       next if form_answer.shortlisted_documents_wrapper.try(:submitted?)
 
       form_answer.collaborators.each do |collaborator|

--- a/app/views/content_only/post_submission/_shortlisted.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted.html.slim
@@ -25,7 +25,12 @@
 
       .content-right.content-offset-24
         p.govuk-body
-          ' Please review the following actions to complete your shortlisted application.
+          - if award.requires_vocf? || award.provided_estimates?
+            ' Please review the following actions to complete your shortlisted application.
+          - else
+            ' If you have already provided actual figures along with your application, you do not need to do anything further.
+            br
+
           = link_to users_form_answer_path(award, format: :pdf), "target" => "_blank", "aria-label" => "Download application #{award.id} for #{award.award_type_full_name + ' Award'}", class: 'govuk-link' do
             | Download your aplication
 
@@ -54,7 +59,7 @@
                 = link_to "Download the external accountant’s report form", users_form_answer_audit_certificate_url(award, format: :pdf), "aria-label" => "Download the external accountant’s report form for #{award.id} for #{award.award_type_full_name + 'Award'}", class: 'govuk-link'
               li
                 = link_to "Provide verification of commercial figures", users_form_answer_audit_certificate_url(award), class: "govuk-button govuk-!-margin-bottom-0", "aria-label" => "Provide verification of commercial figures for #{award.id} #{award.award_type_full_name + 'Award'}"
-          - else # if award.requires_vocf?
+          - elsif award.provided_estimates? # if award.requires_vocf?
             li
               strong
                 | Latest financial information

--- a/spec/features/users/figures_and_vat_returns_spec.rb
+++ b/spec/features/users/figures_and_vat_returns_spec.rb
@@ -7,6 +7,10 @@ describe "User uploads VAT returns and actual figures" do
   let!(:form_answer) { create(:form_answer, :mobility, :recommended, user: user) }
 
   before do
+    form_answer.document["product_estimated_figures"] = "yes"
+    form_answer.document["product_estimates_use"] = "text"
+    form_answer.save!
+
     login_as user
 
     settings.email_notifications.create!(

--- a/spec/models/form_answer_state_machine_spec.rb
+++ b/spec/models/form_answer_state_machine_spec.rb
@@ -84,6 +84,10 @@ describe FormAnswerStateMachine do
 
       context "non-VoCF forms" do
         before do
+          mobility_fa.document["product_estimated_figures"] = "yes"
+          mobility_fa.document["product_estimates_use"] = "text"
+          mobility_fa.save!
+
           form_answer.update(state: "assessment_in_progress")
           create(:audit_certificate, form_answer: form_answer)
         end

--- a/spec/services/notifiers/email_notification_service_spec.rb
+++ b/spec/services/notifiers/email_notification_service_spec.rb
@@ -123,8 +123,22 @@ describe Notifiers::EmailNotificationService do
     let(:kind) { "shortlisted_po_sd_reminder" }
     let(:form_answer) { create(:form_answer, :mobility, :submitted, state: "recommended") }
     let(:fa_no_notification) { create(:form_answer, :trade, :submitted, state: "recommended") }
+    let(:fa_actual_figures) { create(:form_answer, :mobility, :submitted, state: "recommended") }
     let(:fa_with_submitted_docs) { create(:form_answer, :mobility, :submitted, state: "recommended") }
     let(:mailer) { double(deliver_later!: true) }
+
+    before do
+      form_answer.document["product_estimated_figures"] = "yes"
+      form_answer.document["product_estimates_use"] = "text"
+      form_answer.save!
+
+      fa_with_submitted_docs.document["product_estimated_figures"] = "yes"
+      fa_with_submitted_docs.document["product_estimates_use"] = "text"
+      fa_with_submitted_docs.save!
+
+      fa_actual_figures.document["product_estimated_figures"] = "no"
+      fa_actual_figures.save!
+    end
 
     it "triggers current notification" do
       sdw = create(:shortlisted_documents_wrapper, form_answer: fa_with_submitted_docs)


### PR DESCRIPTION
- in the dashboard  only display the 'Download your application' and a message above the link "If you have already provided actual figures along with your application, you do not need to do anything further."
- SHORTLISTED REMINDER - PO & SD mailer should not be sent to applicants who have provided ACTUAL figures in the online form
- DO NOT automatically disqualify SD and PO application if they have not provided any additional financial documents and have provided ACTUAL figures in the online form
- for JS and non-JS view, prevent applicants from accessing the upload pages directly via the URL

https://app.asana.com/0/1200504523179345/1203181178829099/f