### PR TITLE
Fix pre-filling dates along w/ specs

### DIFF
--- a/app/form_pointers/financial_summary_pointer.rb
+++ b/app/form_pointers/financial_summary_pointer.rb
@@ -59,23 +59,14 @@ class FinancialSummaryPointer < FormFinancialPointer
 
     input.values.each_with_object([]) do |x, acc|
       d = dates.dup
+      length = x.detect(&:first).values.flatten.size
+      diff = ::Utils::Diff.calc(dates.size, length, abs: false)
+
+      d.shift(diff) if diff && diff.positive?
 
       if dates_changed
-        max = data_minmax(x).dig(:max)
-        diff = ::Utils::Diff.calc(dates.size, max, abs: false)
-
-        d.shift(diff) if diff && diff.positive?
-
         idx = x.index { |h| h.keys[0] == :financial_year_changed_dates }
         x.delete_at(idx) if idx
-      else
-        min = data_minmax(x).dig(:min)
-        diff = [
-          ::Utils::Diff.calc(dates.size, period_length),
-          ::Utils::Diff.calc(dates.size, min)
-        ].max
-
-        d.shift(diff) if diff && diff.positive?
       end
 
       x.unshift(Hash[:dates, d])

--- a/spec/form_pointers/financial_summary_pointer_spec.rb
+++ b/spec/form_pointers/financial_summary_pointer_spec.rb
@@ -10,10 +10,6 @@ describe FinancialSummaryPointer do
 
   let(:form_answer) { create :form_answer, :trade, :submitted }
 
-  let(:financial_years) do
-    ["02/01/2020", "02/01/2021", "02/01/2022", "02/01/2023"]
-  end
-
   describe "#summary_data" do
     context "financial years have changed and product introduction date > company incorporation date" do
       let(:data) do
@@ -145,7 +141,7 @@ describe FinancialSummaryPointer do
 
         allow(pointer).to receive(:data) { data }
         allow(pointer).to receive(:partitioned_hash) { partitioned_hash }
-        allow(pointer).to receive(:fetch_financial_year_dates) { [financial_years, false] }
+        allow(pointer).to receive(:fetch_financial_year_dates) { [["02/01/2022", "02/01/2023"], false] }
 
         expect(pointer.summary_data).to eq(
           [
@@ -192,7 +188,7 @@ describe FinancialSummaryPointer do
 
         allow(pointer).to receive(:data) { data }
         allow(pointer).to receive(:partitioned_hash) { partitioned_hash }
-        allow(pointer).to receive(:fetch_financial_year_dates) { [financial_years, false] }
+        allow(pointer).to receive(:fetch_financial_year_dates) { [["02/01/2020", "02/01/2021", "02/01/2022", "02/01/2023"], false] }
 
         expect(pointer.summary_data).to eq(
           [


### PR DESCRIPTION
## 📝 A short description of the changes
Fixes related to #2383 
 - pre-filling of dates for table display is fixed
 - specs are fixed as they calculated with wrong years supplied to them in the first place

## 🔗 Link to the relevant story (or stories)

## :shipit: Deployment implications

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

