### PR TITLE
Default fields pdf dynamic labels

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -206,7 +206,7 @@ jQuery ->
   # Get the latest financial year date from input
   updateYearEndInput = () ->
     fy_latest_changed_input = $(".js-financial-year-changed-dates .fy-latest .govuk-date-input")
-    fy_latest_changed_input.find("input").removeAttr("disabled")
+    fy_latest_changed_input.find("input").removeAttr("readonly")
 
     fy_day = $('.js-financial-year-latest input.js-fy-day').val()
     fy_month = $('.js-financial-year-latest input.js-fy-month').val()
@@ -240,7 +240,7 @@ jQuery ->
     #
     #    $(this).find("input.js-fy-year").val(this_year)
 
-    fy_latest_changed_input.find("input").attr("disabled", "disabled")
+    fy_latest_changed_input.find("input").attr("readonly", "readonly")
     $(".js-financial-year-changed-dates").attr("data-year", fy_year)
 
     # We should change the last year date regardless if it's present or not
@@ -257,8 +257,8 @@ jQuery ->
     if $(".js-financial-year-change input:checked").val() == "no"
       # If the financial year haven't changed, clear manually entered dates
       $(".js-financial-year-changed-dates .js-fy-entries").each ->
-        $(this).find("input.js-fy-day").removeAttr("disabled").val("")
-        $(this).find("input.js-fy-month").removeAttr("disabled").val("")
+        $(this).find("input.js-fy-day").removeAttr("readonly").val("")
+        $(this).find("input.js-fy-month").removeAttr("readonly").val("")
 
       # Year end hasn't changed, auto select the year
       fy_latest_changed_input = $(".js-financial-year")

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -166,6 +166,12 @@ jQuery ->
             $(this).addClass("show-question")
           else
             $(this).removeClass("show-question")
+    else
+      question.each () ->
+        if $(this).is('[data-default]')
+          $(this).addClass("show-question")
+        else
+          $(this).removeClass("show-question")
 
   $(".js-conditional-answer .govuk-date-input input").each () ->
     rangeConditionalQuestion($(this))

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -614,8 +614,7 @@ window.FormValidation =
       # console.log "validateMoneyByYears"
       @validateMoneyByYears(question)
 
-    if question.hasClass("question-date-by-years") &&
-       question.find(".show-question").length == (question.find(".js-conditional-question").length - 1)
+    if question.hasClass("question-date-by-years") && question.find(".show-question").length
       @validateDateByYears(question)
 
     if question.find(".match").length

--- a/app/forms/award_years/v2024/innovation/innovation_step4.rb
+++ b/app/forms/award_years/v2024/innovation/innovation_step4.rb
@@ -62,7 +62,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
           conditional :financial_year_date_changed, "yes"
         end
 
@@ -115,7 +115,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
           conditional :financial_year_date_changed, :true
 
           employees_question
@@ -138,7 +138,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
 
           conditional :financial_year_date_changed, :true
         end
@@ -154,7 +154,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
 
           conditional :financial_year_date_changed, :true
         end
@@ -168,7 +168,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
 
           conditional :financial_year_date_changed, :true
           turnover :total_turnover
@@ -185,7 +185,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
           context %(
             <p>
               Use a minus symbol to record any losses.
@@ -209,7 +209,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
 
           conditional :financial_year_date_changed, :true
         end
@@ -327,7 +327,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
         end
 
         by_years :sales, "Sales of your innovative product/service (if applicable)." do
@@ -339,7 +339,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
         end
 
         by_years :sales_exports, "Of which exports (if applicable)." do
@@ -352,7 +352,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
         end
 
         by_years :sales_royalties, "Of which royalties or licences (if applicable)." do
@@ -365,7 +365,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
         end
 
         textarea :drops_in_sales, "Explain any drop in sales or the number of units sold (if applicable)." do
@@ -389,7 +389,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
         end
 
         textarea :avg_unit_price_desc, "Explain your unit selling prices or contract values, highlighting any changes over the above periods (if applicable)." do
@@ -410,7 +410,7 @@ class AwardYears::V2024::QAEForms
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: {value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(3, 4)) }, 3, data: {value: AwardYear.start_trading_between(3, 4, minmax: true, format: true), type: :range, identifier: "3 to 4"}
           by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(4, 5)) }, 4, data: {value: AwardYear.start_trading_between(4, 5, minmax: true, format: true), type: :range, identifier: "4 to 5"}
