### PR TITLE
adds additional product fields when js not enabled

### DIFF
--- a/app/views/qae_form/_by_trade_goods_and_services_fields.html.slim
+++ b/app/views/qae_form/_by_trade_goods_and_services_fields.html.slim
@@ -16,4 +16,4 @@ li.js-add-example.js-list-item data-value=placement data-type="in_clause_collect
     span.govuk-error-message
     input.js-trigger-autosave.govuk-input.govuk-input--width-5 type="number" pattern="[0-9]*" min=question.min max=question.max name="#{question.input_name}[#{index}][total_overseas_trade]" value=(item.present? ? item['total_overseas_trade'] : '') autocomplete="off" id=question.input_name(suffix: "total_overseas_trade_#{placement}") *possible_read_only_ops
 
-  = link_to "Remove", "#", class: "remove-link js-remove-link #{'visuallyhidden' if !item.present?} #{'read_only' if admin_in_read_only_mode?}"
+  = link_to "Remove", "#", class: "remove-link js-remove-link if-no-js-hide #{'visuallyhidden' if (count == 1)} #{'read_only' if admin_in_read_only_mode?}"

--- a/app/views/qae_form/_by_trade_goods_and_services_label_question.html.slim
+++ b/app/views/qae_form/_by_trade_goods_and_services_label_question.html.slim
@@ -1,16 +1,24 @@
 .js-by-trade-goods-and-services-amount role="group" id="q_#{question.key}"
   input name="#{question.input_name}[array]" value="true" type="hidden" *possible_read_only_ops
 
-  ol.list-add.if-no-js-hide data-add-limit="#{question.product_limit}" data-need-to-clear-example=true data-default="1"
+  ol.list-add data-add-limit="#{question.product_limit}" data-need-to-clear-example=true data-default="1"
     - question.trade_goods_and_services.each_with_index do |product, index|
       - placement = index + 1
       - item = question.trade_goods_and_services[index]
-      = render "qae_form/by_trade_goods_and_services_fields", placement: placement, item: item, index: index, question: question
+      = render "qae_form/by_trade_goods_and_services_fields", placement: placement, item: item, index: index, question: question, count: question.trade_goods_and_services.count
 
     - if question.trade_goods_and_services.count < 1
       - index = 0, placement = 1, item = {}
-      = render "qae_form/by_trade_goods_and_services_fields", placement: placement, item: item, index: index, question: question
+      = render "qae_form/by_trade_goods_and_services_fields", placement: placement, item: item, index: index, question: question, count: 1
+
+    noscript
+      .list-add
+        - if question.trade_goods_and_services.count < question.product_limit
+          - (question.trade_goods_and_services.count+1..question.product_limit).each do |index|
+            - placement = index
+            - item = {}
+            = render "qae_form/by_trade_goods_and_services_fields", placement: placement, item: item, index: index, question: question, count: 5
 
   .if-no-js-hide.govuk-button-group
-    a.govuk-button.govuk-button--secondary.button-add.js-button-add class=("visuallyhidden" if question.trade_goods_and_services.count >= question.product_limit)  href="#" aria-label="Add another product or service" data-entity="product" *possible_read_only_ops
+    a.govuk-button.govuk-button--secondary.button-add.js-button-add class=("visuallyhidden" if question.trade_goods_and_services.count >= question.product_limit) href="#" aria-label="Add another product or service" data-entity="product" *possible_read_only_ops
         | Add another product or service


### PR DESCRIPTION
## 📝 A short description of the changes

* The KAE forms should also work if javascript is not enabled on the client browser. The trade products questions uses javascript to add/remove trade product fields from the question. Where javascript is not enabled the max limit of fields should be displayed. This fix adds fields up to the difference of saved answers minus the question limit.
* `count` and property is passed to the trade fields partial. Count is used to hide the remove link if the count is 1. The last remaining product should not be removed.

Remove links and the add button are always hidden when javascript is not enabled using the if-no-js-hide class.

## 🔗 Link to the relevant story (or stories)

* https://docs.google.com/spreadsheets/d/1V-60y25BcgwUc7nHT7uowRXn1waYo0TwXpT9ESxHAB0/edit#gid=1207156860

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

