### PR TITLE
Adds unique ids across appraisal view

### DIFF
--- a/app/assets/stylesheets/admin/_variables.scss
+++ b/app/assets/stylesheets/admin/_variables.scss
@@ -13,8 +13,8 @@ $grey-tab-hover:  #666;
 $grey-panel:      #dadad9;
 $white-true:      #fff;
 $green:           #5C802D;
-$amber:           #A86500;
-$red:             #e30613;
+$amber:           #995C00;
+$red:             #A0030E;
 $blue:            #3276b1;
 $selectable:      #e3e3e3;
 

--- a/app/views/admin/audit_certificate/_form.html.slim
+++ b/app/views/admin/audit_certificate/_form.html.slim
@@ -17,7 +17,7 @@
 
     .form-group
       label.form-label Document title
-      = form.text_field :attachment, class: "form-control attachment-title"
+      = form.text_field :attachment, class: "form-control attachment-title", id: "audit_certificate_attachment_input"
 
     .form-actions.text-right
       = link_to "Cancel", "#", class: "btn btn-default btn-cancel"

--- a/app/views/admin/comments/_form.html.slim
+++ b/app/views/admin/comments/_form.html.slim
@@ -2,7 +2,7 @@
   label
     ' Add a comment
   = f.hidden_field :section
-  = f.text_area :body, class: 'form-control', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.section}-new-comment"
+  = f.text_area :body, id: "#{f.object.section}_comment_body", class: 'form-control', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.section}-new-comment"
   .comment-actions
     = f.check_box :flagged
     = link_to "#flag-comment", class: "link-flag-comment js-link-flag-comment"

--- a/app/views/admin/comments/_form.html.slim
+++ b/app/views/admin/comments/_form.html.slim
@@ -1,10 +1,10 @@
 .form-container.comment-new
   label
     ' Add a comment
-  = f.hidden_field :section
+  = f.hidden_field :section, id: "#{f.object.section}_section_hidden_field"
   = f.text_area :body, id: "#{f.object.section}_comment_body", class: 'form-control', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.section}-new-comment"
   .comment-actions
-    = f.check_box :flagged
+    = f.check_box :flagged, id: "#{f.object.section}_flagged_hidden_checkbox"
     = link_to "#flag-comment", class: "link-flag-comment js-link-flag-comment"
       span.unflagged-visible
         ' Mark as flagged

--- a/app/views/admin/form_answers/_assessors_section.html.slim
+++ b/app/views/admin/form_answers/_assessors_section.html.slim
@@ -31,7 +31,8 @@
           .form-fields
             = form.select :assessor_id,
                           available_assessors_for_select,
-                          { include_blank: true }
+                          { include_blank: true },
+                          id: 'assessor_assignment_primary_assessor_id'
 
           = link_to "#", class: "form-edit-link"
             span.glyphicon.glyphicon-pencil
@@ -61,7 +62,10 @@
                    authenticity_token: true do |form|
 
           .form-fields
-            = form.select :assessor_id, available_assessors_for_select, { include_blank: true }
+            = form.select :assessor_id,
+                          available_assessors_for_select,
+                          { include_blank: true },
+                          id: 'assessor_assignment_secondary_assessor_id'
           = link_to "#", class: "form-edit-link"
             span.glyphicon.glyphicon-pencil
             ' Edit

--- a/app/views/admin/form_answers/_section_admin_comments.html.slim
+++ b/app/views/admin/form_answers/_section_admin_comments.html.slim
@@ -1,5 +1,5 @@
 .panel.panel-default
-  .panel-heading#admin-comments-heading role="tab"
+  .panel-heading#admin-comments-heading
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-application-info" href="#section-admin-comments" aria-expanded="true" aria-controls="section-admin-comments"
         ' Admin Comments
@@ -15,7 +15,7 @@
               - last_comment = @form_answer.comments.admin.first
               = "Updated by #{message_author_name(last_comment.author)} - #{l(last_comment.created_at, format: :date_at_time)}"
 
-  #section-admin-comments.section-admin-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="admin-comments-heading"
+  #section-admin-comments.section-admin-comments.panel-collapse.collapse aria-labelledby="admin-comments-heading"
     .panel-body
       .comments-container data-comment-form=new_admin_form_answer_comment_path(@form_answer)
         - if !(defined? read_only)

--- a/app/views/admin/form_answers/_section_admin_comments.html.slim
+++ b/app/views/admin/form_answers/_section_admin_comments.html.slim
@@ -19,7 +19,7 @@
     .panel-body
       .comments-container data-comment-form=new_admin_form_answer_comment_path(@form_answer)
         - if !(defined? read_only)
-          = form_for([:admin, @form_answer, @form_answer.comments.new(section: "admin")]) do |f|
+          = form_for([:admin, @form_answer, @form_answer.comments.new(section: "admin")], html: { id: "admin_comment_form" }) do |f|
             = render('admin/comments/form', f: f)
           .comment-insert
         - if !(defined? read_only)

--- a/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
@@ -1,5 +1,5 @@
 .panel.panel-default
-  .panel-heading#appraisal-form-moderated-heading role="tab"
+  .panel-heading#appraisal-form-moderated-heading
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-assessment" href="#section-appraisal-form-moderated" aria-expanded="true" aria-controls="section-appraisal-form-moderated"
         ' Appraisal Form (Moderated)
@@ -7,7 +7,7 @@
           small
             = moderated_assessment.last_editor_info
 
