### PR TITLE
removes product input question

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -827,6 +827,35 @@ jQuery ->
       $("#form_eligibility_show").addClass("visuallyhidden")
       $("#form_eligibility_questions").removeClass("visuallyhidden")
 
+  # Updates labels and ids on trade product fields
+  resetTradeProductIndexes = (question) ->
+    list_count = question.find("li").length
+    question.find("li").each (index) ->
+      idx = index + 1
+      id = "form[trade_goods_and_services_explanations"
+      name = "form[trade_goods_and_services_explanations]"
+      products = $(this).find(".trade-good-product")
+      percentages = $(this).find(".trade-good-percentage")
+      word_limit = products.find("textarea").attr("data-word-max")
+      remove_link = $(this).find(".js-remove-link")
+
+      products.find("label").get(0).innerText = "Product/Service " + idx + " (word limit: #{word_limit}):"
+      products.find("label").attr("for", id + "_desc_short_#{idx}]" )
+      products.find("textarea").attr({
+        "id": id + "_desc_short_#{idx}]",
+        "name": name + "[#{idx}][desc_short]"
+      })
+      percentages.find("label").attr("for", id + "_total_overseas_trade_#{idx}]")
+      percentages.find("input").attr({
+        "id": id + "_total_overseas_trade_#{idx}]",
+        "name": name + "[#{idx}][total_overseas_trade]"
+      })
+      remove_link.attr("aria-label", "Remove " + ordinal(idx) + " product")
+      if list_count <= 1
+        remove_link.addClass("visuallyhidden")
+      else
+        remove_link.removeClass("visuallyhidden")
+
   # Clicking `+ Add` on certain questions add fields
   $(document).on "click", ".question-block .js-button-add", (e) ->
     e.preventDefault()
@@ -851,16 +880,20 @@ jQuery ->
             can_add = false
 
           if li_size + 1 >= add_limit_attr
-            question.find(".js-button-add").addClass("govuk-!-display-none")
+            question.find(".js-button-add").addClass("visuallyhidden")
+
 
         if can_add
           add_eg = add_eg.replace(/((\w+|_)\[(\w+|_)\]\[)(\d+)\]/g, "$1#{li_size}]")
           add_eg = add_eg.replace(/((\w+|_)\[(\w+|_)\]\[)(\{index\})\]/g, "$1#{li_size}]")
 
-          question.find(".list-add").append("<li class='js-add-example js-list-item'>#{add_eg}</li>")
+          question.find(".list-add").append("<li class='js-add-example if-no-js-hide js-list-item'>#{add_eg}</li>")
           question.find(".list-add").find("li:last-child input").prop("disabled", false)
 
           idx = question.find(".list-add").find("> li").length
+
+          # update labels and aria-labels on new product fields
+          resetTradeProductIndexes(question.find(".list-add"))
 
           question.find(".list-add").find("li:last-child .remove-link").attr("aria-label", "Remove " + ordinal(idx) + " " + entity)
           clear_example = question.find(".list-add").attr("data-need-to-clear-example")
@@ -889,7 +922,9 @@ jQuery ->
   # Removing these added fields
   $(document).on "click", ".govuk-form-group .list-add .js-remove-link", (e) ->
     e.preventDefault()
+
     if !$(this).hasClass("read-only")
+      parent = $(this).closest(".list-add")
       parent_ul = $(this).closest("ul")
       $(this).closest(".govuk-form-group")
              .find(".js-button-add")
@@ -907,6 +942,8 @@ jQuery ->
         $("input.remove", $(this).closest("li")).val("1")
       else
         $(this).closest("li").remove()
+
+      resetTradeProductIndexes(parent)
 
       questionAddDefaultReached(parent_ul)
       window.FormValidation.validateStep()

--- a/app/assets/javascripts/frontend/clear_form_elements.js.coffee
+++ b/app/assets/javascripts/frontend/clear_form_elements.js.coffee
@@ -1,7 +1,7 @@
 window.clearFormElements = (obj) ->
   obj.find(':input').each ->
     switch @type
-      when 'password', 'text', 'textarea', 'file', 'select-one', 'select-multiple', 'tel'
+      when 'password', 'text', 'textarea', 'file', 'select-one', 'select-multiple', 'tel', 'number'
         $(this).val ''
       when 'checkbox', 'radio'
         @checked = false

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -126,14 +126,9 @@ window.FormValidation =
     # if it's a conditional question, but condition was not satisfied
     conditional = true
 
