### PR TITLE
Moves notification banner from season-opens-soon to season-closed

### DIFF
--- a/app/views/content_only/info_messages/_award_season_closed.html.slim
+++ b/app/views/content_only/info_messages/_award_season_closed.html.slim
@@ -1,6 +1,15 @@
 article.group role="article"
   div
-    br
+    .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+      .govuk-notification-banner__header
+        .govuk-notification-banner__title#govuk-notification-banner-title
+          | Important
+      .govuk-notification-banner__content
+        p.govuk-notification-banner__heading.name-change-notification
+          | We are delighted to announce that the name of these Awards has changed to The King's Awards for Enterprise. The first King's Awards will be announced on 21 April 2023, The Late Queen Elizabeth II's birthday. Please see the
+          =<> link_to "official press notice", "", target: '_blank'
+          | for further details.
+
     .application-notice.info-notice
       p.govuk-body
         = render "content_only/info_messages/new_users_message"

--- a/app/views/content_only/info_messages/_award_season_opens_soon.html.slim
+++ b/app/views/content_only/info_messages/_award_season_opens_soon.html.slim
@@ -2,16 +2,7 @@
 
 article.group role="article"
   div
-    .govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
-      .govuk-notification-banner__header
-        .govuk-notification-banner__title#govuk-notification-banner-title
-          | Important
-      .govuk-notification-banner__content
-        p.govuk-notification-banner__heading.name-change-notification
-          | We are delighted to announce that the name of these Awards has changed to The King's Awards for Enterprise. The first King's Awards will be announced on 21 April 2023, The Late Queen Elizabeth II's birthday. Please see the
-          =<> link_to "official press notice", "", target: '_blank'
-          | for further details.
-
+    br
     .application-notice.info-notice
       p.govuk-body
         = render "content_only/info_messages/new_users_message"


### PR DESCRIPTION
## 📝 A short description of the changes

* The notification banner is to inform users about the rebrand to Kings Awards for Enterprise. As production is currently in the shortlisted stage, the notification should appear in the award-season-closed partial and not in the award-season-opens-soon partial. This will now display to users in the current stage.

### 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="976" alt="Screenshot 2023-02-21 at 15 42 47" src="https://user-images.githubusercontent.com/65811538/220392480-8b268fe7-f5ea-43db-8328-e053da527cb8.png">

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/home/1200061634431011/1203936475486477

## :shipit: Deployment implications

* To deploy with other rebrand commits.

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
- [x] I have attached screenshots of visual changes