-  #section-appraisal-form-moderated.section-appraisal-form.section-appraisal-form-moderated.panel-collapse.collapse role="tabpanel" aria-labelledby="appraisal-form-moderated-heading"
+  #section-appraisal-form-moderated.section-appraisal-form.section-appraisal-form-moderated.panel-collapse.collapse aria-labelledby="appraisal-form-moderated-heading"
     .panel-body
       = simple_form_for([namespace_name, moderated_assessment],
                         remote: true,

--- a/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
@@ -12,9 +12,9 @@
       = simple_form_for([namespace_name, primary_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { "data-type" => "json"}) do |f|
+                        html: { "data-type" => "json", id: "primary_appraisal_form" }) do |f|
 
-        = hidden_field_tag :updated_section
+        = hidden_field_tag :updated_section, nil, id: "primary_updated_section_hidden_field"
         = render_section(resource, f)
         = f.submit "Save changes", class: "if-js-hide btn btn-primary"
       .clear

--- a/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
@@ -1,12 +1,12 @@
 .panel.panel-default
-  .panel-heading#appraisal-form-primary-heading role="tab"
+  .panel-heading#appraisal-form-primary-heading
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-assessment" href="#section-appraisal-form-primary" aria-expanded="true" aria-controls="section-appraisal-form-primary"
         ' Appraisal Form (Primary)
         - if primary_assessment.last_editor_info.present?
           small
             = primary_assessment.last_editor_info
-  #section-appraisal-form-primary.section-appraisal-form.section-appraisal-form-primary.panel-collapse.collapse role="tabpanel" aria-labelledby="appraisal-form-primary-heading"
+  #section-appraisal-form-primary.section-appraisal-form.section-appraisal-form-primary.panel-collapse.collapse aria-labelledby="appraisal-form-primary-heading"
     .panel-body
 
       = simple_form_for([namespace_name, primary_assessment],

--- a/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
@@ -12,9 +12,9 @@
       = simple_form_for([namespace_name, secondary_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { "data-type" => "json"}) do |f|
+                        html: { "data-type" => "json", id: "secondary_appraisal_form"}) do |f|
 
-        = hidden_field_tag :updated_section
+        = hidden_field_tag :updated_section, nil, id: "secondary_updated_section_hidden_field"
         = render_section(resource, f)
         = f.submit "Save changes", class: "if-js-hide btn btn-primary"
       .clear

--- a/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
@@ -1,12 +1,12 @@
 .panel.panel-default
-  .panel-heading#appraisal-form-secondary-heading role="tab"
+  .panel-heading#appraisal-form-secondary-heading
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-assessment" href="#section-appraisal-form-secondary" aria-expanded="true" aria-controls="section-appraisal-form-secondary"
         ' Appraisal Form (Secondary)
         - if secondary_assessment.last_editor_info.present?
           small
             = secondary_assessment.last_editor_info
-  #section-appraisal-form-secondary.section-appraisal-form.section-appraisal-form-secondary.panel-collapse.collapse role="tabpanel" aria-labelledby="appraisal-form-secondary-heading"
+  #section-appraisal-form-secondary.section-appraisal-form.section-appraisal-form-secondary.panel-collapse.collapse aria-labelledby="appraisal-form-secondary-heading"
     .panel-body
 
       = simple_form_for([namespace_name, secondary_assessment],

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -2,7 +2,7 @@
   - visible_case_summaries(current_subject, resource).each do |assessment_obj|
     - assessment = assessment_obj.assessment
     .panel.panel-parent
-      .panel-heading role="tab" id="case-summary-heading-#{assessment.position}"
+      .panel-heading id="case-summary-heading-#{assessment.position}"
         h4.panel-title
           a data-toggle="collapse" href="#section-case-summary-#{assessment.position}" aria-expanded="true" aria-controls="section-case-summary-#{assessment.position}"
             ' Case Summary (for recommended or reserved applications only)
@@ -11,7 +11,7 @@
             - if assessment.editable.present?
               small
                 = "Updated by #{message_author_name(assessment.editable)} - #{format_date(assessment.updated_at)}"
-      .panel-collapse.collapse role="tabpanel" aria-labelledby="case-summary-heading-#{assessment.position}" id="section-case-summary-#{assessment.position}" class="section-case-summary-#{assessment.position}"
+      .panel-collapse.collapse aria-labelledby="case-summary-heading-#{assessment.position}" id="section-case-summary-#{assessment.position}" class="section-case-summary-#{assessment.position}"
 
         .panel-body
           /.alert.alert-glyphicon.alert-info
@@ -27,7 +27,7 @@
             = render partial: "admin/form_answers/appraisal_form_components/application_background_section",
               locals: { f: f}
             = render_section(resource, f)
-            = hidden_field_tag :updated_section
+            = hidden_field_tag :updated_section, nil, id: "updated_section_#{assessment.position}"
             = f.submit "Save changes", class: "if-js-hide btn btn-primary"
 
           .clear

--- a/app/views/admin/form_answers/_section_company_details.html.slim
+++ b/app/views/admin/form_answers/_section_company_details.html.slim
@@ -1,5 +1,5 @@
 .panel.panel-default
-  .panel-heading#company-details-heading role="tab"
+  .panel-heading#company-details-heading
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-application-info" href="#section-company-details" aria-expanded="true" aria-controls="section-company-details"
         = @form_answer.promotion? ? "Nominee Details" : "Company Details"
@@ -8,7 +8,7 @@
             = "Updated by: #{resource.company_details_editable.decorate.full_name} - #{format_date(resource.company_details_updated_at)}"
 
 
-  #section-company-details.section-company-details.panel-collapse.collapse role="tabpanel" aria-labelledby="company-details-heading"
+  #section-company-details.section-company-details.panel-collapse.collapse aria-labelledby="company-details-heading"
     .panel-body.company-details-forms
       = render "admin/form_answers/company_details/company_name_form"
       = render "admin/form_answers/company_details/organisation_type_form"

--- a/app/views/admin/form_answers/_section_critical_comments.html.slim
+++ b/app/views/admin/form_answers/_section_critical_comments.html.slim
@@ -1,5 +1,5 @@
 .panel.panel-default
-  .panel-heading#critical-comments-heading role="tab"
+  .panel-heading#critical-comments-heading
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-assessment" href="#section-critical-comments" aria-expanded="true" aria-controls="section-critical-comments"
         ' Critical Comments
@@ -15,7 +15,7 @@
               - last_comment = @form_answer.comments.critical.first
               = "Updated by #{message_author_name(last_comment.author)} - #{l(last_comment.created_at, format: :date_at_time)}"
 
-  #section-critical-comments.section-critical-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="critical-comments-heading"
+  #section-critical-comments.section-critical-comments.panel-collapse.collapse aria-labelledby="critical-comments-heading"
     .panel-body
       .comments-container.comment-assessor
         = form_for([namespace_name, @form_answer, @form_answer.comments.new(section: "critical")]) do |f|

--- a/app/views/admin/form_answers/_section_draft_notes.html.slim
+++ b/app/views/admin/form_answers/_section_draft_notes.html.slim
@@ -1,13 +1,13 @@
 - @form_answer.draft_note || @form_answer.build_draft_note
 
 .panel.panel-default
-  .panel-heading#draft-notes-heading role="tab"
+  .panel-heading#draft-notes-heading
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-assessment" href="#section-draft-notes" aria-expanded="true" aria-controls="section-draft-notes"
         ' Draft Notes
         - if @form_answer.draft_note.decorate.try(:last_updated_by).present?
           small= @form_answer.draft_note.decorate.try(:last_updated_by)
-  #section-draft-notes.section-draft-notes.panel-collapse.collapse role="tabpanel" aria-labelledby="draft-notes-heading"
+  #section-draft-notes.section-draft-notes.panel-collapse.collapse aria-labelledby="draft-notes-heading"
     .panel-body
       = simple_form_for([namespace_name, @form_answer, @form_answer.draft_note],
                         remote: true,

--- a/app/views/admin/form_answers/_section_financial_summary.html.slim
+++ b/app/views/admin/form_answers/_section_financial_summary.html.slim
@@ -1,6 +1,6 @@
 - if !financial_pointer.period_length.zero? && @form_answer.submitted?
   .panel.panel-default
-    .panel-heading#financial-summary-heading role="tab"
+    .panel-heading#financial-summary-heading
       h4.panel-title
         a data-toggle="collapse" data-parent="#submitted-application" href="#financial-summary" aria-expanded="true" aria-controls="financial-summary"
           ' Financial Summary
@@ -11,7 +11,7 @@
               ' -
               = l @form_answer.financial_summary_updated_at.to_datetime, format: :date_at_time
 
-    #financial-summary.section-financial-summary.panel-collapse.collapse role="tabpanel" aria-labelledby="financial-summary-heading"
+    #financial-summary.section-financial-summary.panel-collapse.collapse aria-labelledby="financial-summary-heading"
       .panel-body
         = render "admin/form_answers/financials_review"
         = render "admin/form_answers/financial_summary/list", financial_pointer: financial_pointer

--- a/app/views/admin/form_answers/_section_palace_attendees.html.slim
+++ b/app/views/admin/form_answers/_section_palace_attendees.html.slim
@@ -1,11 +1,11 @@
 - if @form_answer.palace_invite.present?
   - palace_invite = @form_answer.palace_invite
   .panel.panel-default
-    .panel-heading#palace-attendees-heading role="tab"
+    .panel-heading#palace-attendees-heading
       h4.panel-title
         a data-toggle="collapse" data-parent="#panel-winners" href="#section-palace-attendees" aria-expanded="true" aria-controls="section-palace-attendees"
           ' Palace Attendees
-    #section-palace-attendees.section-palace-attendees.panel-collapse.collapse role="tabpanel" aria-labelledby="palace-attendees-heading"
+    #section-palace-attendees.section-palace-attendees.panel-collapse.collapse aria-labelledby="palace-attendees-heading"
       .panel-body.if-no-js-hide
         - palace_invite.palace_attendees.build if palace_invite.palace_attendees.blank?
         - palace_invite.palace_attendees.each_with_index do |pa, index|

--- a/app/views/admin/form_answers/_section_press_summary.html.slim
+++ b/app/views/admin/form_answers/_section_press_summary.html.slim
@@ -1,11 +1,11 @@
 .panel.panel-default
-  .panel-heading#press-summary-heading role="tab"
+  .panel-heading#press-summary-heading
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-winners" href="#section-press-summary" aria-expanded="true" aria-controls="section-press-summary"
         ' Press Book Notes
         small.updated-by
           - if @form_answer.press_summary_updated_by
             = @form_answer.press_summary_updated_by
-  #section-press-summary.section-press-summary.panel-collapse.collapse role="tabpanel" aria-labelledby="press-summary-heading"
+  #section-press-summary.section-press-summary.panel-collapse.collapse aria-labelledby="press-summary-heading"
     .panel-body
       = render "admin/press_summaries/section", form_answer: @form_answer

--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -1,26 +1,26 @@
 - title "Admin: Application #{@form_answer.urn.presence}"
 
-.panel-group#submitted-application-parent-parent role="tablist" aria-multiselectable="true"
+.panel-group#submitted-application-parent-parent
   .panel.panel-default.panel-parent
-    .panel-heading#application-info-heading role="tab"
+    .panel-heading#application-info-heading
       h4.panel-title
         a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-application-info" aria-expanded="true" aria-controls="section-application-info"
           ' Application info
-    #section-application-info.section-application-info.panel-collapse.collapse.in role="tabpanel" aria-labelledby="application-info-heading"
+    #section-application-info.section-application-info.panel-collapse.collapse.in aria-labelledby="application-info-heading"
       .panel-body
-        .panel-group#panel-application-info-parent role="tablist" aria-multiselectable="true"
+        .panel-group#panel-application-info-parent
           = render "section_admin_comments"
           = render "section_company_details"
           = render "section_financial_summary"
 
   .panel.panel-default.panel-parent
-    .panel-heading#assessment-heading role="tab"
+    .panel-heading#assessment-heading
       h4.panel-title
         a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-assessment" aria-expanded="true" aria-controls="section-assessment"
           ' Assessment
-    #section-assessment.section-application-info.panel-collapse.collapse.in role="tabpanel" aria-labelledby="assessment-heading"
+    #section-assessment.section-application-info.panel-collapse.collapse.in aria-labelledby="assessment-heading"
       .panel-body
-        .panel-group#panel-assessment-parent role="tablist" aria-multiselectable="true"
+        .panel-group#panel-assessment-parent
           = render "section_critical_comments"
           = render "section_draft_notes"
           = render "admin/form_answers/section_appraisal_form_primary"
@@ -32,7 +32,7 @@
 
   - if show_feedback_section?
     .panel.panel-default.panel-parent
-      .panel-heading#feedback-heading role="tab"
+      .panel-heading#feedback-heading
         h4.panel-title
           a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-feedback" aria-expanded="true" aria-controls="section-feedback"
             ' Feedback (for not recommended applications only)
@@ -43,30 +43,30 @@
             - if @form_answer.feedback_updated_by
               small
                 = @form_answer.feedback_updated_by
-      #section-feedback.section-application-info.panel-collapse.collapse role="tabpanel" aria-labelledby="feedback-heading"
+      #section-feedback.section-application-info.panel-collapse.collapse aria-labelledby="feedback-heading"
         .panel-body
           = render "admin/feedbacks/section", form_answer: @form_answer
 
   - if show_winners_section?
     .panel.panel-default.panel-parent
-      .panel-heading#winners-heading role="tab"
+      .panel-heading#winners-heading
         h4.panel-title
           a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-winners" aria-expanded="true" aria-controls="section-winners"
             ' Recipients
-      #section-winners.section-application-info.panel-collapse.collapse.in role="tabpanel" aria-labelledby="winners-heading"
+      #section-winners.section-application-info.panel-collapse.collapse.in aria-labelledby="winners-heading"
         .panel-body
-          .panel-group#panel-winners-parent role="tablist" aria-multiselectable="true"
+          .panel-group#panel-winners-parent
             - if show_press_summary_subsection?
               = render "section_press_summary"
             - if show_palace_attendees_subsection?
               = render "section_palace_attendees"
 
   .panel.panel-default.panel-parent
-    .panel-heading#logs-heading role="tab"
+    .panel-heading#logs-heading
       h4.panel-title
         a data-toggle="collapse" data-parent="#submitted-application-parent" href="#section-logs" aria-expanded="true" aria-controls="section-logs"
           ' Application Audit Log
-    #section-logs.section-application-info.panel-collapse.collapse role="tabpanel" aria-labelledby="logs-heading"
+    #section-logs.section-application-info.panel-collapse.collapse aria-labelledby="logs-heading"
       .panel-body
         - @audit_events.reverse.each do |log|
           p = log.to_s

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -36,8 +36,8 @@
       .clear
 
     = f.input section.desc,
-              wrapper_html: { class: 'form-group' },
-              input_html: { class: 'form-control js-char-count', rows: 5, "data-word-max" => (@form_answer.promotion? ? 1500 : 1200), "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-#{section.desc}" },
+              wrapper_html: { class: 'form-group'},
+              input_html: {id: "#{f.object.position}_#{section.desc}_comment", class: 'form-control js-char-count', rows: 5, "data-word-max" => (@form_answer.promotion? ? 1500 : 1200), "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-#{section.desc}" },
               as: :text,
               label: false
 

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -8,7 +8,7 @@
               as: :select,
               label: false,
               collection: form.options,
-              input_html: { class: "if-js-hide", "data-updated-section" => section.rate }
+              input_html: { class: "if-js-hide", "data-updated-section" => section.rate, id: "#{f.object.position}_#{section.desc}_select" }
 
     label.form-label.form-label-rag
       span.rag_section_label

--- a/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
@@ -3,7 +3,7 @@
             authenticity_token: true,
             class: "submit-assessment")
 
-    = hidden_field_tag :assessment_id, assessment.id
+    = hidden_field_tag :assessment_id, assessment.id, id: "#{assessment.position}_assessment_id_submit_appraisal_form_hidden_field"
 
     .feedback-holder
 
@@ -18,7 +18,7 @@
     - unlock_url = namespace_name == :admin ? unlock_admin_assessment_submission_url(assessment) : unlock_assessor_assessment_submission_url(assessment)
 
     = form_tag unlock_url, method: :patch do
-      = hidden_field_tag :assessment_id, assessment.id
+      = hidden_field_tag :assessment_id, assessment.id, id: "#{assessment.position}_assessment_id_unlock_appraisal_form_hidden_field"
       .feedback-holder.alert.alert-success
         ' Assessment submitted
 

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -35,7 +35,7 @@
       .clear
     = f.input section.desc,
               wrapper_html: { class: 'form-group' },
-              input_html: { class: 'form-control js-char-count', rows: 5, "data-word-max" => 1200, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-#{section.desc}"},
+              input_html: {id: "#{f.object.position}_#{section.desc}_verdict", class: 'form-control js-char-count', rows: 5, "data-word-max" => 1200, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-#{section.desc}"},
               as: :text,
               label: false
 

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -35,7 +35,7 @@
       .clear
     = f.input section.desc,
               wrapper_html: { class: 'form-group' },
-              input_html: {id: "#{f.object.position}_#{section.desc}_verdict", class: 'form-control js-char-count', rows: 5, "data-word-max" => 1200, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-#{section.desc}"},
+              input_html: {id: "#{f.object.position}_verdict", class: 'form-control js-char-count', rows: 5, "data-word-max" => 1200, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.id}-#{section.desc}"},
               as: :text,
               label: false
 

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -8,7 +8,7 @@
               as: :select,
               label: false,
               collection: form.options,
-              input_html: { class: "if-js-hide", "data-updated-section"  => section.desc}
+              input_html: { class: "if-js-hide", "data-updated-section"  => section.desc, id: "#{f.object.position}_#{section.desc}_select"}
 
     label.form-label.form-label-rag
       = section.label

--- a/app/views/admin/form_answers/company_details/_company_name_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_company_name_form.html.slim
@@ -4,9 +4,9 @@
     = simple_form_for [namespace_name, @form_answer],
                       remote: true,
                       authenticity_token: true,
-                      html: { "data-type" => "html", class: "company-name-form"} do |f|
+                      html: { "data-type" => "html", class: "company-name-form", id: "company-name-form-admin-appraisal"} do |f|
 
-      = hidden_field_tag :section, "company_name"
+      = hidden_field_tag :section, "company_name", id: "section_company_name_hidden_field"
       .form-container
         label.form-label = account_name
         .form-value

--- a/app/views/admin/form_answers/company_details/previous_wins/_form.html.slim
+++ b/app/views/admin/form_answers/company_details/previous_wins/_form.html.slim
@@ -1,9 +1,9 @@
 = simple_form_for [namespace_name, @form_answer],
                   remote: true,
                   authenticity_token: true,
-                  html: { "data-type" => "html" } do |f|
+                  html: { "data-type" => "html", id: "previous_wins_form" } do |f|
 
-  = hidden_field_tag :section, "previous_wins"
+  = hidden_field_tag :section, "previous_wins", id: "previous_wins_section_hidden_field"
   .form-container
     = render "admin/form_answers/company_details/previous_wins/show"
 

--- a/app/views/admin/settings/deadlines/_application_submission_stage_deadlines.html.slim
+++ b/app/views/admin/settings/deadlines/_application_submission_stage_deadlines.html.slim
@@ -1,9 +1,9 @@
 .panel.panel-default
-  .panel-heading#application-submission-stage-deadlines-heading role="tab"
+  .panel-heading#application-submission-stage-deadlines-heading
     h3.panel-title
       a data-toggle="collapse" data-parent="#panel-application-submission-stage" href="#section-application-submission-stage-deadlines" aria-expanded="true" aria-controls="section-application-submission-stage-deadlines"
         ' Deadlines
-  #section-application-submission-stage-deadlines.section-appraisal-form.section-application-submission-stage-deadlines.panel-collapse.collapse.in role="tabpanel" aria-labelledby="application-submission-stage-deadlines-heading"
+  #section-application-submission-stage-deadlines.section-appraisal-form.section-application-submission-stage-deadlines.panel-collapse.collapse.in aria-labelledby="application-submission-stage-deadlines-heading"
     .panel-body
       ul
         li = render 'deadline_form', kind: 'innovation_submission_start'

--- a/app/views/admin/settings/deadlines/_application_submission_stage_email_notifications.html.slim
+++ b/app/views/admin/settings/deadlines/_application_submission_stage_email_notifications.html.slim
@@ -1,8 +1,8 @@
 .panel.panel-default
-  .panel-heading#application-submission-stage-email-notifications-heading role="tab"
+  .panel-heading#application-submission-stage-email-notifications-heading
     h3.panel-title
       a data-toggle="collapse" data-parent="#panel-application-submission-stage" href="#section-application-submission-stage-email-notifications" aria-expanded="true" aria-controls="section-application-submission-stage-email-notifications"
         ' Email notification
-  #section-application-submission-stage-email-notifications.section-appraisal-form.section-application-submission-stage-email-notifications.panel-collapse.collapse.in role="tabpanel" aria-labelledby="application-submission-stage-email-notifications-heading"
+  #section-application-submission-stage-email-notifications.section-appraisal-form.section-application-submission-stage-email-notifications.panel-collapse.collapse.in aria-labelledby="application-submission-stage-email-notifications-heading"
     .panel-body
       = render 'email_notification', kind: 'reminder_to_submit'

--- a/app/views/admin/settings/deadlines/_award_year_open_stage_email_notifications.html.slim
+++ b/app/views/admin/settings/deadlines/_award_year_open_stage_email_notifications.html.slim
@@ -1,9 +1,9 @@
 .panel.panel-default
-  .panel-heading#open-stage-email-notifications-heading role="tab"
+  .panel-heading#open-stage-email-notifications-heading
     h3.panel-title
       a data-toggle="collapse" data-parent="#panel-open-stage" href="#section-open-stage-email-notifications" aria-expanded="true" aria-controls="section-open-stage-email-notifications"
         ' Email notification
-  #section-open-stage-email-notifications.section-appraisal-form.section-open-stage-email-notifications.panel-collapse.collapse.in role="tabpanel" aria-labelledby="open-stage-email-notifications-heading"
+  #section-open-stage-email-notifications.section-appraisal-form.section-open-stage-email-notifications.panel-collapse.collapse.in aria-labelledby="open-stage-email-notifications-heading"
     .panel-body
       = render 'email_notification', kind: 'award_year_open_notifier'
       = render 'email_notification', kind: 'innovation_submission_started_notification'

--- a/app/views/admin/settings/deadlines/_final_stage_deadlines.html.slim
+++ b/app/views/admin/settings/deadlines/_final_stage_deadlines.html.slim
@@ -1,9 +1,9 @@
 .panel.panel-default
-  .panel-heading#shortlisted-stage-deadlines-heading role="tab"
+  .panel-heading#shortlisted-stage-deadlines-heading
     h3.panel-title
       a data-toggle="collapse" data-parent="#panel-shortlisted-stage" href="#section-shortlisted-stage-deadlines" aria-expanded="true" aria-controls="section-shortlisted-stage-deadlines"
         ' Deadlines
-  #section-shortlisted-stage-deadlines.section-appraisal-form.section-shortlisted-stage-deadlines.panel-collapse.collapse.in role="tabpanel" aria-labelledby="shortlisted-stage-deadlines-heading"
+  #section-shortlisted-stage-deadlines.section-appraisal-form.section-shortlisted-stage-deadlines.panel-collapse.collapse.in aria-labelledby="shortlisted-stage-deadlines-heading"
     .panel-body
       ul
         li = render 'deadline_form', kind: 'buckingham_palace_attendees_details'

--- a/app/views/admin/settings/deadlines/_final_stage_email_notifications.html.slim
+++ b/app/views/admin/settings/deadlines/_final_stage_email_notifications.html.slim
@@ -1,9 +1,9 @@
 .panel.panel-default
-  .panel-heading#final-stage-email-notifications-heading role="tab"
+  .panel-heading#final-stage-email-notifications-heading
     h3.panel-title
       a data-toggle="collapse" data-parent="#panel-final-stage" href="#section-final-stage-email-notifications" aria-expanded="true" aria-controls="section-final-stage-email-notifications"
         ' Email notification
-  #section-final-stage-email-notifications.section-appraisal-form.section-final-stage-email-notifications.panel-collapse.collapse.in role="tabpanel" aria-labelledby="final-stage-email-notifications-heading"
+  #section-final-stage-email-notifications.section-appraisal-form.section-final-stage-email-notifications.panel-collapse.collapse.in aria-labelledby="final-stage-email-notifications-heading"
     .panel-body
       = render 'email_notification', kind: 'winners_notification'
       = render 'email_notification', kind: 'winners_head_of_organisation_notification'

--- a/app/views/admin/settings/deadlines/_registration_stage_deadlines.html.slim
+++ b/app/views/admin/settings/deadlines/_registration_stage_deadlines.html.slim
@@ -1,9 +1,9 @@
 .panel.panel-default
-  .panel-heading#registration-stage-deadlines-heading role="tab"
+  .panel-heading#registration-stage-deadlines-heading
     h3.panel-title
       a data-toggle="collapse" data-parent="#panel-registration-stage" href="#section-registration-stage-deadlines" aria-expanded="true" aria-controls="section-registration-stage-deadlines"
         ' Deadlines
-  #section-registration-stage-deadlines.section-appraisal-form.section-registration-stage-deadlines.panel-collapse.collapse.in role="tabpanel" aria-labelledby="registration-stage-deadlines-heading"
+  #section-registration-stage-deadlines.section-appraisal-form.section-registration-stage-deadlines.panel-collapse.collapse.in aria-labelledby="registration-stage-deadlines-heading"
     .panel-body
       ul
         li = render 'deadline_form', kind: 'award_year_switch'

--- a/app/views/admin/settings/deadlines/_shortlisted_stage_deadlines.html.slim
+++ b/app/views/admin/settings/deadlines/_shortlisted_stage_deadlines.html.slim
@@ -1,9 +1,9 @@
 .panel.panel-default
-  .panel-heading#final-stage-deadlines-heading role="tab"
+  .panel-heading#final-stage-deadlines-heading
     h3.panel-title
       a data-toggle="collapse" data-parent="#panel-final-stage" href="#section-final-stage-deadlines" aria-expanded="true" aria-controls="section-final-stage-deadlines"
         ' Deadlines
-  #section-final-stage-deadlines.section-appraisal-form.section-final-stage-deadlines.panel-collapse.collapse.in role="tabpanel" aria-labelledby="final-stage-deadlines-heading"
+  #section-final-stage-deadlines.section-appraisal-form.section-final-stage-deadlines.panel-collapse.collapse.in aria-labelledby="final-stage-deadlines-heading"
     .panel-body
       ul
         li = render 'deadline_form', kind: 'audit_certificates'

--- a/app/views/admin/settings/deadlines/_shortlisted_stage_email_notifications.html.slim
+++ b/app/views/admin/settings/deadlines/_shortlisted_stage_email_notifications.html.slim
@@ -1,9 +1,9 @@
 .panel.panel-default
-  .panel-heading#shortlisted-stage-email-notifications-heading role="tab"
+  .panel-heading#shortlisted-stage-email-notifications-heading
     h2.panel-title
       a data-toggle="collapse" data-parent="#panel-shortlisted-stage" href="#section-shortlisted-stage-email-notifications" aria-expanded="true" aria-controls="section-shortlisted-stage-email-notifications"
         ' Email notification
-  #section-shortlisted-stage-email-notifications.section-appraisal-form.section-shortlisted-stage-email-notifications.panel-collapse.collapse.in role="tabpanel" aria-labelledby="shortlisted-stage-email-notifications-heading"
+  #section-shortlisted-stage-email-notifications.section-appraisal-form.section-shortlisted-stage-email-notifications.panel-collapse.collapse.in aria-labelledby="shortlisted-stage-email-notifications-heading"
     .panel-body
       = render 'email_notification', kind: 'shortlisted_notifier'
       = render 'email_notification', kind: 'shortlisted_po_sd_notifier'

--- a/app/views/admin/settings/show.html.slim
+++ b/app/views/admin/settings/show.html.slim
@@ -12,7 +12,7 @@
   .clear
   br
 
-  .panel-group#admin-settings-parent role="tablist" aria-multiselectable="true"
+  .panel-group#admin-settings-parent
     = render "admin/settings/stages/registration_stage"
     = render "admin/settings/stages/application_submission_stage"
     = render "admin/settings/stages/shortlisted_stage"

--- a/app/views/admin/settings/stages/_application_submission_stage.html.slim
+++ b/app/views/admin/settings/stages/_application_submission_stage.html.slim
@@ -1,10 +1,10 @@
 .panel.panel-default.panel-parent
-  .panel-heading#application-submission-stage-heading role="tab"
+  .panel-heading#application-submission-stage-heading
     h3.panel-title
       a data-toggle="collapse" data-parent="#admin-settings" href="#application-submission-stage" aria-expanded="true" aria-controls="application-submission-stage"
         ' Application Submission Stage
-  #application-submission-stage.panel-collapse.collapse.in role="tabpanel" aria-labelledby="application-submission-stage-heading"
+  #application-submission-stage.panel-collapse.collapse.in aria-labelledby="application-submission-stage-heading"
     .panel-body
-      .panel-group#panel-application-submission-stage-parent role="tablist" aria-multiselectable="true"
+      .panel-group#panel-application-submission-stage-parent
         = render "admin/settings/deadlines/application_submission_stage_deadlines"
         = render "admin/settings/deadlines/application_submission_stage_email_notifications"

--- a/app/views/admin/settings/stages/_final_stage.html.slim
+++ b/app/views/admin/settings/stages/_final_stage.html.slim
@@ -1,10 +1,10 @@
 .panel.panel-default.panel-parent
-  .panel-heading role="tab" id="final-stage-header"
+  .panel-heading id="final-stage-header"
     h2.panel-title
       a.collapsed data-toggle="collapse" data-parent="#admin-settings" href="#final-stage" aria-expanded="false" aria-controls="final-stage"
         ' Final Stage
-  #final-stage.panel-collapse.collapse.in role="tabpanel" aria-labelledby="final-stage-header"
+  #final-stage.panel-collapse.collapse.in aria-labelledby="final-stage-header"
     .panel-body
-      .panel-group#panel-final-stage-parent role="tablist" aria-multiselectable="true"
+      .panel-group#panel-final-stage-parent
         = render "admin/settings/deadlines/final_stage_deadlines"
         = render "admin/settings/deadlines/final_stage_email_notifications"

--- a/app/views/admin/settings/stages/_registration_stage.html.slim
+++ b/app/views/admin/settings/stages/_registration_stage.html.slim
@@ -1,10 +1,10 @@
 .panel.panel-default.panel-parent
-  .panel-heading#registration-stage-heading role="tab"
+  .panel-heading#registration-stage-heading
     h2.panel-title
       a data-toggle="collapse" data-parent="#admin-settings" href="#registration-stage" aria-expanded="true" aria-controls="registration-stage"
         ' Registration Stage
-  #registration-stage.panel-collapse.collapse.in role="tabpanel" aria-labelledby="registration-stage-heading"
+  #registration-stage.panel-collapse.collapse.in aria-labelledby="registration-stage-heading"
     .panel-body
-      .panel-group#panel-registration-stage-parent role="tablist" aria-multiselectable="true"
+      .panel-group#panel-registration-stage-parent
         = render "admin/settings/deadlines/registration_stage_deadlines"
         = render "admin/settings/deadlines/award_year_open_stage_email_notifications"

--- a/app/views/admin/settings/stages/_shortlisted_stage.html.slim
+++ b/app/views/admin/settings/stages/_shortlisted_stage.html.slim
@@ -1,10 +1,10 @@
 .panel.panel-default.panel-parent
-  .panel-heading role="tab" id="shortlisted-stage-header"
+  .panel-heading id="shortlisted-stage-header"
     h2.panel-title
       a.collapsed data-toggle="collapse" data-parent="#admin-settings" href="#shortlisted-stage" aria-expanded="false" aria-controls="shortlisted-stage"
         ' Shortlisted Stage
-  #shortlisted-stage.panel-collapse.collapse.in role="tabpanel" aria-labelledby="shortlisted-stage-header"
+  #shortlisted-stage.panel-collapse.collapse.in aria-labelledby="shortlisted-stage-header"
     .panel-body
-      .panel-group#panel-shortlisted-stage-parent role="tablist" aria-multiselectable="true"
+      .panel-group#panel-shortlisted-stage-parent
         = render "admin/settings/deadlines/shortlisted_stage_deadlines"
         = render "admin/settings/deadlines/shortlisted_stage_email_notifications"

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,49 +1,49 @@
 = simple_form_for [:admin, resource], html: { class: "qae-form" } do |f|
-  .panel-group#user-form-panel-parent role="tablist" aria-multiselectable="true"
+  .panel-group#user-form-panel-parent
     .panel.panel-default
-      .panel-heading#user-details-heading role="tab"
+      .panel-heading#user-details-heading
         h2.panel-title
           a data-toggle="collapse" data-parent="#user-form-panel" href="#user-details" aria-expanded="true" aria-controls="user-details"
             = controller_name == "users" ? "Applicant" : controller_name.singularize.titleize
             '  Details
-      #user-details.section-user-details.panel-collapse.collapse.in role="tabpanel" aria-labelledby="user-details-heading"
+      #user-details.section-user-details.panel-collapse.collapse.in aria-labelledby="user-details-heading"
         .panel-body
           = render "fields_user_details", f: f
 
     .panel.panel-default
-      .panel-heading role="tab" id="organisation-details-header"
+      .panel-heading id="organisation-details-header"
         h2.panel-title
           a.collapsed data-toggle="collapse" data-parent="#user-form-panel" href="#organisation-details" aria-expanded="false" aria-controls="organisation-details"
             ' Organisation Details
-      #organisation-details.section-organisation-details.panel-collapse.collapse role="tabpanel" aria-labelledby="organisation-details-header"
+      #organisation-details.section-organisation-details.panel-collapse.collapse aria-labelledby="organisation-details-header"
         .panel-body
           = render "fields_organisation_details", f: f
 
     .panel.panel-default
-      .panel-heading role="tab" id="contact-preferences-header"
+      .panel-heading id="contact-preferences-header"
         h2.panel-title
           a.collapsed data-toggle="collapse" data-parent="#user-form-panel" href="#contact-preferences" aria-expanded="false" aria-controls="contact-preferences"
             ' Contact Preferences
-      #contact-preferences.section-contact-preferences.panel-collapse.collapse role="tabpanel" aria-labelledby="contact-preferences-header"
+      #contact-preferences.section-contact-preferences.panel-collapse.collapse aria-labelledby="contact-preferences-header"
         .panel-body
           = render "fields_contact_preferences", f: f
 
     - unless action_name == "new"
       .panel.panel-default
-        .panel-heading role="tab" id="section-collaborators-header"
+        .panel-heading id="section-collaborators-header"
           h2.panel-title
             a.collapsed data-toggle="collapse" data-parent="#user-form-panel" href="#section-collaborators" aria-expanded="false" aria-controls="section-collaborators"
               ' Collaborators
-        #section-collaborators.section-collaborators.panel-collapse.collapse role="tabpanel" aria-labelledby="section-collaborators-header"
+        #section-collaborators.section-collaborators.panel-collapse.collapse aria-labelledby="section-collaborators-header"
           .panel-body
             = render "fields_collaborators", f: f, resource: resource
 
     .panel.panel-default
-      .panel-heading role="tab" id="section-password-header"
+      .panel-heading id="section-password-header"
         h2.panel-title
           a.collapsed data-toggle="collapse" data-parent="#user-form-panel" href="#section-password" aria-expanded="false" aria-controls="section-password"
             ' Password
-      #section-password.section-password.panel-collapse.collapse role="tabpanel" aria-labelledby="section-password-header"
+      #section-password.section-password.panel-collapse.collapse aria-labelledby="section-password-header"
         .panel-body
           = render "fields_password", f: f
 

--- a/app/views/assessor/reports/_primary_vs_secondary_appraisals.html.slim
+++ b/app/views/assessor/reports/_primary_vs_secondary_appraisals.html.slim
@@ -7,9 +7,10 @@
       - next if key.to_s == "promotion" && hide_promotion?
       - link_ops = {category: key, format: :csv, year: @award_year.year}
 
-      = link_to assessor_report_path("discrepancies_between_primary_and_secondary_appraisals", link_ops), class: "action-title"
-        span.glyphicon.glyphicon-download-alt.black
-        span.visible-lg.visible-md
-        = value
+      li
+        = link_to assessor_report_path("discrepancies_between_primary_and_secondary_appraisals", link_ops), class: "action-title"
+          span.glyphicon.glyphicon-download-alt.black
+          span.visible-lg.visible-md
+          = value
         
   .clear

--- a/spec/features/admin/form_answers/comments_management_spec.rb
+++ b/spec/features/admin/form_answers/comments_management_spec.rb
@@ -18,14 +18,14 @@ I want to be able to view, create and destroy the comments per application.
 
   it "adds the comment" do
     within admin_comments do
-      populate_comment_form
+      populate_comment_form("admin")
       expect { click_button "Comment" }.to change { Comment.count }.by(1)
     end
   end
 
   it "deletes the comment" do
     within admin_comments do
-      populate_comment_form
+      populate_comment_form("admin")
       click_button "Comment"
     end
 
@@ -36,7 +36,7 @@ I want to be able to view, create and destroy the comments per application.
 
   it "displays the comments" do
     within admin_comments do
-      populate_comment_form
+      populate_comment_form("admin")
       click_button "Comment"
       visit admin_form_answer_path(form_answer)
     end
@@ -49,7 +49,7 @@ I want to be able to view, create and destroy the comments per application.
         first("#admin-comments-heading a").click
 
         within admin_comments do
-          populate_comment_form
+          populate_comment_form("admin")
           find(".js-link-flag-comment").click
           click_button "Comment"
           expect(page).to have_selector(".comment-flagged", count: 1)
@@ -70,7 +70,7 @@ I want to be able to view, create and destroy the comments per application.
         first("#critical-comments-heading a").click
 
         within critical_comments do
-          populate_comment_form
+          populate_comment_form("critical")
           find(".js-link-flag-comment").click
           click_button "Comment"
 
@@ -84,8 +84,8 @@ I want to be able to view, create and destroy the comments per application.
 
   private
 
-  def populate_comment_form
-    fill_in("comment_body", with: "body")
+  def populate_comment_form(prefix)
+    fill_in("#{prefix}_comment_body", with: "body")
   end
 end
 # TODO: can be added as shared example per assessor

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -30,9 +30,9 @@ shared_context "successful appraisal form edition" do
 
     context "multiple descriptions change" do
       it "updates the form in separation" do
-        assert_multiple_description_change(primary, primary_header)
-        assert_multiple_description_change(secondary, secondary_header)
-        assert_multiple_description_change(moderated, moderated_header)
+        assert_multiple_description_change(primary, primary_header, "primary")
+        assert_multiple_description_change(secondary, secondary_header, "secondary")
+        assert_multiple_description_change(moderated, moderated_header, "moderated")
       end
     end
   end
@@ -106,7 +106,7 @@ def assert_description_change(section_id, header_id)
   within section_id do
     within ".#{selector}" do
       expect(page).to have_selector("textarea", count: 1)
-      fill_in(selector, with: text)
+      find("textarea").fill_in(with: text)
     end
     within parent_selector do
       find(".form-save-link").click
@@ -127,18 +127,14 @@ def assert_description_change(section_id, header_id)
   visit show_path
 end
 
-def assert_multiple_description_change(section_id, header_id)
+def assert_multiple_description_change(section_id, header_id, prefix)
   text = "should NOT be saved"
   text2 = "should be saved"
   find("#{header_id} .panel-title a").click
   take_a_nap
 
   within section_id do
-    unless section_id == moderated
-      fill_in("assessor_assignment_level_of_innovation_desc", with: text)
-    end
-
-    fill_in("assessor_assignment_verdict_desc", with: text2)
+    fill_in("#{prefix}_verdict", with: text2)
     all(".form-save-link").last.click
     wait_for_ajax
   end
@@ -152,7 +148,7 @@ def assert_multiple_description_change(section_id, header_id)
 
     all(".form-edit-link").last.click
 
-    expect(page.find("#assessor_assignment_verdict_desc").text).to eq  text2
+    expect(page.find("##{prefix}_verdict").text).to eq  text2
   end
 end
 


### PR DESCRIPTION
## 📝 A short description of the changes

* Mostly changes to add unique ids to elements in the appraisal page
* Also corrects a bug where list elements were not correctly wrapped in `<li>` tags

* Removes tab roles from collapsable components on Settings/Users/Appraisals pages to address nested interactive elements issue

## 🔗 Link to the relevant story (or stories)

* No specific card for first 2 tasks
* https://app.asana.com/0/1204861597377754/1204935845819515/f
* https://app.asana.com/0/1204861597377754/1204935845819540/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