-    if question.find(".js-by-trade-goods-and-services-amount").length > 0
-      # If it's the trade B1 question which has multiple siblings that have js-conditional-question
-      if question.find(".js-conditional-question.show-question .js-by-trade-goods-and-services-amount .js-conditional-question.show-question").length == 0
+    question.find(".js-conditional-question").each ->
+      if !$(this).hasClass("show-question")
         conditional = false
-    else
-      question.find(".js-conditional-question").each ->
-        if !$(this).hasClass("show-question")
-          conditional = false
 
     if !conditional
       return
@@ -142,7 +137,7 @@ window.FormValidation =
     # like name and address
     if question.find(".js-by-trade-goods-and-services-amount").length > 0
       # If it's the trade B1 question which has multiple siblings that have js-conditional-question
-      subquestions = question.find(".js-by-trade-goods-and-services-amount .js-conditional-question.show-question .govuk-form-group")
+      subquestions = question.find(".js-by-trade-goods-and-services-amount .govuk-form-group")
     else
       subquestions = question.find(".govuk-form-group .govuk-form-group")
 
@@ -543,7 +538,7 @@ window.FormValidation =
       @addErrorClass(question)
 
   validateGoodsServicesPercentage: (question) ->
-    totalOverseasTradeInputs = question.find(".js-by-trade-goods-and-services-amount .show-question input[type='number']")
+    totalOverseasTradeInputs = question.find(".js-by-trade-goods-and-services-amount input[type='number']")
     totalOverseasTradePercentage = 0
     missingOverseasTradeValue = false
     totalOverseasTradeInputs.each ->
@@ -551,11 +546,10 @@ window.FormValidation =
         totalOverseasTradePercentage += parseFloat($(this).val())
       else
         missingOverseasTradeValue = true
-    if !missingOverseasTradeValue
-      if totalOverseasTradePercentage != 100
-        @logThis(question, "validateGoodsServicesPercentage", "% of your total overseas trade should add up to 100")
-        @appendMessage(question, "% of your total overseas trade should add up to 100")
-        @addErrorClass(question)
+    if totalOverseasTradePercentage != 100
+      @logThis(question, "validateGoodsServicesPercentage", "% of your total overseas trade should add up to 100")
+      @appendMessage(question, "% of your total overseas trade should add up to 100")
+      @addErrorClass(question)
 
   validateSelectionLimit: (question) ->
     selection_limit = question.data("selection-limit")

--- a/app/forms/award_years/v2024/international_trade/international_trade_step3.rb
+++ b/app/forms/award_years/v2024/international_trade/international_trade_step3.rb
@@ -74,24 +74,6 @@ class AwardYears::V2024::QAEForms
           application_type_question true
         end
 
-        dropdown :trade_goods_amount, "How many types of products/services make up your international trade?" do
-          classes "sub-question"
-          ref "C 2.1"
-          required
-          context %(
-            <p>
-              If you have more than 5, group them into fewer types of products/services.
-            </p>
-          )
-          option "", "Select"
-          option "1", "1"
-          option "2", "2"
-          option "3", "3"
-          option "4", "4"
-          option "5", "5"
-          default_option "1"
-        end
-
         by_trade_goods_and_services_label :trade_goods_and_services_explanations, "List and briefly describe each product or service you export." do
           classes "sub-question word-max-strict"
           sub_ref "C 2.3"
@@ -104,10 +86,8 @@ class AwardYears::V2024::QAEForms
               If relevant, give details of material used or end use, for example: 'design and manufacture of bespoke steel windows and doors'. Your percentage answers below should add up to 100.
             </p>
           )
-          additional_pdf_context %(
-            You will need to complete this information for each product or service depending on your answer to question B2.1
-          )
           rows 2
+          product_limit 5
           words_max 15
           min 0
           max 100

--- a/app/forms/qae_form_builder/by_trade_goods_and_services_label_question.rb
+++ b/app/forms/qae_form_builder/by_trade_goods_and_services_label_question.rb
@@ -8,7 +8,7 @@ class QAEFormBuilder
       result = super
 
       question.trade_goods_and_services.each_with_index do |entity, index|
-        if index + 1 <= question.answers["trade_goods_amount"].to_i
+        if index + 1 <= question.answers["trade_goods_and_services_explanations"].length.to_i
           question.required_sub_fields_list.each do |attr|
             if !entity[attr].present?
               result[question.key] ||= {}
@@ -18,7 +18,6 @@ class QAEFormBuilder
           end
         end
       end
-
       result
     end
 
@@ -38,7 +37,7 @@ class QAEFormBuilder
   end
 
   class ByTradeGoodsAndServicesLabelQuestionBuilder < QuestionBuilder
-    def rows num
+    def rows num=3
       @q.rows = num
     end
 
