### PR TITLE
[KAE-ACC-2023] Admin/Assessor UI - Page not zoomable

### DIFF
--- a/app/assets/stylesheets/admin/page-settings.scss
+++ b/app/assets/stylesheets/admin/page-settings.scss
@@ -108,6 +108,7 @@
       max-width: none;
       a {
         text-decoration: underline;
+        overflow-wrap: break-word;
       }
     }
 

--- a/app/assets/stylesheets/frontend/layout.scss
+++ b/app/assets/stylesheets/frontend/layout.scss
@@ -628,6 +628,7 @@ header.page-header aside .inner {
     &.sidebar-helpline {
       a {
         text-decoration: underline;
+        overflow-wrap: break-word;
       }
     }
   }


### PR DESCRIPTION
## 📝 A short description of the changes

* When zoomed in to 400% or using large font size some long urls are overlapping over text. This adds break-word wrap to those links.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1204861597377754/1204979100571057

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
Before:
<img width="1792" alt="Screenshot 2023-07-10 at 13 51 26" src="https://github.com/bitzesty/qae/assets/65811538/c1ee7c5d-52e4-46ea-99fa-00a03f09d5c2">


After:
<img width="1175" alt="Screenshot 2023-07-10 at 13 49 51" src="https://github.com/bitzesty/qae/assets/65811538/5e58fe23-e8cd-4d4a-b398-f4ed17a59212">

