### PR TITLE
Add day/month range condition

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -126,15 +126,29 @@ jQuery ->
     ), 50)
   # Range conditional using a is within range
   rangeConditionalQuestion = (input) ->
-    fieldset = input.closest(".js-conditional-answer")
-    answer = fieldset.attr("data-answer")
+    block = input.closest(".js-conditional-answer")
+    answer = block.attr("data-answer")
     question = $(".conditional-question[data-question='#{answer}'][data-type='range']")
 
-    d_input = fieldset.find(".govuk-date-input")
+    d_input = block.find(".govuk-date-input")
 
-    d_day = d_input.find(".js-date-input-day").val()
-    d_month = d_input.find(".js-date-input-month").val()
-    d_year = d_input.find(".js-date-input-year").val()
+    d_day_input = d_input.find("input.js-date-input-day")
+    d_month_input = d_input.find("input.js-date-input-month")
+    d_year_input = d_input.find("input.js-date-input-year")
+
+    fy_day_input = d_input.find("input.js-fy-day")
+    fy_month_input = d_input.find("input.js-fy-month")
+
+    isFyRange = (fy_day_input && fy_month_input)
+
+    if (fy_day_input.length && fy_month_input.length)
+      d_day = fy_day_input.val()
+      d_month = fy_month_input.val()
+      d_year = 2000
+    else
+      d_day = d_day_input.val()
+      d_month = d_month_input.val()
+      d_year = d_year_input.val()
 
     if (d_day && d_month && d_year)
       question.each () ->

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -218,12 +218,13 @@ jQuery ->
     fy_latest_changed_input.find("input.js-fy-month").val(fy_month)
 
     # Auto fill the year for previous years
-    $(".js-financial-year-changed-dates .js-fy-entries").each ->
-     if $(this).find("input.js-fy-year").val() == ""
-       parent_fy = $(this).parent().find(".js-fy-entries")
-       this_year = fy_year - (parent_fy.size() - parent_fy.index($(this)) - 1)
-
-       $(this).find("input.js-fy-year").val(this_year)
+    # Disabled for year 2023
+    # $(".js-financial-year-changed-dates .js-fy-entries").each ->
+    #  if $(this).find("input.js-fy-year").val() == ""
+    #    parent_fy = $(this).parent().find(".js-fy-entries")
+    #    this_year = fy_year - (parent_fy.size() - parent_fy.index($(this)) - 1)
+    #
+    #    $(this).find("input.js-fy-year").val(this_year)
 
     fy_latest_changed_input.find("input").attr("disabled", "disabled")
     $(".js-financial-year-changed-dates").attr("data-year", fy_year)

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -436,7 +436,7 @@ window.FormValidation =
             @addErrorClass(question)
 
   validateDateByYears: (question) ->
-    for subquestionBlock in question.find(".js-fy-entry-container.show-question .govuk-date-input")
+    for subquestionBlock in question.find(".show-question .govuk-date-input")
       subq = $(subquestionBlock)
       qParent = subq.closest(".js-fy-entries")
       errorsContainer = qParent.find(".govuk-error-message").html()

--- a/app/forms/award_years/v2024/innovation/innovation_step4.rb
+++ b/app/forms/award_years/v2024/innovation/innovation_step4.rb
@@ -27,7 +27,7 @@ class AwardYears::V2024::QAEForms
             </p>
           )
 
-          conditional :financial_year_date, :true
+          conditional :financial_year_date, :day_month_range, range: AwardYear.fy_date_range_threshold(minmax: true)
         end
 
         options :financial_year_date_changed, "Did your year-end date change during your <span class='js-entry-period-subtext'>five</span> most recent financial years that you will be providing figures for?" do

--- a/app/forms/award_years/v2024/innovation/innovation_step4.rb
+++ b/app/forms/award_years/v2024/innovation/innovation_step4.rb
@@ -27,7 +27,7 @@ class AwardYears::V2024::QAEForms
             </p>
           )
 
-          conditional :financial_year_date, :day_month_range, range: AwardYear.fy_date_range_threshold(minmax: true)
+          conditional :financial_year_date, :day_month_range, range: AwardYear.fy_date_range_threshold(minmax: true), data: {value: AwardYear.fy_date_range_threshold(minmax: true, format: true), type: :range}
         end
 
         options :financial_year_date_changed, "Did your year-end date change during your <span class='js-entry-period-subtext'>five</span> most recent financial years that you will be providing figures for?" do

--- a/app/forms/award_years/v2024/international_trade/international_trade_step4.rb
+++ b/app/forms/award_years/v2024/international_trade/international_trade_step4.rb
@@ -67,7 +67,7 @@ class AwardYears::V2024::QAEForms
             </p>
           )
 
-          conditional :financial_year_date, :day_month_range, range: AwardYear.fy_date_range_threshold(minmax: true)
+          conditional :financial_year_date, :day_month_range, range: AwardYear.fy_date_range_threshold(minmax: true), data: {value: AwardYear.fy_date_range_threshold(minmax: true, format: true), type: :range}
         end
 
         options :financial_year_date_changed, "Did your year-end date change during your <span class='js-entry-period-subtext'>three or six</span>-year entry period that you will be providing figures for?" do

--- a/app/forms/award_years/v2024/international_trade/international_trade_step4.rb
+++ b/app/forms/award_years/v2024/international_trade/international_trade_step4.rb
@@ -67,8 +67,7 @@ class AwardYears::V2024::QAEForms
             </p>
           )
 
