### PR TITLE
Changes queen references to king in URN generation and report headers

### DIFF
--- a/app/models/reports/cases_status_report.rb
+++ b/app/models/reports/cases_status_report.rb
@@ -91,7 +91,7 @@ class Reports::CasesStatusReport
       method: :case_withdrawn
     },
     {
-      label: "QAEOPermission",
+      label: "KAOPermission",
       method: :qao_permission
     },
     {

--- a/app/models/reports/press_book_list.rb
+++ b/app/models/reports/press_book_list.rb
@@ -91,7 +91,7 @@ class Reports::PressBookList
       method: :assessor_agreed_press_note
     },
     {
-      label: "QAOAgreedPressNote",
+      label: "KAOAgreedPressNote",
       method: :qao_agreed_press_note
     },
     {

--- a/app/models/reports/registered_users.rb
+++ b/app/models/reports/registered_users.rb
@@ -91,15 +91,15 @@ class Reports::RegisteredUsers
       method: :employees
     },
     {
-      label: "QAOPermission",
+      label: "KAOPermission",
       method: :qao_permission
     },
     {
-      label: "HowDidYouHearAboutQA",
+      label: "HowDidYouHearAboutKA",
       method: :qae_info_source
     },
     {
-      label: "HowDidYouHearAboutQAOther",
+      label: "HowDidYouHearAboutKAOther",
       method: :qae_info_source_other
     }
   ]

--- a/app/models/urn_builder.rb
+++ b/app/models/urn_builder.rb
@@ -20,7 +20,7 @@ class UrnBuilder
 
     next_seq = fa.class.connection.select_value("SELECT nextval(#{ActiveRecord::Base.connection.quote(sequence_attr)})")
 
-    generated_urn = "QA#{sprintf('%.4d', next_seq)}/"
+    generated_urn = "KA#{sprintf('%.4d', next_seq)}/"
     suffix = {
       "promotion" => "EP",
       "development" => "S",

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -26,7 +26,7 @@ module PdfAuditCertificates::General::SharedElements
   end
 
   def render_urn
-    render_text_line("<b>QA ref</b>: #{form_answer.urn}", 1, inline_format: true)
+    render_text_line("<b>KA ref</b>: #{form_answer.urn}", 1, inline_format: true)
   end
 
   def render_base_paragraph

--- a/app/pdf_generators/shared_pdf_helpers/draw_elements.rb
+++ b/app/pdf_generators/shared_pdf_helpers/draw_elements.rb
@@ -16,7 +16,7 @@ module SharedPdfHelpers::DrawElements
   end
 
   def render_urn(x_coord, y_coord)
-    pdf_doc.text_box "QA Ref: #{form_answer.urn}",
+    pdf_doc.text_box "KA Ref: #{form_answer.urn}",
                      header_text_properties.merge(at: [x_coord.mm, y_coord.mm + DEFAULT_OFFSET])
   end
 

--- a/spec/models/form_answer_spec.rb
+++ b/spec/models/form_answer_spec.rb
@@ -198,12 +198,12 @@ RSpec.describe FormAnswer, type: :model do
     let(:award_year) {AwardYear.current.year.to_s[2..-1]}
 
     it "creates form with URN" do
-      expect(form_answer.urn).to eq("QA0001/#{award_year}T")
+      expect(form_answer.urn).to eq("KA0001/#{award_year}T")
     end
 
     it "increments URN" do
       other_form_answer = create(:form_answer, :trade, :submitted)
-      expect(other_form_answer.urn).to eq("QA0002/#{award_year}T")
+      expect(other_form_answer.urn).to eq("KA0002/#{award_year}T")
     end
 
     it "increments global counter, shared for all categories" do
@@ -212,10 +212,10 @@ RSpec.describe FormAnswer, type: :model do
       form3 = create(:form_answer, :promotion, submitted_at: Time.current)
       form4 = create(:form_answer, :development, submitted_at: Time.current)
 
-      expect(form1.urn).to eq("QA0002/#{award_year}T")
-      expect(form2.urn).to eq("QA0003/#{award_year}I")
-      expect(form3.urn).to eq("QA0001/18EP")
-      expect(form4.urn).to eq("QA0004/#{award_year}S")
+      expect(form1.urn).to eq("KA0002/#{award_year}T")
+      expect(form2.urn).to eq("KA0003/#{award_year}I")
+      expect(form3.urn).to eq("KA0001/18EP")
+      expect(form4.urn).to eq("KA0004/#{award_year}S")
     end
   end
 

--- a/spec/support/shared_contexts/admin_case_summary_pdf_file_checks.rb
+++ b/spec/support/shared_contexts/admin_case_summary_pdf_file_checks.rb
@@ -42,7 +42,7 @@ shared_context "admin case summary pdf file checks" do
   end
 
   let(:urn) do
-    "QA Ref: #{form_answer.urn}"
+    "KA Ref: #{form_answer.urn}"
   end
 
   let(:applicant) do

--- a/spec/support/shared_contexts/admin_feedback_pdf_file_checks.rb
+++ b/spec/support/shared_contexts/admin_feedback_pdf_file_checks.rb
@@ -42,7 +42,7 @@ shared_context "admin feedback pdf file checks" do
   end
 
   let(:urn) do
-    "QA Ref: #{form_answer.urn}"
+    "KA Ref: #{form_answer.urn}"
   end
 
   let(:applicant) do


### PR DESCRIPTION
## 📝 A short description of the changes

* Changes the URN builder to use the prefix KAO instead of QAO
* Changes report headers from QAE and QAO to KAE and KAO respectively

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/home/1200061634431011/1203714690964341
* https://docs.google.com/spreadsheets/d/16keNAr6gpdaHJNs6Ja_JPjp-_5-uTDMndqaPYQSzZno/edit#gid=1982224279

## :shipit: Deployment implications

* To be deployed to production with other rebrand changes

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft - n/a
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas - n/a
- [x] I have made corresponding changes to the documentation - n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits - n/a
- [x] I have attached screenshots of visual changes - n/a
