### PR TITLE
fix "Enter your year-end dates" validation

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -449,7 +449,7 @@ window.FormValidation =
       return
     # end of conditional validation
 
-    for subquestionBlock in question.find(".show-question .govuk-date-input")
+    for subquestionBlock in question.find(".by-years-wrapper.show-question .govuk-date-input")
       subq = $(subquestionBlock)
       qParent = subq.closest(".js-fy-entries")
       errorsContainer = qParent.find(".govuk-error-message").html()


### PR DESCRIPTION
## 📝 A short description of the changes

* resolves the issue with question being invalid even though all the info is filled in

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/home/1178339740118267/1204412218516950

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

before 
<img width="454" alt="image" src="https://user-images.githubusercontent.com/332810/236214153-7b44c1f0-1f00-4abd-bb69-303c520082b2.png">

after
valid:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/332810/236214362-ed69448e-b988-4d70-9354-c54a372a5dc8.png">
invalid:
<img width="857" alt="image" src="https://user-images.githubusercontent.com/332810/236214433-57f4534f-72a4-428e-afbe-0e14b8548026.png">
