### PR TITLE
Replaces queen with king in automated system mailers

### DIFF
--- a/app/mailers/account_mailers/base_mailer.rb
+++ b/app/mailers/account_mailers/base_mailer.rb
@@ -1,5 +1,5 @@
 class AccountMailers::BaseMailer < ApplicationMailer
-  default from: ENV["MAILER_FROM"] || "no-reply@queens-awards-enterprise.service.gov.uk",
+  default from: ENV["MAILER_FROM"] || "no-reply@kings-awards-enterprise.service.gov.uk",
           reply_to: "kingsawards@beis.gov.uk"
 
   layout "mailer"

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 class ApplicationMailer < Mail::Notify::Mailer
 
-  default from: ENV["MAILER_FROM"] || "no-reply@queens-awards-enterprise.service.gov.uk",
+  default from: ENV["MAILER_FROM"] || "no-reply@kings-awards-enterprise.service.gov.uk",
           reply_to: "kingsawards@beis.gov.uk"
 
   def send_mail_if_not_bounces(template_id, headers)

--- a/app/mailers/users/audit_certificate_mailer.rb
+++ b/app/mailers/users/audit_certificate_mailer.rb
@@ -3,7 +3,7 @@ class Users::AuditCertificateMailer < ApplicationMailer
     @form_answer = FormAnswer.find(form_answer_id).decorate
     @recipient = User.find(user_id).decorate
 
-    subject = "Queen's Awards for Enterprise: Verification of Commercial Figures submitted"
+    subject = "King's Awards for Enterprise: Verification of Commercial Figures submitted"
     send_mail_if_not_bounces ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @recipient.email, subject: subject_with_env_prefix(subject)
   end
 end

--- a/app/mailers/users/collaboration_mailer.rb
+++ b/app/mailers/users/collaboration_mailer.rb
@@ -6,7 +6,7 @@ class Users::CollaborationMailer < ApplicationMailer
     @generated_password = generated_password
     @devise_confirmation_token = devise_confirmation_token
 
-    @subject = "[Queen's Awards for Enterprise] #{@user_who_added.full_name} added you to collaborators!"
+    @subject = "[King's Awards for Enterprise] #{@user_who_added.full_name} added you to collaborators!"
 
     send_mail_if_not_bounces ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @collaborator.email, subject: subject_with_env_prefix(@subject)
   end

--- a/app/mailers/users/commercial_figures_mailer.rb
+++ b/app/mailers/users/commercial_figures_mailer.rb
@@ -3,7 +3,7 @@ class  Users::CommercialFiguresMailer < ApplicationMailer
     @form_answer = FormAnswer.find(form_answer_id).decorate
     @recipient = User.find(user_id).decorate
 
-    subject = "Queen's Awards for Enterprise: Latest financial information has been submitted"
+    subject = "King's Awards for Enterprise: Latest financial information has been submitted"
     send_mail_if_not_bounces ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @recipient.email, subject: subject_with_env_prefix(subject)
   end
 end

--- a/app/mailers/users/submission_mailer.rb
+++ b/app/mailers/users/submission_mailer.rb
@@ -5,7 +5,7 @@ class Users::SubmissionMailer < ApplicationMailer
     @form_answer = FormAnswer.find(form_answer_id).decorate
     @form_owner = @form_answer.user.decorate
     @recipient = User.find(user_id).decorate
-    @subject = "[Queen's Awards for Enterprise] submission successfully created!"
+    @subject = "[King's Awards for Enterprise] submission successfully created!"
 
     send_mail_if_not_bounces ENV['GOV_UK_NOTIFY_API_TEMPLATE_ID'], to: @recipient.email, subject: subject_with_env_prefix(@subject)
   end

--- a/app/views/admins/mailer/confirmation_instructions.text.erb
+++ b/app/views/admins/mailer/confirmation_instructions.text.erb
@@ -1,6 +1,6 @@
 Welcome <%= @email %>
 
-You have signed up for a Queen's Awards for Enterprise account.
+You have signed up for a King's Awards for Enterprise account.
 
 You can confirm your email account using link below:
 <%= confirmation_url(@resource, confirmation_token: @token) %>
