### PR TITLE
Change past applications back to queens award

### DIFF
--- a/app/views/content_only/past_applications/_winners.html.slim
+++ b/app/views/content_only/past_applications/_winners.html.slim
@@ -5,7 +5,7 @@
   .content-right.content-offset-36
     p.govuk-body
       strong
-        ' Congratulations on winning a King's Award for Enterprise
+        ' Congratulations on winning a Queen's Award for Enterprise
   .clear
 
 - past_awarded_applications.each do |award|


### PR DESCRIPTION
## 📝 A short description of the changes

* Past applications will still be referred to as Queen's Awards on the site so this change reverts a previous change.

### 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="902" alt="Screenshot 2023-02-21 at 09 23 41" src="https://user-images.githubusercontent.com/65811538/220303311-38a29f75-4062-404b-a84f-f98e362ead6c.png">

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/home/1200061634431011/1204007081172114

## :shipit: Deployment implications

* To be deployed with other rebranding changes

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft - n/a
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas - n/a
- [x] I have made corresponding changes to the documentation - n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits - n/a
- [x] I have attached screenshots of visual changes