### PR TITLE
Use `setTimeout` to delay fn execution during page load

### DIFF
--- a/app/assets/javascripts/frontend/custom_questions/options_with_preselected_conditions_question.js.coffee
+++ b/app/assets/javascripts/frontend/custom_questions/options_with_preselected_conditions_question.js.coffee
@@ -11,7 +11,10 @@ window.OptionsWithPreselectedConditionsQuestion = init: ->
       dependable_children_div_block.find("h2 [data-preselected-condition='default']").removeClass "display-none"
       dependable_controls.removeClass "display-none"
     else
-      $(".js-options-with-dependent-child-select").trigger("change")
+      setTimeout (->
+        $(".js-options-with-dependent-child-select").trigger("change")
+        return
+      ), 10
 
     # otherwise it's always true on page load
     # when user triggers this method manually


### PR DESCRIPTION
Some selectors don't seem to be ready during page load as lot is done through Javascript so trying to delay triggering change.