### PR TITLE
Adds new calculateRowsToExcludeFromBottom() function to replace hardcoding these values

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -303,6 +303,13 @@ jQuery ->
     else if type == 'others'
       proportionInput?.value = ( colSums[cell.cellIndex] / (colSums[cell.cellIndex] + referenceValue) * 100).toFixed(2)
 
+  calculateRowsToExcludeFromBottom = (table, className) ->
+    rows = table.querySelectorAll('tr');
+    for i in [rows.length - 1..0] by -1
+      if rows[i].classList.contains(className)
+        row_count_from_bottom = rows.length - i
+        return row_count_from_bottom
+
   updateColumnTotalsCalculation = (table) ->
     inputFields = table.querySelectorAll('input[type="number"]')
     colCount = table.rows[0].cells.length
@@ -310,9 +317,9 @@ jQuery ->
     subtotalsRowSelector = table.querySelector('.auto-subtotals-row')
     if subtotalsRowSelector 
       subtotalsRow = subtotalsRowSelector.cells
-      rowsToExclude = 4
+      rowsToExclude = calculateRowsToExcludeFromBottom(table, 'auto-subtotals-row')
     else
-      rowsToExclude = 2
+      rowsToExclude = calculateRowsToExcludeFromBottom(table, 'auto-totals-row')
     othersRow = table.querySelector('.others-not-disadvantaged-row').cells
     disadvantagedRow = table.querySelector('tbody').querySelector('tr:nth-child(1)').cells
     proportionRow = table.querySelector('.auto-proportion-row').cells


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds new calculateRowsToExcludeFromBottom() function to replace hardcoding these values.
* For matrices where subtotals, others, totals and proportion rows are present, the values for cells in these rows must be excluded from sums, so this function calculates the number of rows from the bottom that 'subtotals' row is and excludes values below this.
* Similarly for matrices where only totals and proportion rows are present, this function will calculate how many rows from the bottom the totals row is

## 🔗 Link to the relevant story (or stories)

* 

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

