### PR TITLE
Increase upload file size for audit certificates

### DIFF
--- a/app/models/audit_certificate.rb
+++ b/app/models/audit_certificate.rb
@@ -6,7 +6,7 @@ class AuditCertificate < ActiveRecord::Base
     validates :attachment, presence: true,
                            on: :create,
                            file_size: {
-                             maximum: 10.megabytes.to_i
+                             maximum: 15.megabytes.to_i
                            }
 
     validates :form_answer_id, uniqueness: true,


### PR DESCRIPTION
https://app.asana.com/0/1200504523179343/1203329331282225/

Increases the upload limit from 10mb to 15mb