### PR TITLE
Fixes collaborator deletion with javascript disabled

### DIFF
--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -1015,3 +1015,14 @@ ul.no-bullets {
 form.audit-certificate-upload-form span.button-add {
   margin-bottom: 20px;
 }
+
+// Navigation link
+.nav-link--sign-out {
+  background-color: transparent;
+  color: white;
+  border: none;
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: left;
+  padding: 0;
+}

--- a/app/views/account/collaborators/confirm_deletion.html.slim
+++ b/app/views/account/collaborators/confirm_deletion.html.slim
@@ -7,18 +7,23 @@
     h1.govuk-heading-l
       ' Are you sure you want remove this collaborator?
 
-    p.govuk-body
-      ' You need to have at least one collaborator added to your account. If you remove this collaborator, please add another one; otherwise, you won't be able to:
-    ul.govuk-list.govuk-list--bullet
-      li access or submit your applications;
-      li access the recipients' dashboard if you win the award.
+    - if collaborators.count == 1
+
+      p.govuk-body
+        ' You need to have at least one collaborator added to your account. If you remove this collaborator, please add another one; otherwise, you won't be able to:
+      ul.govuk-list.govuk-list--bullet
+        li access or submit your applications;
+        li access the recipients' dashboard if you win the award.
 
     .govuk-button-group
       - form_id = params[:form_id].presence
 
-      = link_to "Yes, remove collaborator", account_collaborator_path(collaborator, form_id: form_id),
-                method: :delete,
-                class: "govuk-button govuk-button--warning"
+      = form_for collaborator, url: account_collaborator_path(collaborator, form_id: form_id), method: :delete do |f|
+        = f.submit "Yes, remove collaborator", class: "govuk-button govuk-button--warning if-js-hide"
 
-      = link_to "Cancel", edit_account_collaborator_path(collaborator, form_id: form_id),
-                  class: "govuk-button govuk-button--secondary"
+        = link_to "Yes, remove collaborator", account_collaborator_path(collaborator, form_id: form_id),
+                  method: :delete,
+                  class: "govuk-button govuk-button--warning if-no-js-hide"
+
+        = link_to "Cancel", edit_account_collaborator_path(collaborator, form_id: form_id),
+                    class: "govuk-button govuk-button--secondary"

--- a/app/views/account/collaborators/edit.html.slim
+++ b/app/views/account/collaborators/edit.html.slim
@@ -19,7 +19,10 @@ h1.govuk-heading-xl
         - else
           = link_to "Remove collaborator", account_collaborator_path(collaborator, form_id: form_id),
                     method: :delete,
-                    class: "collaborator-remove-link govuk-link"
+                    class: "collaborator-remove-link govuk-link if-no-js-hide",
+                    id: "js-remove-collaborator-link"
+          = link_to "Remove collaborator", confirm_deletion_account_collaborator_path(collaborator, form_id: form_id),
+                    class: "collaborator-remove-link govuk-link if-js-hide"
 
     .article-container
       article.group role="article"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -35,7 +35,7 @@ title = content_for?(:title) ? yield(:title)  + " - King's Awards for Enterprise
             = link_to "Account details", correspondent_details_account_path, class: 'govuk-header__link'
         - if current_user.present?
           li.govuk-header__navigation-item
-            = link_to "Sign out", destroy_user_session_path, method: :delete, class: 'govuk-header__link'
+            = button_to  "Sign out", destroy_user_session_path, method: :delete, class: 'govuk-header__link nav-link--sign-out'
 
 - content_for :inside_header do
   - if landing_page?

--- a/spec/acceptance/steps/admin_sign_in_steps.rb
+++ b/spec/acceptance/steps/admin_sign_in_steps.rb
@@ -10,7 +10,7 @@ step "I sign in as admin" do
 end
 
 step "I should see sign out link" do
-  expect(page).to have_link('Sign out')
+  expect(page).to have_selector(:link_or_button, 'Sign out')
 end
 
 step "I am admin user" do

--- a/spec/features/account/collaborators_spec.rb
+++ b/spec/features/account/collaborators_spec.rb
@@ -209,7 +209,7 @@ So that they can collaborate form answers
           end
 
           expect {
-            click_link "Remove collaborator"
+            click_link 'js-remove-collaborator-link'
           }.to change {
             account.reload.users.count
           }.by(-1)

--- a/spec/features/users/collaborator_registration_flow_spec.rb
+++ b/spec/features/users/collaborator_registration_flow_spec.rb
@@ -28,7 +28,7 @@ describe "Collaborator registration flow" do
     collab.confirmed_at = Time.now
     collab.save!
 
-    click_link "Sign out"
+    click_button "Sign out"
 
     login_as(collab.reload, scope: :user)
     visit root_path


### PR DESCRIPTION
## 📝 A short description of the changes

* When JS is disabled, uses a confirm deletion page to delete collaborators
* Changes sign out link to a button to work with JS disabled.
* Adds styling for nav button

## 🔗 Link to the relevant story (or stories)

* https://docs.google.com/spreadsheets/d/1V-60y25BcgwUc7nHT7uowRXn1waYo0TwXpT9ESxHAB0/edit#gid=170569556

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

![Screenshot 2023-04-24 at 13 24 53](https://user-images.githubusercontent.com/65811538/233995792-a20014e6-2d4f-4cdd-80f0-8f642c90abe8.png)