@@ -10,4 +10,4 @@ We recommend that you bookmark the login page to make it easier to find it in fu
 If you've not signed up for an account with us, you can ignore this email.
 
 Thank you,
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/admins/mailer/reset_password_instructions.text.erb
+++ b/app/views/admins/mailer/reset_password_instructions.text.erb
@@ -8,4 +8,4 @@ You can reset your password using link below:
 If you didn't request a password reset, someone may be trying to access your account.
 
 Thank you,
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/admins/mailer/unlock_instructions.text.erb
+++ b/app/views/admins/mailer/unlock_instructions.text.erb
@@ -7,4 +7,4 @@ Click the link below to unlock your account:
 <%= unlock_url(@resource, unlock_token: @token) %>
 
 Thank you,
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/assessors/general_mailer/audit_certificate_uploaded.text.erb
+++ b/app/views/assessors/general_mailer/audit_certificate_uploaded.text.erb
@@ -7,4 +7,4 @@ You can view this application via the link below:
 
 Thank you,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/assessors/general_mailer/led_application_withdrawn.text.erb
+++ b/app/views/assessors/general_mailer/led_application_withdrawn.text.erb
@@ -7,4 +7,4 @@ You can view this application via the link below:
 
 Thank you,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/assessors/general_mailer/vat_returns_submitted.text.erb
+++ b/app/views/assessors/general_mailer/vat_returns_submitted.text.erb
@@ -7,4 +7,4 @@ You can view this application via the link below:
 
 Thank you,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/users/audit_certificate_mailer/notify.text.erb
+++ b/app/views/users/audit_certificate_mailer/notify.text.erb
@@ -6,4 +6,4 @@ Please do not make any public announcement of your shortlisted status as the ass
 
 Kind regards,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/users/collaboration_mailer/access_granted.text.erb
+++ b/app/views/users/collaboration_mailer/access_granted.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @collaborator.full_name %>,
 
-<%= @user_who_added.full_name %> has invited you to collaborate with them on a Queen's Award for Enterprise application.
+<%= @user_who_added.full_name %> has invited you to collaborate with them on a King's Award for Enterprise application.
 
 <% if @new_user %>
   Your username:
@@ -9,12 +9,12 @@ Dear <%= @collaborator.full_name %>,
   Your password:
   <%= @generated_password %>
 
-  You need to confirm your email to access your account through the link below: 
+  You need to confirm your email to access your account through the link below:
   <%= confirmation_url(@collaborator, confirmation_token: @devise_confirmation_token) %>
 
-  After confirmation you can log in using link: 
+  After confirmation you can log in using link:
   <%= new_user_session_url %>
-  
+
   Also you can optionaly change your password using link:
   <%= password_settings_account_url %>
 <% else %>
@@ -24,4 +24,4 @@ Dear <%= @collaborator.full_name %>,
 
 Thank you,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/users/commercial_figures_mailer/notify.text.erb
+++ b/app/views/users/commercial_figures_mailer/notify.text.erb
@@ -6,4 +6,4 @@ Please do not make any public announcement of your shortlisted status as the ass
 
 Kind regards,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,6 +1,6 @@
 Welcome <%= @email %>,
 
-You have signed up for a Queen's Awards for Enterprise account.
+You have signed up for a King's Awards for Enterprise account.
 
 You can confirm your email via the link below:
 <%= confirmation_url(@resource, confirmation_token: @token) %>
@@ -12,4 +12,4 @@ Note: If you are having issues opening the confirmation link then please try usi
 
 Thank you,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -9,4 +9,4 @@ If you didn't request a password reset, someone may be trying to access your acc
 
 Thank you,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/users/mailer/unlock_instructions.html.erb
+++ b/app/views/users/mailer/unlock_instructions.html.erb
@@ -9,4 +9,4 @@ Note: If you are having issues opening the confirmation link then please try usi
 
 Thank you,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/app/views/users/submission_mailer/success.text.erb
+++ b/app/views/users/submission_mailer/success.text.erb
@@ -2,19 +2,19 @@
 
 <%= "Dear #{@recipient.full_name}," %>
 
-Thank you for submitting your <%= app_alias %> for <%= @form_answer.promotion? ? "The Queen's Award for Enterprise Promotion" : "The Queen's Awards for Enterprise" %> <%= AwardYear.current.year %>.
+Thank you for submitting your <%= app_alias %> for <%= @form_answer.promotion? ? "The King's Award for Enterprise Promotion" : "The King's Awards for Enterprise" %> <%= AwardYear.current.year %>.
 