@@ -53,6 +52,10 @@ class QAEFormBuilder
     def max num
       @q.max = num
     end
+
+    def product_limit num
+      @q.product_limit = num
+    end
   end
 
   class ByAmountCondition
@@ -63,6 +66,6 @@ class QAEFormBuilder
   end
 
   class ByTradeGoodsAndServicesLabelQuestion < Question
-    attr_accessor :rows, :words_max, :min, :max
+    attr_accessor :rows, :words_max, :min, :max, :product_limit
   end
 end

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/lists.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/lists.rb
@@ -185,7 +185,7 @@ module QaePdfForms::CustomQuestions::Lists
   end
 
   def render_goods_and_services
-    trade_goods_amount = filled_answers["trade_goods_amount"]
+    trade_goods_amount = filled_answers["trade_goods_and_services_explanations"].length
 
     if trade_goods_amount.present?
       humanized_answer[0..(trade_goods_amount.to_i - 1)].map do |item|

--- a/app/views/admin/form_answers/company_details/_goods_services_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_goods_services_form.html.slim
@@ -8,7 +8,7 @@
         - elsif @form_answer.document["trade_goods_and_services_explanations"].present?
           ul.list-unstyled.good-services-list
             - @form_answer.document["trade_goods_and_services_explanations"].each_with_index do |service, index|
-              - if index < @form_answer.document["trade_goods_amount"].to_i
+              - if index < @form_answer.document["trade_goods_and_services_explanations"].length
                 li
                   label.label-small
                     = "Goods/services #{index + 1}"
@@ -24,7 +24,7 @@
               - elsif @form_answer.document["trade_goods_and_services_explanations"].present?
                 ul.list-unstyled.good-services-list
                   - @form_answer.document["trade_goods_and_services_explanations"].each_with_index do |service, index|
-                    - if index < @form_answer.document["trade_goods_amount"].to_i
+                    - if index < @form_answer.document["trade_goods_and_services_explanations"].length
                       li.well
                         label
                           = "Goods/services #{index + 1}"

--- a/app/views/qae_form/_by_trade_goods_and_services_fields.html.slim
+++ b/app/views/qae_form/_by_trade_goods_and_services_fields.html.slim
@@ -1,0 +1,19 @@
+li.js-add-example.js-list-item data-value=placement data-type="in_clause_collection"
+  .govuk-form-group.trade-good-product.question-required
+    label.govuk-label for=question.input_name(suffix: "desc_short_#{placement}")
+      = "Product/Service #{placement} (word limit: #{question.words_max}):"
+    - errors = @form_answer.validator_errors
+    - if errors && errors[question.key] && errors[question.key][index]
+      span.govuk-error-message
+        = errors[question.key][index]
+    span.govuk-error-message
+    textarea.govuk-textarea.js-trigger-autosave.js-char-count rows=question.rows data-word-max=question.words_max name="#{question.input_name}[#{index}][desc_short]" id=question.input_name(suffix: "desc_short_#{placement}") *possible_read_only_ops
+      = item.present? ? item['desc_short'] : ''
+
+  .govuk-form-group.trade-good-percentage.question-required
+    label.govuk-label for=question.input_name(suffix: "total_overseas_trade_#{placement}")
+      ' % of your total overseas trade:
+    span.govuk-error-message
+    input.js-trigger-autosave.govuk-input.govuk-input--width-5 type="number" pattern="[0-9]*" min=question.min max=question.max name="#{question.input_name}[#{index}][total_overseas_trade]" value=(item.present? ? item['total_overseas_trade'] : '') autocomplete="off" id=question.input_name(suffix: "total_overseas_trade_#{placement}") *possible_read_only_ops
+
+  = link_to "Remove", "#", class: "remove-link js-remove-link #{'visuallyhidden' if !item.present?} #{'read_only' if admin_in_read_only_mode?}"

--- a/app/views/qae_form/_by_trade_goods_and_services_label_question.html.slim
+++ b/app/views/qae_form/_by_trade_goods_and_services_label_question.html.slim
@@ -1,23 +1,16 @@
 .js-by-trade-goods-and-services-amount role="group" id="q_#{question.key}"
   input name="#{question.input_name}[array]" value="true" type="hidden" *possible_read_only_ops
 
-  - (1..5).each_with_index do |placement, index|
-    - item = question.trade_goods_and_services[index]
+  ol.list-add.if-no-js-hide data-add-limit="#{question.product_limit}" data-need-to-clear-example=true data-default="1"
+    - question.trade_goods_and_services.each_with_index do |product, index|
+      - placement = index + 1
+      - item = question.trade_goods_and_services[index]
+      = render "qae_form/by_trade_goods_and_services_fields", placement: placement, item: item, index: index, question: question
 
