### PR TITLE
Fix website link add and remove for non-js

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -839,7 +839,7 @@ jQuery ->
       word_limit = products.find("textarea").attr("data-word-max")
       remove_link = $(this).find(".js-remove-link")
 
-      products.find("label").get(0).innerText = "Product/Service " + idx + " (word limit: #{word_limit}):"
+      products.find("label").get(0).innerText = "Product or service description " + idx + " (word limit: #{word_limit}):"
       products.find("label").attr("for", id + "_desc_short_#{idx}]" )
       products.find("textarea").attr({
         "id": id + "_desc_short_#{idx}]",

--- a/app/controllers/form/form_links_controller.rb
+++ b/app/controllers/form/form_links_controller.rb
@@ -45,17 +45,29 @@ class Form::FormLinksController < Form::MaterialsBaseController
       @form_answer.document = add_link_result_doc
       @form_answer.save
 
-      redirect_to form_form_answer_form_attachments_url(@form_answer)
+      redirect_to edit_form_url(id: @form_answer.id, step: "supplementary-materials-confirmation")
     else
       render :new
     end
+  end
+
+  def confirm_deletion
+    self.form_link = FormLink.new(link_params)
   end
 
   def destroy
     @form_answer.document = remove_link_result_doc
     @form_answer.save
 
-    redirect_to form_form_answer_form_attachments_url(@form_answer)
+    respond_to do |format|
+      format.html do
+        if request.xhr? || request.format.js?
+          head :ok
+        else
+          redirect_to edit_form_url(id: @form_answer.id, step: "supplementary-materials-confirmation")
+        end
+      end
+    end
   end
 
   private

--- a/app/views/form/form_links/confirm_deletion.html.slim
+++ b/app/views/form/form_links/confirm_deletion.html.slim
@@ -1,0 +1,42 @@
+- content_for :breadcrumbs do
+  li = link_to "Applications", dashboard_path
+  li = @form.title
+
+header.page-header.group.page-header-over-sidebar
+  div
+    h1
+      = @form.title
+
+.steps-progress-container
+  .steps-progress-content
+    = render 'qae_form/form_header', form: @form, current_step: "supplementary-materials-confirmation"
+
+    .article-container.article-container-wider.step-article.step-current
+      article.group role="article"
+        .inner
+          fieldset.question-block
+            h2 Deletion of website address.
+
+            ul.list-add
+              li
+                div
+                  p
+                    | Are you sure?
+                  br
+                  = simple_form_for form_link,
+                                    url: form_form_answer_form_links_url(@form_answer, link: form_link.link),
+                                    html: { class: 'qae-form', method: :delete } do |f|
+                    f.input
+                    .row
+                      .span-12
+                        = f.submit "Delete", class: "button button-alt"
+                    .clear
+
+          footer
+            nav.pagination.no-border aria-label="Pagination" role="navigation"
+              ul.group
+                li.previous.previous-alternate
+                  = link_to edit_form_url(id: params[:form_answer_id], step: "supplementary-materials-confirmation"), rel: "prev", title: "Back to company information", role: "button" do
+                    span.pagination-label Back
+
+    = render "qae_form/steps_progress_bar", current_step: "supplementary-materials-confirmation"

--- a/app/views/qae_form/_by_trade_goods_and_services_fields.html.slim
+++ b/app/views/qae_form/_by_trade_goods_and_services_fields.html.slim
@@ -1,7 +1,7 @@
 li.js-add-example.js-list-item data-value=placement data-type="in_clause_collection"
   .govuk-form-group.trade-good-product.question-required
     label.govuk-label for=question.input_name(suffix: "desc_short_#{placement}")
-      = "Product/Service #{placement} (word limit: #{question.words_max}):"
+      = "Product or service description #{placement} (word limit: #{question.words_max}):"
     - errors = @form_answer.validator_errors
     - if errors && errors[question.key] && errors[question.key][index]
       span.govuk-error-message
@@ -12,7 +12,7 @@ li.js-add-example.js-list-item data-value=placement data-type="in_clause_collect
 
   .govuk-form-group.trade-good-percentage.question-required
     label.govuk-label for=question.input_name(suffix: "total_overseas_trade_#{placement}")
-      ' % of your total overseas trade:
+      ' % of your total overseas trade the product/service represents:
     span.govuk-error-message
     input.js-trigger-autosave.govuk-input.govuk-input--width-5 type="number" pattern="[0-9]*" min=question.min max=question.max name="#{question.input_name}[#{index}][total_overseas_trade]" value=(item.present? ? item['total_overseas_trade'] : '') autocomplete="off" id=question.input_name(suffix: "total_overseas_trade_#{placement}") *possible_read_only_ops
 

--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -32,11 +32,11 @@
               .govuk-form-group
                 label.govuk-label class="govuk-!-margin-bottom-2 display-inline" for=question.input_name(suffix: 'link', index: idx)
                   ' Website address
-                = link_to "Remove", form_form_answer_form_attachment_url(@form_answer.id, el['link'].to_i),
-                                      possible_read_only_ops.merge({class: "remove-link govuk-button govuk-button--warning remove-website display-inline mt-0",
-                                                                    remote: true,
-                                                                    method: :delete})
+                = link_to "Remove", "#", class: "remove-link govuk-button govuk-button--warning if-no-js-hide remove-website display-inline mt-0"
+                = link_to "Remove", confirm_deletion_form_form_answer_form_links_path(@form_answer.id, form_link: {link: el['link'], description: el['description']}),
+                                    possible_read_only_ops.merge({class: "govuk-link remove-link govuk-button govuk-button--warning float-right display-inline mt--5 if-js-hide"})
                 input.govuk-input.js-trigger-autosave type="text" id=question.input_name(suffix: 'link', index: idx) name=question.input_name(suffix: 'link', index: idx) value=question.input_value(suffix: 'link', index: idx)  *possible_read_only_ops
+
 
           - if question.description
             .govuk-form-group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,6 @@ Rails.application.routes.draw do
       resources :form_attachments, only: [:index, :new, :create, :destroy] do
         get :confirm_deletion
       end
-      resource :form_links, only: [:new, :create, :destroy]
       resources :organisational_charts, only: [:new, :create, :destroy] do
         get :confirm_deletion
       end
@@ -150,7 +149,8 @@ Rails.application.routes.draw do
       [
         :current_queens_awards,
         :awards,
-        :subsidiaries
+        :subsidiaries,
+        :form_links
       ].each do |resource_name|
         resource resource_name, only: [:new, :create, :edit, :update, :destroy] do
           get :confirm_deletion


### PR DESCRIPTION
## 📝 A short description of the changes

* This updates the adding and removal of form_links to the supplementary materials section of the form
* Fixes redirects to go to form path instead of form_attachments path
* Adds a confirm_deletion interim page to be used when javascript is not enabled
* Copy changes to products question

## 🔗 Link to the relevant story (or stories)

* https://docs.google.com/spreadsheets/d/1V-60y25BcgwUc7nHT7uowRXn1waYo0TwXpT9ESxHAB0/edit#gid=1207156860

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

