### PR TITLE
Bump `vigilion-rails` to `2.2.0`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem 'carrierwave', '~> 1.3'
 gem 'fog', "1.42.1"
 gem "fog-aws"
 gem 'vigilion', '~> 1.0.4'
-gem 'vigilion-rails', '~> 2.1.0'
+gem 'vigilion-rails', '~> 2.2.0'
 
 # Background jobs
 gem "sidekiq", "~> 6.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -799,7 +799,7 @@ GEM
       faraday
       faraday-detailed_logger
       faraday_middleware
-    vigilion-rails (2.1.0)
+    vigilion-rails (2.2.0)
       rails (>= 6.0.3.7)
       vigilion (~> 1.0.4)
     virtus (2.0.0)
@@ -931,7 +931,7 @@ DEPENDENCIES
   turnip (~> 4.2.0)
   uglifier (>= 2.7.2)
   vigilion (~> 1.0.4)
-  vigilion-rails (~> 2.1.0)
+  vigilion-rails (~> 2.2.0)
   virtus
   webmock (= 3.5.0)
   webpacker (= 6.0.0.beta.7)


### PR DESCRIPTION
## 📝 A short description of the changes
Updated gem `vigilion-rails` to `2.2.0` to fix error occurring when user tries to remove files which is then checked for viruses.

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/home/1178339740118267/1204412218516950

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