-    .js-conditional-question data-question=question.step.form[:trade_goods_amount].parameterized_title data-value=placement data-type="in_clause_collection"
-      .govuk-form-group
-        label.govuk-label for=question.input_name(suffix: "desc_short_#{placement}")
-          = "Product/Service #{placement} (word limit: #{question.words_max}):"
-        - errors = @form_answer.validator_errors
-        - if errors && errors[question.key] && errors[question.key][index]
-          span.govuk-error-message
-            = errors[question.key][index]
-        span.govuk-error-message
-        textarea.govuk-textarea.js-trigger-autosave.js-char-count rows=question.rows data-word-max=question.words_max name="#{question.input_name}[#{index}][desc_short]" id=question.input_name(suffix: "desc_short_#{placement}") *possible_read_only_ops
-          = item.present? ? item['desc_short'] : ''
+    - if question.trade_goods_and_services.count < 1
+      - index = 0, placement = 1, item = {}
+      = render "qae_form/by_trade_goods_and_services_fields", placement: placement, item: item, index: index, question: question
 
-      .govuk-form-group
-        label.govuk-label for=question.input_name(suffix: "total_overseas_trade_#{placement}")
-          ' % of your total overseas trade:
-        span.govuk-error-message
-        input.js-trigger-autosave.govuk-input.govuk-input--width-5 type="number" pattern="[0-9]*" min=question.min max=question.max name="#{question.input_name}[#{index}][total_overseas_trade]" value=(item.present? ? item['total_overseas_trade'] : '') autocomplete="off" id=question.input_name(suffix: "total_overseas_trade_#{placement}") *possible_read_only_ops
+  .if-no-js-hide.govuk-button-group
+    a.govuk-button.govuk-button--secondary.button-add.js-button-add class=("visuallyhidden" if question.trade_goods_and_services.count >= question.product_limit)  href="#" aria-label="Add another product or service" data-entity="product" *possible_read_only_ops
+        | Add another product or service

--- a/spec/fixtures/form_answer_trade.json
+++ b/spec/fixtures/form_answer_trade.json
@@ -138,7 +138,7 @@
 "financial_year_changed_dates_3of6day": "",
 "financial_year_changed_dates_4of6day": "",
 "financial_year_changed_dates_5of6day": "",
-"trade_goods_and_services_explanations": "[\"{\\\"desc_short\\\":\\\"123\\\",\\\"total_overseas_trade\\\":\\\"30\\\"}\", \"{\\\"desc_short\\\":\\\"\\\",\\\"total_overseas_trade\\\":\\\"\\\"}\", \"{\\\"desc_short\\\":\\\"\\\",\\\"total_overseas_trade\\\":\\\"\\\"}\", \"{\\\"desc_short\\\":\\\"\\\",\\\"total_overseas_trade\\\":\\\"\\\"}\", \"{\\\"desc_short\\\":\\\"\\\",\\\"total_overseas_trade\\\":\\\"\\\"}\"]",
+"trade_goods_and_services_explanations": "[\"{\\\"desc_short\\\":\\\"123\\\",\\\"total_overseas_trade\\\":\\\"100\\\"}\"]",
 "financial_year_changed_dates_1of3month": "",
 "financial_year_changed_dates_1of6month": "",
 "financial_year_changed_dates_2of3month": "",


### PR DESCRIPTION
## 📝 A short description of the changes

* replaces number of trade goods question with dynamic add buttons if more products are needed
- [x] Remove trade_goods_amount question
- [x] Replace trade_goods_amount with trade_goods_and_services_explanations.count in admin/form_answer#show
- [x] Replace other areas trade_goods_amount answer is used
- [x] Add "Add" button to display new product fields
- [x] After adding new product clear values from example-to-add copy
- [x] After adding new product change label and aria label for last .li item
- [x] Add remove link
- [x] Do not display remove link if only 1 product showing
- [x] When removing items need to reindex to display labels and aria labels incorrectly. (this does not currently work properly on the award question either B16.1).
- [x] Save/update all added fields to document
- [x] Show validation errors when total percentage does not equal 100% and when fields are empty 
- [ ] Check non-js/pdf version. Display all 5 product fields by default, hide add and remove buttons. Add copy help.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1203885366810939
* https://docs.google.com/document/d/1pA_tf278ooNyq3nkgOVYD5blBxRWXEMZ/
* Removing question C2.1

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

<img width="633" alt="Screenshot 2023-04-19 at 21 55 55" src="https://user-images.githubusercontent.com/65811538/233399325-29350fcc-4fe6-4cde-9e2e-34adfff11c00.png">
