### PR TITLE
Upgrade bundler version for CI and CF buildpack version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           DISPLAY_SOCIAL_MOBILITY_AWARD: true
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/qae_test"
-          BUNDLER_VERSION: 2.3.26
+          BUNDLER_VERSION: 2.4.4
           DOCKER_TLS_CERTDIR: ""
         run: |
           sudo apt update

--- a/bin/deploy
+++ b/bin/deploy
@@ -10,7 +10,7 @@ curl -X POST \
 $SLACK_WEBHOOK
 
 # Pin ruby buildpack
-export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.9.0"
+export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.9.1"
 
 cf create-app-manifest "$CF_APP"-worker
 cf push -f "$CF_APP"-worker_manifest.yml -b $CF_BUILDPACK


### PR DESCRIPTION
## 📝 A short description of the changes

Buildpack upgrades are due 17-02-2023. This commit updates the application to be compatible with the latest buildpack release.

* updates to the latest CloudFoundry buildpack version to 1.9.1
* uses latest compatible bundler version, 2.4.4
* no ruby version changes

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1203947141166914/f

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits
- [ ] I have attached screenshots of visual changes
