### PR TITLE
Fixes subsidiary remove button

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -1022,32 +1022,33 @@ jQuery ->
 
   # Updates labels and ids on trade product fields
   resetTradeProductIndexes = (question) ->
-    list_count = question.find("li").length
-    question.find("li").each (index) ->
-      idx = index + 1
-      id = "form[trade_goods_and_services_explanations"
-      name = "form[trade_goods_and_services_explanations]"
-      products = $(this).find(".trade-good-product")
-      percentages = $(this).find(".trade-good-percentage")
-      word_limit = products.find("textarea").attr("data-word-max")
-      remove_link = $(this).find(".js-remove-link")
+    if question.hasClass("js-by-trade-goods-and-services-amount")
+      list_count = question.find("li").length
+      question.find("li").each (index) ->
+        idx = index + 1
+        id = "form[trade_goods_and_services_explanations"
+        name = "form[trade_goods_and_services_explanations]"
+        products = $(this).find(".trade-good-product")
+        percentages = $(this).find(".trade-good-percentage")
+        word_limit = products.find("textarea").attr("data-word-max")
+        remove_link = $(this).find(".js-remove-link")
 
-      products.find("label").get(0).innerText = "Product or service description " + idx + " (word limit: #{word_limit}):"
-      products.find("label").attr("for", id + "_desc_short_#{idx}]" )
-      products.find("textarea").attr({
-        "id": id + "_desc_short_#{idx}]",
-        "name": name + "[#{idx}][desc_short]"
-      })
-      percentages.find("label").attr("for", id + "_total_overseas_trade_#{idx}]")
-      percentages.find("input").attr({
-        "id": id + "_total_overseas_trade_#{idx}]",
-        "name": name + "[#{idx}][total_overseas_trade]"
-      })
-      remove_link.attr("aria-label", "Remove " + ordinal(idx) + " product")
-      if list_count <= 1
-        remove_link.addClass("visuallyhidden")
-      else
-        remove_link.removeClass("visuallyhidden")
+        products.find("label").get(0).innerText = "Product or service description " + idx + " (word limit: #{word_limit}):"
+        products.find("label").attr("for", id + "_desc_short_#{idx}]" )
+        products.find("textarea").attr({
+          "id": id + "_desc_short_#{idx}]",
+          "name": name + "[#{idx}][desc_short]"
+        })
+        percentages.find("label").attr("for", id + "_total_overseas_trade_#{idx}]")
+        percentages.find("input").attr({
+          "id": id + "_total_overseas_trade_#{idx}]",
+          "name": name + "[#{idx}][total_overseas_trade]"
+        })
+        remove_link.attr("aria-label", "Remove " + ordinal(idx) + " product")
+        if list_count <= 1
+          remove_link.addClass("visuallyhidden")
+        else
+          remove_link.removeClass("visuallyhidden")
 
   # Clicking `+ Add` on certain questions add fields
   $(document).on "click", ".question-block .js-button-add", (e) ->

--- a/app/views/qae_form/_by_trade_goods_and_services_label_question.html.slim
+++ b/app/views/qae_form/_by_trade_goods_and_services_label_question.html.slim
@@ -1,7 +1,7 @@
 .js-by-trade-goods-and-services-amount role="group" id="q_#{question.key}"
   input name="#{question.input_name}[array]" value="true" type="hidden" *possible_read_only_ops
 
-  ol.list-add data-add-limit="#{question.product_limit}" data-need-to-clear-example=true data-default="1"
+  ol.list-add.js-by-trade-goods-and-services-amount data-add-limit="#{question.product_limit}" data-need-to-clear-example=true data-default="1"
     - question.trade_goods_and_services.each_with_index do |product, index|
       - placement = index + 1
       - item = question.trade_goods_and_services[index]

--- a/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
+++ b/app/views/qae_form/_subsidiaries_associates_plants_question.html.slim
@@ -76,17 +76,17 @@ div role="group" id="q_#{question.key}"
 
         - unless admin_in_read_only_mode?
           - aria_title = ordinal(index + 1) + " subsidiary"
-          
+
           - if !subsidiary["name"].blank?
             - aria_title = subsidiary["name"] + " subsidiary"
 
