### PR TITLE
Removes social mobility heading

### DIFF
--- a/app/views/content_only/_current_applications.html.slim
+++ b/app/views/content_only/_current_applications.html.slim
@@ -4,8 +4,7 @@
       .govuk-summary-list__row
         dt.govuk-summary-list__key
           h3.govuk-heading-s
-            - app_name = award.decorate.application_name
-            = app_name == "Promoting Opportunity" ? "Social Mobility" : app_name
+            = award.decorate.application_name
           br
           span.govuk-body-s
             = award.award_type_full_name


### PR DESCRIPTION
https://app.asana.com/0/1200504523179343/1203221881006757/

Change 'Social mobility' to 'Promoting Opportunity' in the user dashboard