-          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus"}
+          by_year_condition :innovation_was_launched_in_the_market, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(5, 99)) }, 5, data: {value: AwardYear.start_trading_between(5, 99, minmax: true, format: true), type: :range, identifier: "5 plus", default: true}, default: true
         end
 
         textarea :costs_change_desc, "Explain your direct unit or contract costs, highlighting any changes over the above periods (if applicable)." do

--- a/app/forms/qae_form_builder/by_years_label_question.rb
+++ b/app/forms/qae_form_builder/by_years_label_question.rb
@@ -29,6 +29,7 @@ class QAEFormBuilder
 
     def active_fields
       c = active_by_year_condition
+      c ||= default_by_year_condition
       return [] unless c
 
       (1..c.years).map{|y| "#{y}of#{c.years}"}
@@ -54,6 +55,13 @@ class QAEFormBuilder
         else
           form[c.question_key].input_value == c.question_value
         end
+      end
+    end
+
+    def default_by_year_condition
+      delegate_obj.by_year_conditions.find do |c|
+        return false unless c.question_value.respond_to?(:call)
+        (c.options || {}).dig(:default) == true
       end
     end
   end

--- a/app/forms/qae_form_builder/by_years_question.rb
+++ b/app/forms/qae_form_builder/by_years_question.rb
@@ -29,6 +29,7 @@ class QAEFormBuilder
 
     def active_fields
       c = active_by_year_condition
+      c ||= default_by_year_condition
       return [] unless c
 
       (1..c.years).map{|y| "#{y}of#{c.years}"}
@@ -53,6 +54,13 @@ class QAEFormBuilder
         else
           form[c.question_key].input_value == c.question_value
         end
+      end
+    end
+
+    def default_by_year_condition
+      delegate_obj.by_year_conditions.find do |c|
+        return false unless c.question_value.respond_to?(:call)
+        (c.options || {}).dig(:default) == true
       end
     end
   end

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
@@ -1,17 +1,13 @@
 module QaePdfForms::CustomQuestions::ByYear
   EMPTY_STRING = "".freeze
   YEAR_LABELS = %w(day month year).freeze
-  FINANCIAL_YEAR_PREFIX = "Financial year".freeze
-  YEAR_ENDING_IN_PREFIX = "Year ended".freeze
-  AS_AT_DATE_PREFIX = "As at".freeze
-  AS_AT_DATE_PREFIX_QUESTION_KEYS = [
-    :total_net_assets
-  ].freeze
+  FORMATTED_FINANCIAL_YEAR_WITH_DATE = "Financial year %<index>d ended %<date>s".freeze
+  FORMATTED_FINANCIAL_YEAR_WITHOUT_DATE = "Financial year %<index>d".freeze
+  FORMATTED_AS_AT_DATE = "As at %<date>s".freeze
+  AS_AT_DATE_PREFIX_QUESTION_KEYS = [:total_net_assets].freeze
   ANSWER_FONT_START = "<color rgb='#{FormPdf::DEFAULT_ANSWER_COLOR}'>".freeze
   ANSWER_FONT_END = "</color>".freeze
-  CALCULATED_FINANCIAL_DATA = [
-    :uk_sales
-  ].freeze
+  CALCULATED_FINANCIAL_DATA = [:uk_sales].freeze
   OMIT_COLON_KEYS = [:financial_year_changed_dates].freeze
 
   def render_years_labels_table
@@ -19,18 +15,17 @@ module QaePdfForms::CustomQuestions::ByYear
       a.split("/")
     end
 
-    # not needed for 2021
     # rows.push(latest_year_label)
 
-    financial_dates_changed_year_headers.each_with_index do |header_item, placement|
+    financial_dates_year_headers(format: FORMATTED_FINANCIAL_YEAR_WITHOUT_DATE).each_with_index do |header_item, placement|
       form_pdf.default_bottom_margin
