### PR TITLE
Do not trigger `change` event to prevent validating form from the start

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -268,7 +268,6 @@ jQuery ->
     #
     #    $(this).find("input.js-fy-year").val(this_year)
 
-    fy_latest_changed_input.find("input").trigger("change")
     fy_latest_changed_input.find("input").attr("readonly", "readonly")
     $(".js-financial-year-changed-dates").attr("data-year", fy_year)
 


### PR DESCRIPTION
## 📝 A short description of the changes

 - remove event trigger from JS causing the form to be validated right from the start

NOTE: issue w/ error incorrect redirect after file is deleted is not solved here. PR has been raised [here](https://github.com/vigilion/vigilion-rails/pull/54) which should solve the issue. `vigilion-rails` gem will need to be updated once that is merged though.

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/home/1178339740118267/1204412218516950

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