-          = link_to "Remove", confirm_deletion_form_form_answer_subsidiaries_path(@form_answer.id, subsidiary: { name: subsidiary['name'], location: subsidiary['location'] }), class: "govuk-link remove-link", "aria-label" => "Remove " + aria_title
-
+          = link_to "Remove", confirm_deletion_form_form_answer_subsidiaries_path(@form_answer.id, subsidiary: { name: subsidiary['name'], location: subsidiary['location'] }), class: "govuk-link remove-link if-js-hide govuk-button govuk-button--warning", "aria-label" => "Remove " + aria_title
+          = link_to "Remove", "#", class: "js-remove-link if-no-js-hide govuk-button govuk-button--warning", "aria-label" => "Remove " + aria_title
           = link_to "Edit", edit_form_form_answer_subsidiaries_path(@form_answer, subsidiary: subsidiary), class: "govuk-link remove-link non-js-edit-link if-js-hide", "aria-label" => "Edit " + aria_title
     - if question.subsidiaries.none?
       li.js-add-example.if-no-js-hide
         - unless admin_in_read_only_mode?
-          = link_to "Remove", "#", class: "remove-link js-remove-link"
+          = link_to "Remove", "#", class: "remove-link js-remove-link govuk-button govuk-button--warning"
         .clear
 
         .govuk-grid-row
@@ -112,6 +112,6 @@ div role="group" id="q_#{question.key}"
               ' Specify the reason why you are including it.
             textarea.govuk-textarea.award-textarea.js-char-count.js-trigger-autosave rows="2" name="#{question.input_name}[0][description]" autocomplete="off" data-word-max=question.details_words_max *possible_read_only_ops
 
-        
+
 
 = link_to "+ Add subsidiary, associate or plant", new_form_form_answer_subsidiaries_url(@form_answer.id), class: "govuk-button govuk-button--secondary button-add js-button-add", "aria-label" => "Add subsidiary, associate or plant", "data-entity" => "subsidiary"

--- a/app/views/qae_form/_upload_question.html.slim
+++ b/app/views/qae_form/_upload_question.html.slim
@@ -14,10 +14,10 @@
 
               - unless admin_in_read_only_mode?
                 - if question.key == :org_chart
-                  = link_to "Remove", form_form_answer_organisational_chart_confirm_deletion_url(@form_answer.id, el['file'].to_i), class: "govuk-link remove-link if-js-hide"
+                  = link_to "Remove", form_form_answer_organisational_chart_confirm_deletion_url(@form_answer.id, el['file'].to_i), class: "govuk-link remove-link if-js-hide govuk-button govuk-button--warning"
 
                   = link_to "Remove", form_form_answer_organisational_chart_url(@form_answer.id, el['file'].to_i),
-                                      possible_read_only_ops.merge({class: "govuk-link remove-link if-no-js-hide",
+                                      possible_read_only_ops.merge({class: "govuk-link remove-link if-no-js-hide govuk-button govuk-button--warning float-right display-inline mt--5",
                                                                     remote: true,
                                                                     method: :delete})
                 - else


### PR DESCRIPTION
## 📝 A short description of the changes

* `resetTradeProductIndexes()` was causing javascript errors on questions that did not have innerText properties so a condition is added to check for the `js-by-trade-goods-and-services-amount` class.
* Adds styling to remove links
* Adds `js-remove-link` to avoid form_attachment path redirect

## 🔗 Link to the relevant story (or stories)

* https://docs.google.com/spreadsheets/d/1Gl58IDELmwctLvOTdulaNnGw-MoBRBMzPs-M_uEV1co/edit#gid=0

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="633" alt="Screenshot 2023-05-04 at 08 55 10" src="https://user-images.githubusercontent.com/65811538/236147672-c8735c3b-2fbf-4eb3-b86f-1a89f55bb589.png">

<img width="687" alt="Screenshot 2023-05-04 at 08 55 01" src="https://user-images.githubusercontent.com/65811538/236147849-8526652a-cac1-4f2f-ba60-4347f7b21e8d.png">


<img width="707" alt="Screenshot 2023-05-04 at 09 03 49" src="https://user-images.githubusercontent.com/65811538/236147693-936e5d91-c6bd-454b-97b1-ce1b5ab6e621.png">