-Your Unique Reference Number (URN) is 
+Your Unique Reference Number (URN) is
 #<%= @form_answer.urn %>
 
-You can view and download your submissions (and edit up until <%= remove_html_tags(application_deadline(:submission_end)) %>) by logging into your account:  
+You can view and download your submissions (and edit up until <%= remove_html_tags(application_deadline(:submission_end)) %>) by logging into your account:
 <%= dashboard_url %>
 
-To find out more on what happens next visit please review The Queen’s Awards for Enterprise timeline information page:
+To find out more on what happens next visit please review The King's Awards for Enterprise timeline information page:
 <%= timeline_url %>
 
 If you have any further queries about the <%= app_alias %> process you can call us on 020 7215 6880 or email us kingsawards@beis.gov.uk.
 
 Kind regards,
 
-The Queen's Awards Office
+The King's Awards Office

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,7 +5,7 @@ Devise.setup do |config|
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in DeviseMailer.
-  config.mailer_sender = ENV["MAILER_FROM"] || "no-reply@queens-awards-enterprise.service.gov.uk"
+  config.mailer_sender = ENV["MAILER_FROM"] || "no-reply@kings-awards-enterprise.service.gov.uk"
 
   # Configure the class responsible to send e-mails.
   #config.mailer = "Devise::Mailer"