-          conditional :financial_year_date, :true
-          # conditional :financial_year_date, :optional_financial_year
+          conditional :financial_year_date, :day_month_range, range: AwardYear.fy_date_range_threshold(minmax: true)
         end
 
         options :financial_year_date_changed, "Did your year-end date change during your <span class='js-entry-period-subtext'>three or six</span>-year entry period that you will be providing figures for?" do

--- a/app/forms/qae_form_builder/by_years_question.rb
+++ b/app/forms/qae_form_builder/by_years_question.rb
@@ -38,7 +38,7 @@ class QAEFormBuilder
       delegate_obj.by_year_conditions.find do |c|
         if c.question_value.respond_to?(:call)
           q = form[c.question_key]
-          if q.is_a?(QAEFormBuilder::DateQuestion)
+          if q.is_a?(QAEFormBuilder::DateQuestion) || q.is_a?(QAEFormBuilder::DateQuestionDecorator)
             date = []
             q.required_sub_fields.each do |sub|
               date << q.input_value(suffix: sub.keys[0])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
       index_step_text = name
     end
 
-    
+
     if opts[:index] && opts[:active]
       if opts[:index] == opts[:active]
         step_status  = "current"
@@ -54,7 +54,11 @@ module ApplicationHelper
     for condition in question.conditions
       dep = question.form[condition.question_key]
       raise "Can't find parent question for conditional #{question.key} -> #{condition.question_key}" unless dep
-      current = content_tag(:div, current, class: "js-conditional-question", data: {question: dep.parameterized_title, value: condition.question_value})
+
+      data_attrs = {question: dep.parameterized_title, value: condition.question_value}
+      data_attrs = data_attrs.merge((condition.options || {}).fetch(:data, {})) if condition.options
+
+      current = content_tag(:div, current, class: "js-conditional-question", data: data_attrs)
     end
 
     current

--- a/app/models/award_year.rb
+++ b/app/models/award_year.rb
@@ -322,13 +322,15 @@ class AwardYear < ApplicationRecord
     end
 
     def fy_date_range_threshold(**opts)
-      year = current.year - 1
+      year = 2000
 
       from = Settings.current_award_year_switch_date&.trigger_at
       from ||= Date.new(year, DEFAULT_FINANCIAL_SWITCH_MONTH, DEFAULT_FINANCIAL_SWITCH_DAY)
+      from = from.change(year: year)
 
       to = Settings.current_submission_deadline&.trigger_at
       to ||= Date.new(year, DEFAULT_FINANCIAL_DEADLINE_MONTH, DEFAULT_FINANCIAL_DEADLINE_DAY)
+      to = to.change(year: year)
 
       if opts[:minmax] == true
         return (from..to).minmax.map { |d| d.strftime("%d/%m/%Y") } if opts[:format] == true

--- a/app/models/award_year.rb
+++ b/app/models/award_year.rb
@@ -320,5 +320,22 @@ class AwardYear < ApplicationRecord
         start_date..end_date
       end
     end
+
+    def fy_date_range_threshold(**opts)
+      year = current.year - 1
+
+      from = Settings.current_award_year_switch_date&.trigger_at
+      from ||= Date.new(year, DEFAULT_FINANCIAL_SWITCH_MONTH, DEFAULT_FINANCIAL_SWITCH_DAY)
+
+      to = Settings.current_submission_deadline&.trigger_at
+      to ||= Date.new(year, DEFAULT_FINANCIAL_DEADLINE_MONTH, DEFAULT_FINANCIAL_DEADLINE_DAY)
+
+      if opts[:minmax] == true
+        return (from..to).minmax.map { |d| d.strftime("%d/%m/%Y") } if opts[:format] == true
+        (from..to).minmax
+      else
+        from..to
+      end
+    end
   end
 end

--- a/app/views/qae_form/_turnover_exports_calculation_question_one_option_block.html.slim
+++ b/app/views/qae_form/_turnover_exports_calculation_question_one_option_block.html.slim
@@ -1,4 +1,6 @@
-.js-conditional-question.conditional-question.show-question data-question="development_performance_years-how-would-you-describe-the-impact-of-your-sustainable-development-on-your-organisation-s-financial-performance" data-value=("3 to 5")
+- question_key = "development_performance_years-how-would-you-describe-the-impact-of-your-sustainable-development-on-your-organisation-s-financial-performance"
+
+.js-conditional-question.conditional-question.show-question  data=(c.question_value.respond_to?(:call) ? c.options.dig(:data).merge(question: question_key) : {question: question_key, value: "3 to 5"})
   .row
     - (1..3).each do |y|
       div class="span-financial span-4"

--- a/app/views/qae_form/_turnover_exports_calculation_question_standart_block.html.slim
+++ b/app/views/qae_form/_turnover_exports_calculation_question_standart_block.html.slim
@@ -1,5 +1,5 @@
 - for c in question.by_year_conditions
-  .js-conditional-question data-question=question.step.form[c.question_key].parameterized_title data-value=c.question_value
+  .js-conditional-question data=(c.question_value.respond_to?(:call) ? c.options.dig(:data).merge(question: question.step.form[c.question_key].parameterized_title) : {question: question.step.form[c.question_key].parameterized_title, value: c.question_value})
     .row
       - (1..c.years).each do |y|
         div class="span-financial span-4"


### PR DESCRIPTION
## 📝 A short description of the changes
Based on work done in #2353.
 - Disabled pre-filling of dates for previous years (copied)
 - Implemented hiding of sub-question based on day/month input - added also ability to add options to conditional so it can go `conditional :key, :value, option1: 1, option2: 2`. Can be used to add data attributes to HTML elements to make work with JS bit easier
 - Fixed turnover calculation block as it was broken from before
 - Fixed validation for multiple year input

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/home/1178339740118267/1204412218516950

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

