### PR TITLE
Fetching applications from the same entity

### DIFF
--- a/app/services/company_registration_number.rb
+++ b/app/services/company_registration_number.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class CompanyRegistrationNumber
+  COMPANY_REGISTRATION_NUMBER_REGEX = %r{(?!\s)((AC|ZC|FC|GE|LP|OC|SE|SA|SZ|SF|GS|SL|SO|SC|ES|NA|NZ|NF|GN|NL|NC|R0|NI|EN|\d{0,2}|SG|FE(\s?))\d{5}(\d|C|R))|((RS|SO)\d{3}(\d{3}|\d{2}[WSRCZF]|\d(FI|RS|SA|IP|US|EN|AS)|CUS))|((NI|SL)\d{5}[\dA])|(OC(([\dP]{5}[CWERTB])|([\dP]{4}(OC|CU))))}i.freeze
+
+  def self.extract_from(content)
+    new(content).extract
+  end
+
+  attr_reader :content, :sanitizer
+
+  def initialize(content)
+    @sanitizer ||= Rails::Html::FullSanitizer.new
+    @content = content.to_s
+  end
+
+  def extract
+    return [] if content.blank?
+
+    sanitized = sanitize(content).strip
+    parts = tokenize(content)
+    numbers = parts.each_with_object([]) do |part, memo|
+      memo << part if part =~ COMPANY_REGISTRATION_NUMBER_REGEX
+    end
+
+    numbers
+  end
+
+  private
+
+  def sanitize(value)
+    sanitizer.sanitize(value)
+  end
+
+  def tokenize(value)
+    value
+      .remove(/(\(|\[).*(\)|\])/)
+      .scan(/[[:word:]]*/i)
+      .reject(&:blank?)
+  end
+end

--- a/app/validators/company_registration_number_validator.rb
+++ b/app/validators/company_registration_number_validator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Based on: https://gist.github.com/rob-murray/01d43581114a6b319034732bcbda29e1
+
+class CompanyRegistrationNumberValidator < ActiveModel::EachValidator
+  VALID_CRN_REGEX = %r{\A(?!.{9})((AC|ZC|FC|GE|LP|OC|SE|SA|SZ|SF|GS|SL|SO|SC|ES|NA|NZ|NF|GN|NL|NC|R0|NI|EN|\d{0,2}|SG|FE)\d{5}(\d|C|R))|((RS|SO)\d{3}(\d{3}|\d{2}[WSRCZF]|\d(FI|RS|SA|IP|US|EN|AS)|CUS))|((NI|SL)\d{5}[\dA])|(OC(([\dP]{5}[CWERTB])|([\dP]{4}(OC|CU))))\z}i.freeze
+
+  def self.regexp
+    VALID_CRN_REGEX
+  end
+
+  def self.valid?(value)
+    !!(value =~ regexp)
+  end
+
+  def validate_each(record, attribute, value)
+    return if options[:allow_nil] && value.nil?
+    return if options[:allow_blank] && value.blank?
+    return if options[:allow_empty] && value == ""
+    unless self.class.valid?(value)
+      record.errors[attribute] << (options[:message] || "is not a valid company registration number")
+    end
+  end
+end

--- a/app/views/admin/form_answers/_previous_applications_section.html.slim
+++ b/app/views/admin/form_answers/_previous_applications_section.html.slim
@@ -1,7 +1,7 @@
 .well
   h2 Company's other applications
   ul.list-unstyled.other-applications-list
-    - other_applications = @form_answer.account.other_submitted_applications(@form_answer)
+    - other_applications = @form_answer.other_applications_from_same_entity
     - if other_applications.any?
       - other_applications.decorate.each do |application|
         li

--- a/spec/services/company_registration_number_spec.rb
+++ b/spec/services/company_registration_number_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CompanyRegistrationNumber do
+  describe ".extract_from" do
+    it "extracts company registration number from simple string" do
+      content = "06883289"
+
+      expect(
+        described_class.extract_from(content)
+      ).to match_array(["06883289"])
+    end
+
+    it "extracts company registration number from simple string when it is shortened" do
+      content = "6883289"
+
+      expect(
+        described_class.extract_from(content)
+      ).to match_array(["6883289"])
+    end
+
+    it "extracts company registration number from HTML block" do
+      content = %Q{<blockquote>Registered Company Number -&nbsp;.06883289</blockquote>\r\n\r\n<p>&nbsp;</p>\r\n}
+      alternative_content = %Q{<p>My company number is :06883289.</p>\r\n}
+
+      expect(
+        described_class.extract_from(content)
+      ).to match_array(["06883289"])
+
+      expect(
+        described_class.extract_from(alternative_content)
+      ).to match_array(["06883289"])
+    end
+
+    it "extracts multiple company registration numbers from HTML block" do
+      content = %Q{<p>My company numbers are 06883289 and 02429054 as well as 05637000</p>\r\n}
+
+      expect(
+        described_class.extract_from(content)
+      ).to match_array(["06883289", "02429054", "05637000"])
+    end
+  end
+end
+

--- a/spec/validators/company_registration_number_validator_spec.rb
+++ b/spec/validators/company_registration_number_validator_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CompanyRegistrationNumberValidator do
+  def anonymous_class
+    Class.new(ActiveRecord::Base) do
+      self.table_name = "company_registration_number_validator_test"
+
+      validates :registration_number, company_registration_number: true
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "temp")
+      end
+    end
+  end
+
+  before(:each) do
+    ActiveRecord::Base.connection.create_table :company_registration_number_validator_test do |t|
+      t.string :registration_number
+    end
+  end
+
+  it "should validate valid registration number" do
+    %w[
+      123456
+      1234567
+      01234567
+      OC555555
+      LP003139
+      SC123456
+      SO305443
+      SL002900
+      NI123456
+      R0000284
+      NC001306
+      NL000107
+    ].each do |registration_number|
+      model = anonymous_class.new(registration_number: registration_number)
+      expect(model).to be_valid
+    end
+  end
+
+  it "should validate invalid registration number" do
+    %w[
+      012345678
+      AB123456
+      XXXXXXXX
+    ].each do |registration_number|
+      model = anonymous_class.new(registration_number: registration_number)
+      expect(model).to be_invalid
+    end
+  end
+end
+


### PR DESCRIPTION
Asana card here: https://app.asana.com/0/1200504523179345/1202115307313426/f

 - Added validator for validating company registration number. Works well with correctly formatted numbers as well as numbers having leading zero(s) omitted
 - Added extractor service class for extracting company registration numbers from content. Simple string as well as HTML block can be passed to it. It also works when extracting multiple numbers
 - Query to get other applications by the same entity based on the submitted registration number. Still need some work as for example if on the current application the registration number is `6883289`, we may want to look for the applications containing also `06883289` as that is the valid format of the same number.