### PR TITLE
Copy changes - QA 19/10

### DIFF
--- a/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
+++ b/app/views/content_only/post_submission/_shortlisted_advanced_info.html.slim
@@ -32,7 +32,7 @@ details.govuk-details data-module="govuk-details"
       ol
         li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures
         li If relevant, in the Independent Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report
-        li Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed Independent Accountant's Report
+        li Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed Independent Accountant's Report to the applicant
         li Log back to this online portal and follow the "Provide verification of commercial figures" button next to your Shortlisted entries.
 
     p.govuk-body

--- a/app/views/users/audit_certificate_request_mailer/notify.text.erb
+++ b/app/views/users/audit_certificate_request_mailer/notify.text.erb
@@ -17,7 +17,7 @@ If you do not submit your External Accountant's Report before the deadline, we w
      <%= users_form_answer_audit_certificate_url(@form_answer) %>
   2. We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
   3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
-  4. Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report.
+  4. Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report to the applicant.
   5. Log in and upload the External Accountant's Report to the Queen’s Award online portal, “Verification of figures” page, by following the link below:
      <%= users_form_answer_audit_certificate_url(@form_answer) %>
 

--- a/app/views/users/audit_certificate_request_mailer/preview/notify.html.slim
+++ b/app/views/users/audit_certificate_request_mailer/preview/notify.html.slim
@@ -36,7 +36,7 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | 3. If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  | 4. Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report.
+  | 4. Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report to the applicant.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   | 5. Log in and upload the External Accountant's Report to the Queen’s Award online portal, “Verification of figures” page, by following the link below:<br/>

--- a/app/views/users/audit_certificates/show.html.slim
+++ b/app/views/users/audit_certificates/show.html.slim
@@ -15,7 +15,7 @@ header.page-header.group class=('page-header-wider govuk-!-margin-bottom-0')
             li = link_to("Download the External Accountant's Report form.", users_form_answer_audit_certificate_url(form_answer, format: :pdf))
             li We recommend that you send the report to the accountant straight away so that you can agree on the timelines. Let them know if you will be providing revisions to the figures.
             li If relevant, in the External Accountant's Report, provide actual figures to replace estimates submitted at the time of the application or make any other changes to the figures. If you make any revisions, you have to sign the Applicant's Management's Statement section in the report.
-            li Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report.
+            li Once you make the revisions (if any), the accountant may perform their own relevant procedures and will return the completed External Accountant's Report to the applicant.
             li = "Log back to this online portal and follow the \"Verification of Commercial Figures\" link next to your Shortlisted entries. Please upload the External Accountant's Report provided by the accountant, by <strong>#{Settings.current_audit_certificates_deadline.decorate.formatted_trigger_time}</strong>.".html_safe
       br
 


### PR DESCRIPTION
- [x] https://app.asana.com/0/1200061634447616/1203181178829134 [User dashboard] In the expandable section for IT and Innovation, modify point 3 from  '...completed Independent Accountant's Report.' to '...completed Independent Accountant's Report to the applicant'
- [x] https://app.asana.com/0/1200061634447616/1203181178829135 for SHORTLISTED REMINDER - INNOVATION & IT: mailer step 4 change end of sentence from '...completed External Accountant's Report.' to '...completed External Accountant's Report to the applicant'
- [x] https://app.asana.com/0/1200061634447616/1203181178829136 In the VOFF upload page for IT and Innovation tweak step 4 copy: from '...completed External Accountant's Report.' to '...completed External Accountant's Report to the applicant'  