### PR TITLE
Display copy on Create an Account page if submission deadline has passed

### DIFF
--- a/app/assets/stylesheets/frontend/views/dashboard.scss
+++ b/app/assets/stylesheets/frontend/views/dashboard.scss
@@ -360,3 +360,7 @@ ul.no-bullet {
 .name-change-notification {
   max-width: 100%;
 }
+
+.font-22 {
+  font-size: 22px;
+}

--- a/app/views/content_only/info_messages/_award_season_closed.html.slim
+++ b/app/views/content_only/info_messages/_award_season_closed.html.slim
@@ -11,13 +11,12 @@ article.group role="article"
           | for further details.
 
     .application-notice.info-notice
-      p.govuk-body
+      p.govuk-body.font-22
         = render "content_only/info_messages/new_users_message"
-
-        ' The entry period for the
+        '  The 
+        = AwardYear.current.year 
+        '  Awards open for applications on 
+        = Settings.current_award_year_switch_date.trigger_at.strftime("%-d %B %Y")
+        ' . We will send you an email notification when the 
         = AwardYear.current.year
-        '  Awards season has now closed. We will email you when the Awards open.
-        br
-        ' Award recipients will be announced on
-        =< application_deadline_for_year(AwardYear.current, :buckingham_palace_attendees_details, "with_year")
-        ' .
+        '  Awards open.

--- a/app/views/content_only/info_messages/_new_users_message.html.slim
+++ b/app/views/content_only/info_messages/_new_users_message.html.slim
@@ -1,3 +1,3 @@
 - if current_user.new_member?
-  ' Thank you for registering for an account.
+  ' Thank you for creating an account for The King’s Awards for Enterprise.
   br

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -7,8 +7,9 @@
     article.group role="article"
       h1.govuk-heading-xl Create an account
       .application-notice.info-notice
-        p.govuk-body
-          ' Applications for the #{AwardYear.current.year} awards are closed. You can create an account now to receive notifications when the Awards open and close.
+        - if Settings.after_current_submission_deadline?
+          p.govuk-body
+            ' Applications for the #{AwardYear.current.year} awards are closed. You can create an account now to receive notifications when the Awards open and close.
         p.govuk-body
           ' If you are a marketing company applying on behalf of a client, your client should create an account first, then add you as a collaborator.
         p.govuk-body

--- a/spec/factories/settings_factory.rb
+++ b/spec/factories/settings_factory.rb
@@ -35,6 +35,14 @@ FactoryBot.define do
     end
   end
 
+  trait :current_award_year_switch_date do
+    after(:create) do |settings|
+      start = settings.deadlines.where(kind: "award_year_switch").first
+      start.update_column(:trigger_at, Time.zone.now - 25.days)
+      settings.reload
+    end
+  end
+
   trait :expired_audit_submission_deadline do
     after(:create) do |settings|
       start = settings.deadlines.where(kind: "audit_certificates").first

--- a/spec/features/users/figures_and_vat_returns_spec.rb
+++ b/spec/features/users/figures_and_vat_returns_spec.rb
@@ -4,6 +4,7 @@ include Warden::Test::Helpers
 describe "User uploads VAT returns and actual figures" do
   let(:user) { create(:user, :completed_profile) }
   let!(:settings) { create(:settings, :expired_submission_deadlines, award_year_id: AwardYear.current.id) }
+  let!(:settings) {create(:settings, :current_award_year_switch_date, award_year_id: AwardYear.current.id) }
   let!(:form_answer) { create(:form_answer, :mobility, :recommended, user: user) }
 
   before do


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds a condition to hide copy while award year is open and only display if passed

## 🔗 Link to the relevant story (or stories)

* 

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