-      if OMIT_COLON_KEYS.include?(question.key)
-        title = "#{header_item} #{ANSWER_FONT_START}#{rows[placement].join("/")}#{ANSWER_FONT_END}"
-      else
-        title = "#{header_item}: #{ANSWER_FONT_START}#{rows[placement].join(" ")}#{ANSWER_FONT_END}"
-      end
-      form_pdf.text title,
-                    inline_format: true
+      title = if OMIT_COLON_KEYS.include?(question.key)
+                "#{header_item} #{ANSWER_FONT_START}#{rows[placement].join("/")}#{ANSWER_FONT_END}"
+              else
+                "#{header_item}: #{ANSWER_FONT_START}#{rows[placement].join(" ")}#{ANSWER_FONT_END}"
+              end
+
+      form_pdf.text title, inline_format: true
     end
   end
 
@@ -52,45 +47,37 @@ module QaePdfForms::CustomQuestions::ByYear
   end
 
   def year_headers
-    if financial_year_changed_dates?
-      financial_dates_changed_year_headers
-    else
-      financial_dates_not_changed_year_headers
-    end
+    financial_dates_year_headers
   end
 
-  def financial_dates_changed_year_headers
-    res = []
-    size = financial_table_headers.size
-
-    financial_table_headers.each_with_index do |item, placement|
-      header_item = "#{FINANCIAL_YEAR_PREFIX} #{placement + 1}"
-      header_item += " (most recent)" if size == (placement + 1)
-
-      res << header_item
-    end
-
-    res
-  end
-
-  def financial_dates_not_changed_year_headers
-    prefix = if AS_AT_DATE_PREFIX_QUESTION_KEYS.include?(question.key)
-      AS_AT_DATE_PREFIX
-    else
-      YEAR_ENDING_IN_PREFIX
-    end
-
+  def financial_dates_year_headers(**opts)
     if form_pdf.pdf_blank_mode.present? # BLANK FOR MODE
       financial_table_default_headers.map.with_index do |item, index|
         financial_table_default_headers.size == (index + 1) ? "#{item} (most recent)" : item
       end
     else
+      frmt = opts.dig(:format)
+      res = []
       size = financial_table_headers.size
 
-      financial_table_headers.map.with_index do |item, index|
-        item = "#{prefix} #{item}"
-        size == (index.to_i + 1) && item.include?(FINANCIAL_YEAR_PREFIX) ? "#{item} (most recent)" : item
+      financial_table_headers.each_with_index do |item, idx|
+        if AS_AT_DATE_PREFIX_QUESTION_KEYS.include?(question.key)
+          frmt ||= FORMATTED_AS_AT_DATE
+          res << format(frmt, date: item)
+        else
+          if item.split("/").any?(&:blank?)
+            frmt = FORMATTED_FINANCIAL_YEAR_WITHOUT_DATE
+          end
+
+          frmt ||= FORMATTED_FINANCIAL_YEAR_WITH_DATE
+
+          temp = format(frmt, date: item, index: idx.to_i)
+          temp = "#{temp} (most recent)" if size == (idx.to_i + 1)
+          res << temp
+       end
       end
+
+      res
     end
   end
 

--- a/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/by_year.rb
@@ -65,7 +65,10 @@ module QaePdfForms::CustomQuestions::ByYear
           frmt ||= FORMATTED_AS_AT_DATE
           res << format(frmt, date: item)
         else
-          if item.split("/").any?(&:blank?)
+          parts = item.split("/")
+
+          # After splitting by `/` date should always have 3 parts and none of them should be blank.
+          if parts.any?(&:blank?) || parts.size < 3
             frmt = FORMATTED_FINANCIAL_YEAR_WITHOUT_DATE
           end
 


### PR DESCRIPTION
## 📝 A short description of the changes

- Fixed validation when multiple years are required
- PDF dynamic labels with dates (or without if date is not filled)
- Default number of fields (5) when conditional question is not answered yet
- On PDF correctly change number of fields for D6.X questions depending on C2.2 

S/sheet with issues found during QA [here](https://docs.google.com/spreadsheets/d/1V-60y25BcgwUc7nHT7uowRXn1waYo0TwXpT9ESxHAB0/edit#gid=0)

Tab Int' Trade
 - [x] ID 33
 - [x] ID 34

Tab Innovation
 - [x] ID 18
 - [x] ID 22
 - [x] ID 38
 - [x] ID 39
 - [x] ID 44

Tab PO
 - [x] ID 24
 - [x] ID 25
 - [x] ID 26

Tab SD
 - [x] ID 19
 - [x] ID 21
 - [x] ID 22

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/home/1178339740118267/1204412218516950

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