--- a/spec/mailers/account_mailers/business_apps_winners_mailer_spec.rb
+++ b/spec/mailers/account_mailers/business_apps_winners_mailer_spec.rb
@@ -25,7 +25,7 @@ describe AccountMailers::BusinessAppsWinnersMailer do
   describe "#notify" do
     it "renders the headers" do
       expect(mail.to).to eq([account_holder.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/account_mailers/notify_non_shortlisted_mailer_spec.rb
+++ b/spec/mailers/account_mailers/notify_non_shortlisted_mailer_spec.rb
@@ -22,7 +22,7 @@ describe AccountMailers::NotifyNonShortlistedMailer do
     it "renders the headers" do
       expect(mail.subject).to eq(subject)
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do
@@ -46,7 +46,7 @@ describe AccountMailers::NotifyNonShortlistedMailer do
     it "renders the headers" do
       expect(mail.subject).to eq(subject)
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/account_mailers/notify_shortlisted_mailer_spec.rb
+++ b/spec/mailers/account_mailers/notify_shortlisted_mailer_spec.rb
@@ -31,7 +31,7 @@ describe AccountMailers::NotifyShortlistedMailer do
     it "renders the headers" do
       expect(mail.subject).to eq(subject)
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do
@@ -55,7 +55,7 @@ describe AccountMailers::NotifyShortlistedMailer do
     it "renders the headers" do
       expect(mail.subject).to eq(subject)
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/account_mailers/promotion_letters_of_support_reminder_spec.rb
+++ b/spec/mailers/account_mailers/promotion_letters_of_support_reminder_spec.rb
@@ -27,7 +27,7 @@ describe AccountMailers::PromotionLettersOfSupportReminderMailer do
   describe "#notify" do
     it "renders the headers" do
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/account_mailers/reminder_to_submit_mailer_spec.rb
+++ b/spec/mailers/account_mailers/reminder_to_submit_mailer_spec.rb
@@ -15,7 +15,7 @@ describe AccountMailers::ReminderToSubmitMailer do
   describe "#notify" do
     it "renders the headers" do
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/users/audit_certificate_request_mailer_spec.rb
+++ b/spec/mailers/users/audit_certificate_request_mailer_spec.rb
@@ -27,7 +27,7 @@ describe Users::AuditCertificateRequestMailer do
     it "renders the headers" do
       expect(mail.subject).to eq(subject)
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/users/collaboration_mailer_spec.rb
+++ b/spec/mailers/users/collaboration_mailer_spec.rb
@@ -37,7 +37,7 @@ describe Users::CollaborationMailer do
       it "renders the headers" do
         expect(mail.subject).to eq("[King's Awards for Enterprise] #{subject}")
         expect(mail.to).to eq([new_account_admin.email])
-        expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+        expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
       end
 
       it "renders the body" do
@@ -71,7 +71,7 @@ describe Users::CollaborationMailer do
       it "renders the headers" do
         expect(mail.subject).to eq("[King's Awards for Enterprise] #{subject}")
         expect(mail.to).to eq([new_account_admin.email])
-        expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+        expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
       end
 
       it "renders the body" do

--- a/spec/mailers/users/collaboration_mailer_spec.rb
+++ b/spec/mailers/users/collaboration_mailer_spec.rb
@@ -35,7 +35,7 @@ describe Users::CollaborationMailer do
       let(:subject) { "#{account_admin.decorate.full_name} added you to collaborators!" }
 
       it "renders the headers" do
-        expect(mail.subject).to eq("[Queen's Awards for Enterprise] #{subject}")
+        expect(mail.subject).to eq("[King's Awards for Enterprise] #{subject}")
         expect(mail.to).to eq([new_account_admin.email])
         expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
       end
@@ -69,7 +69,7 @@ describe Users::CollaborationMailer do
       let(:subject) { "#{account_admin.decorate.full_name} added you to collaborators!" }
 
       it "renders the headers" do
-        expect(mail.subject).to eq("[Queen's Awards for Enterprise] #{subject}")
+        expect(mail.subject).to eq("[King's Awards for Enterprise] #{subject}")
         expect(mail.to).to eq([new_account_admin.email])
         expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
       end

--- a/spec/mailers/users/custom_mailer_spec.rb
+++ b/spec/mailers/users/custom_mailer_spec.rb
@@ -14,7 +14,7 @@ describe Users::CustomMailer do
     it "renders the headers" do
       expect(mail.subject).to eq(subject)
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/users/shortlisted_reminder_mailer_spec.rb
+++ b/spec/mailers/users/shortlisted_reminder_mailer_spec.rb
@@ -27,7 +27,7 @@ describe Users::ShortlistedReminderMailer do
     it "renders the headers" do
       expect(mail.subject).to eq(subject)
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/users/submission_spec.rb
+++ b/spec/mailers/users/submission_spec.rb
@@ -19,7 +19,7 @@ describe Users::SubmissionMailer do
     let(:mail) { Users::SubmissionMailer.success(user.id, form_answer.id) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("[Queen's Awards for Enterprise] #{subject}")
+      expect(mail.subject).to eq("[King's Awards for Enterprise] #{subject}")
       expect(mail.to).to eq([user.email])
       expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
     end

--- a/spec/mailers/users/submission_spec.rb
+++ b/spec/mailers/users/submission_spec.rb
@@ -21,7 +21,7 @@ describe Users::SubmissionMailer do
     it "renders the headers" do
       expect(mail.subject).to eq("[King's Awards for Enterprise] #{subject}")
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/users/submission_started_notification_mailer_spec.rb
+++ b/spec/mailers/users/submission_started_notification_mailer_spec.rb
@@ -16,7 +16,7 @@ describe Users::SubmissionStartedNotificationMailer do
     it "renders the headers" do
       expect(mail.subject).to eq(subject)
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+      expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
     end
 
     it "renders the body" do

--- a/spec/mailers/users/supporter_mailer_spec.rb
+++ b/spec/mailers/users/supporter_mailer_spec.rb
@@ -19,7 +19,7 @@ describe Users::SupporterMailer do
   it "renders the headers" do
     expect(mail.subject).to eq("[Queen's Awards for Enterprise] Support Letter Request")
     expect(mail.to).to eq([supporter.email])
-    expect(mail.from).to eq(["no-reply@queens-awards-enterprise.service.gov.uk"])
+    expect(mail.from).to eq(["no-reply@kings-awards-enterprise.service.gov.uk"])
   end
 
   it "contains link to the support letter form and nominee's name" do


### PR DESCRIPTION
## 📝 A short description of the changes

* This commit replaces 'queen' with 'king' in automatically generated system emails (password resets etc)

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1203975580941719/f

## :shipit: Deployment implications

* The from email address has been changed from 'no-reply@queens-awards-enterprise.service.gov.uk' to 'no-reply@kings-awards-enterprise.service.gov.uk' so this should not be merged into production until the switchover is ready.

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas - n/a
- [x] I have made corresponding changes to the documentation - n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits - n/a
- [x] I have attached screenshots of visual changes - n/a
