### PR TITLE
Removes button for PO and SD forms

### DIFF
--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -10,7 +10,9 @@
         span.glyphicon.glyphicon-pencil
         span.btn-title
           ' Edit application
-    = render "admin/form_answers/docs/not_completed_audit_certificate"
+
+    - if @form_answer.requires_vocf?
+      = render "admin/form_answers/docs/not_completed_audit_certificate"
     = render "admin/form_answers/docs/download_original_application_pdf_before_deadline"
 
   .sidebar-section


### PR DESCRIPTION
https://app.asana.com/0/1200504523179343/1203221881006753/

- [x] For PO and SD applications, remove the 'View initial Verification of commercial figures PDF' button from the admin/assessors UI