### PR TITLE
Fix financial step calculation with regards to previous years

### DIFF
--- a/app/form_pointers/form_financial_pointer.rb
+++ b/app/form_pointers/form_financial_pointer.rb
@@ -37,7 +37,7 @@ class FormFinancialPointer
     @form_answer_award_year = form_answer.award_year.year
 
     @steps = award_form.steps
-    @financial_step = steps.fourth
+    @financial_step = steps[form_answer.financial_step]
 
     @all_questions = steps.map(&:questions).flatten
     @filled_answers = fetch_filled_answers

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -54,6 +54,22 @@ class FormAnswer < ApplicationRecord
     k == "promotion"
   end
 
+  FINANCIAL_STEPS = {
+    ..2023 => {
+      "trade" => 3,
+      "innovation" => 3,
+      "development" => 3,
+      "mobility" => 3,
+      "promotion" => 3,
+    },
+    2024.. => {
+      "trade" => 4,
+      "innovation" => 4,
+      "development" => 4,
+      "mobility" => 4,
+    }
+  }
+
   enumerize :award_type, in: POSSIBLE_AWARDS, predicates: true
 
   mount_uploader :pdf_version, FormAnswerPdfVersionUploader
@@ -327,6 +343,11 @@ class FormAnswer < ApplicationRecord
 
   def business?
     BUSINESS_AWARD_TYPES.include?(award_type)
+  end
+
+  def financial_step
+    h = FINANCIAL_STEPS.select { |y| y === self.award_year.year }
+    h.values[0][self.award_type] - 1
   end
 
   #


### PR DESCRIPTION
## 📝 A short description of the changes
Financial step changed from being the 3rd step to 4th. This caused issue with forms from previous years as they were not displaying financial summary. 
Probably would be enough to check what's the year for the form but as I was looking at the history of changes I thought the logic was more complicated so I added hash as constant which would define financial step for each year and award type. Will leave it as is for the next year or we can just go for simple condition.

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/1200504523179343/1204553128463890/f

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

