### PR TITLE
Leave C 5.3.1 to appear by default and not make it required

### DIFF
--- a/app/forms/award_years/v2024/social_mobility/social_mobility_step3.rb
+++ b/app/forms/award_years/v2024/social_mobility/social_mobility_step3.rb
@@ -604,10 +604,7 @@ class AwardYears::V2024::QAEForms
         end
 
         textarea :disadvantaged_group_not_in_list, "If you are putting forward a group that is not on this list, please provide details and explain why you believe the group you support should be considered disadvantaged." do
-          classes "sub-question js-conditional-question-checkbox"
           sub_ref "C 5.3.1"
-          required
-          conditional :disadvantaged_participants_in_group_year, :others
           words_max 300
         end
 


### PR DESCRIPTION
## 📝 A short description of the changes

* Remove condition, classes and required attributes from this question. C 5.3.1 should display by default.

## 🔗 Link to the relevant story (or stories)

* 

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="544" alt="Screenshot 2023-04-25 at 4 01 16 pm" src="https://user-images.githubusercontent.com/84323332/234320076-abfe1797-886b-4415-a930-2e43595e9187.png">

