### PR TITLE
Make password errors more accessible

### DIFF
--- a/app/assets/javascripts/frontend/password-strength-indicator.js
+++ b/app/assets/javascripts/frontend/password-strength-indicator.js
@@ -138,6 +138,7 @@ $(function() {
 
         if (someProblem) {
           $('#password-guidance').removeClass("govuk-!-display-none");
+          $('#password-result-span').addClass("visuallyhidden")
         } else {
           $('#password-guidance').addClass("govuk-!-display-none");
         }
@@ -147,8 +148,10 @@ $(function() {
 
         if ($passwordField.val().length == 0) {
           $passwordField.attr('aria-invalid', "true");
+          $('#password-result-span').addClass("visuallyhidden")
         } else if ($.inArray('good-password', guidance) >= 0) {
           $passwordField.attr('aria-invalid', "false");
+          $('#password-result-span').removeClass("visuallyhidden")
         } else {
           $passwordField.attr('aria-invalid', "true");
         }
@@ -160,13 +163,16 @@ $(function() {
 
         if ($passwordConfirmationField.val().length == 0) {
           $passwordConfirmationField.attr('aria-invalid', "true");
+          $('#password-confirmation-result-span').addClass("visuallyhidden")
         } else if ($.inArray('confirmation-not-matching', guidance) >= 0) {
           $passwordConfirmationField.attr('aria-invalid', "true");
           indicator.parent().removeClass('confirmation-matching');
+          $('#password-confirmation-result-span').addClass("visuallyhidden")
         } else if ($.inArray('confirmation-matching', guidance) >= 0) {
           $passwordConfirmationField.attr('aria-invalid', "false");
           if($.inArray('good-password', guidance) >= 0) {
             indicator.parent().addClass('confirmation-matching');
+            $('#password-confirmation-result-span').removeClass("visuallyhidden")
           }
         }
       }

--- a/app/assets/javascripts/frontend/password-strength-indicator.js
+++ b/app/assets/javascripts/frontend/password-strength-indicator.js
@@ -138,7 +138,7 @@ $(function() {
 
         if (someProblem) {
           $('#password-guidance').removeClass("govuk-!-display-none");
-          $('#password-result-span').addClass("visuallyhidden")
+          $('#password-result-span').addClass("hide")
         } else {
           $('#password-guidance').addClass("govuk-!-display-none");
         }
@@ -148,10 +148,10 @@ $(function() {
 
         if ($passwordField.val().length == 0) {
           $passwordField.attr('aria-invalid', "true");
-          $('#password-result-span').addClass("visuallyhidden")
+          $('#password-result-span').addClass("hide")
         } else if ($.inArray('good-password', guidance) >= 0) {
           $passwordField.attr('aria-invalid', "false");
-          $('#password-result-span').removeClass("visuallyhidden")
+          $('#password-result-span').removeClass("hide")
         } else {
           $passwordField.attr('aria-invalid', "true");
         }
@@ -163,16 +163,16 @@ $(function() {
 
         if ($passwordConfirmationField.val().length == 0) {
           $passwordConfirmationField.attr('aria-invalid', "true");
-          $('#password-confirmation-result-span').addClass("visuallyhidden")
+          $('#password-confirmation-result-span').addClass("hide")
         } else if ($.inArray('confirmation-not-matching', guidance) >= 0) {
           $passwordConfirmationField.attr('aria-invalid', "true");
           indicator.parent().removeClass('confirmation-matching');
-          $('#password-confirmation-result-span').addClass("visuallyhidden")
+          $('#password-confirmation-result-span').addClass("hide")
         } else if ($.inArray('confirmation-matching', guidance) >= 0) {
           $passwordConfirmationField.attr('aria-invalid', "false");
           if($.inArray('good-password', guidance) >= 0) {
             indicator.parent().addClass('confirmation-matching');
-            $('#password-confirmation-result-span').removeClass("visuallyhidden")
+            $('#password-confirmation-result-span').removeClass("hide")
           }
         }
       }

--- a/app/assets/stylesheets/admin/_variables.scss
+++ b/app/assets/stylesheets/admin/_variables.scss
@@ -31,3 +31,4 @@ $header-hover: #444;
 $blue-link-colour: #3264A3;
 $govuk-light-blue: #5694ca;
 $govuk-highlight-yellow: #fd0;
+$govuk-warning-red: #d4351c;

--- a/app/views/admin/admins/_form.html.slim
+++ b/app/views/admin/admins/_form.html.slim
@@ -41,7 +41,7 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control', "data-min-password-length" => "10" },
                       label: false
-            span#password-result-span.input-group-addon.visuallyhidden
+            span#password-result-span.input-group-addon.hide
               i#password-result.glyphicon.glyphicon-ok
       .clear
 
@@ -57,7 +57,7 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-confirmation-result-span.input-group-addon.visuallyhidden
+            span#password-confirmation-result-span.input-group-addon.hide
               i#password-confirmation-result.glyphicon.glyphicon-ok
       .clear
 

--- a/app/views/admin/admins/_form.html.slim
+++ b/app/views/admin/admins/_form.html.slim
@@ -26,6 +26,14 @@
   .question-group#password-change-panel
     #password-control-group
       h3 = f.label :password, class: "form-label"
+      .guidance-panel.if-no-js-hide
+        .govuk-form-group--error#password-guidance
+          p.govuk-error-message.text-underline Please improve your password
+          p.govuk-error-message#password-too-short
+            ' It must be at least 10 characters.
+          p.govuk-error-message#parts-of-email It shouldn't include part or all of your email address.
+          p.govuk-error-message#password-entropy
+            ' It must be more complex. Consider using whole sentences (with spaces), lyrics or phrases to make it more memorable.
       .row
         .col-md-4.col-sm-6
           .input-group
@@ -33,23 +41,15 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control', "data-min-password-length" => "10" },
                       label: false
-            span#password-result-span.input-group-addon
+            span#password-result-span.input-group-addon.visuallyhidden
               i#password-result.glyphicon.glyphicon-ok
       .clear
 
-    .guidance-panel.if-no-js-hide
-      #password-guidance
-        br
-        .alert.alert-warning
-          p.text-underline Please improve your password
-          p#password-too-short
-            ' It must be at least 10 characters.
-          p#parts-of-email It shouldn't include part or all of your email address.
-          p#password-entropy
-            ' It must be more complex. Consider using whole sentences (with spaces), lyrics or phrases to make it more memorable.
-
     #password-confirmation-control-group
       h3 = f.label :password_confirmation, label: "Retype password", class: "form-label"
+      .if-no-js-hide
+        .govuk-form-group--error#password-confirmation-guidance
+          p.govuk-error-message#password-confirmation-match The confirmation must match the password
       .row
         .col-md-4.col-sm-6
           .input-group
@@ -57,15 +57,9 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-confirmation-result-span.input-group-addon
+            span#password-confirmation-result-span.input-group-addon.visuallyhidden
               i#password-confirmation-result.glyphicon.glyphicon-ok
       .clear
-
-    .if-no-js-hide
-      #password-confirmation-guidance
-        br
-        .alert.alert-warning
-          p#password-confirmation-match The confirmation must match the password
 
   br
   .row

--- a/app/views/admin/assessors/_form.html.slim
+++ b/app/views/admin/assessors/_form.html.slim
@@ -57,7 +57,7 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-result-span.input-group-addon.visuallyhidden
+            span#password-result-span.input-group-addon.hide
               i#password-result.glyphicon.glyphicon-ok
       .clear
 
@@ -73,7 +73,7 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-confirmation-result-span.input-group-addon.visuallyhidden
+            span#password-confirmation-result-span.input-group-addon.hide
               i#password-confirmation-result.glyphicon.glyphicon-ok
       .clear
 

--- a/app/views/admin/assessors/_form.html.slim
+++ b/app/views/admin/assessors/_form.html.slim
@@ -42,6 +42,14 @@
   .question-group#password-change-panel
     #password-control-group
       h2 = f.label :password, class: "form-label"
+      .guidance-panel.if-no-js-hide
+        .govuk-form-group--error#password-guidance
+          p.govuk-error-message.text-underline Please improve your password
+          p.govuk-error-message#password-too-short
+            ' It must be at least 10 characters.
+          p.govuk-error-message#parts-of-email It shouldn't include part or all of your email address.
+          p.govuk-error-message#password-entropy
+            ' It must be more complex. Consider using whole sentences (with spaces), lyrics or phrases to make it more memorable.
       .row
         .col-md-4.col-sm-6
           .input-group
@@ -49,22 +57,15 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-result-span.input-group-addon
+            span#password-result-span.input-group-addon.visuallyhidden
               i#password-result.glyphicon.glyphicon-ok
       .clear
-    .guidance-panel.if-no-js-hide
-      #password-guidance
-        br
-        .alert.alert-warning
-          p.text-underline Please improve your password
-          p#password-too-short
-            ' It must be at least 10 characters.
-          p#parts-of-email It shouldn't include part or all of your email address.
-          p#password-entropy
-            ' It must be more complex. Consider using whole sentences (with spaces), lyrics or phrases to make it more memorable.
 
     #password-confirmation-control-group
       h2 = f.label :password_confirmation, label: "Retype password", class: "form-label"
+      .if-no-js-hide
+        .govuk-form-group--error#password-confirmation-guidance
+          p.govuk-error-message#password-confirmation-match The confirmation must match the password
       .row
         .col-md-4.col-sm-6
           .input-group
@@ -72,15 +73,9 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-confirmation-result-span.input-group-addon
+            span#password-confirmation-result-span.input-group-addon.visuallyhidden
               i#password-confirmation-result.glyphicon.glyphicon-ok
       .clear
-
-    .if-no-js-hide
-      #password-confirmation-guidance
-        br
-        .alert.alert-warning
-          p#password-confirmation-match The confirmation must match the password
 
   br
 

--- a/app/views/admin/judges/_form.html.slim
+++ b/app/views/admin/judges/_form.html.slim
@@ -26,6 +26,15 @@
   .question-group#password-change-panel
     #password-control-group
       h3 = f.label :password, class: "form-label"
+      .guidance-panel.if-no-js-hide
+        .govuk-form-group--error#password-guidance
+          p.govuk-error-message.text-underline Please improve your password
+          p.govuk-error-message#password-too-short
+            ' It must be at least 10 characters.
+          p.govuk-error-message#parts-of-email It shouldn't include part or all of your email address.
+          p.govuk-error-message#password-entropy
+            ' It must be more complex. Consider using whole sentences (with spaces), lyrics or phrases to make it more memorable.
+
       .row
         .col-md-4.col-sm-6
           .input-group
@@ -33,19 +42,9 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-result-span.input-group-addon
+            span#password-result-span.input-group-addon.visuallyhidden
               i#password-result.glyphicon.glyphicon-ok
       .clear
-    .guidance-panel.if-no-js-hide
-      #password-guidance
-        br
-        .alert.alert-warning
-          p.text-underline Please improve your password
-          p#password-too-short
-            ' It must be at least 10 characters.
-          p#parts-of-email It shouldn't include part or all of your email address.
-          p#password-entropy
-            ' It must be more complex. Consider using whole sentences (with spaces), lyrics or phrases to make it more memorable.
 
     #password-confirmation-control-group
       h3 = f.label :password_confirmation, label: "Retype password", class: "form-label"
@@ -56,15 +55,13 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-confirmation-result-span.input-group-addon
+            span#password-confirmation-result-span.input-group-addon.visuallyhidden
               i#password-confirmation-result.glyphicon.glyphicon-ok
       .clear
 
     .if-no-js-hide
-      #password-confirmation-guidance
-        br
-        .alert.alert-warning
-          p#password-confirmation-match The confirmation must match the password
+      .govuk-form-group--error#password-confirmation-guidance
+        p.govuk-error-message#password-confirmation-match The confirmation must match the password
 
   br
 

--- a/app/views/admin/judges/_form.html.slim
+++ b/app/views/admin/judges/_form.html.slim
@@ -42,7 +42,7 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-result-span.input-group-addon.visuallyhidden
+            span#password-result-span.input-group-addon.hide
               i#password-result.glyphicon.glyphicon-ok
       .clear
 
@@ -55,7 +55,7 @@
                       wrapper_html: { class: 'form-group' },
                       input_html: { class: 'form-control' },
                       label: false
-            span#password-confirmation-result-span.input-group-addon.visuallyhidden
+            span#password-confirmation-result-span.input-group-addon.hide
               i#password-confirmation-result.glyphicon.glyphicon-ok
       .clear
 

--- a/app/views/admin/users/_fields_password.html.slim
+++ b/app/views/admin/users/_fields_password.html.slim
@@ -18,6 +18,14 @@
       - else
         = f.label :password, label: "Password"
         - password_hint = ""
+    .guidance-panel.if-no-js-hide
+      .govuk-form-group--error#password-guidance
+        p.govuk-error-message.text-underline Please improve your password
+        p.govuk-error-message#password-too-short
+          ' It must be at least 10 characters.
+        p.govuk-error-message#parts-of-email It shouldn't include part or all of your email address.
+        p.govuk-error-message#password-entropy
+          ' It must be more complex. Consider using whole sentences (with spaces), lyrics or phrases to make it more memorable.
     .row
       .col-md-4.col-sm-6
         .input-group
@@ -25,22 +33,15 @@
                     wrapper_html: { class: "form-group" },
                     input_html: { class: "form-control password-strength-meter" },
                     label_html: { class: "visuallyhidden" }
-          span#password-result-span.input-group-addon
+          span#password-result-span.input-group-addon.visuallyhidden
             i#password-result.glyphicon.glyphicon-ok
         span.hint = password_hint
 
-  .guidance-panel.if-no-js-hide
-    #password-guidance
-      .alert.alert-warning
-        p.text-underline Please improve your password
-        p#password-too-short
-          ' It must be at least 10 characters.
-        p#parts-of-email It shouldn't include part or all of your email address.
-        p#password-entropy
-          ' It must be more complex. Consider using whole sentences (with spaces), lyrics or phrases to make it more memorable.
-
   .question-group#password-confirmation-control-group
     h3 = f.label :password_confirmation, label: "Retype password"
+    .if-no-js-hide
+      .govuk-form-group--error#password-confirmation-guidance
+        p.govuk-error-message#password-confirmation-match The confirmation must match the password
     .row
       .col-md-4.col-sm-6
         .input-group
@@ -48,11 +49,5 @@
                     wrapper_html: { class: "form-group" },
                     input_html: { class: "form-control" },
                     label_html: { class: "visuallyhidden" }
-          span#password-confirmation-result-span.input-group-addon
+          span#password-confirmation-result-span.input-group-addon.visuallyhidden
             i#password-confirmation-result.glyphicon.glyphicon-ok
-
-  .if-no-js-hide
-    #password-confirmation-guidance
-      br
-      .alert.alert-warning
-        p#password-confirmation-match The confirmation must match the password

--- a/app/views/admin/users/_fields_password.html.slim
+++ b/app/views/admin/users/_fields_password.html.slim
@@ -33,7 +33,7 @@
                     wrapper_html: { class: "form-group" },
                     input_html: { class: "form-control password-strength-meter" },
                     label_html: { class: "visuallyhidden" }
-          span#password-result-span.input-group-addon.visuallyhidden
+          span#password-result-span.input-group-addon.hide
             i#password-result.glyphicon.glyphicon-ok
         span.hint = password_hint
 
@@ -49,5 +49,5 @@
                     wrapper_html: { class: "form-group" },
                     input_html: { class: "form-control" },
                     label_html: { class: "visuallyhidden" }
-          span#password-confirmation-result-span.input-group-addon.visuallyhidden
+          span#password-confirmation-result-span.input-group-addon.hide
             i#password-confirmation-result.glyphicon.glyphicon-ok


### PR DESCRIPTION
## 📝 A short description of the changes

* Remove tick as default and don't show for errors
* Add green tick for valid passwords
* Change errors to red text and move above inputs

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1204861597377754/1204994500690554

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="882" alt="Screenshot 2023-07-18 at 14 07 32" src="https://github.com/bitzesty/qae/assets/65811538/7697738c-8c11-484b-bec3-cc3a4d976baf">
<img width="680" alt="Screenshot 2023-07-18 at 14 07 51" src="https://github.com/bitzesty/qae/assets/65811538/075532e8-88bc-4d9e-94a5-38af08e46879">

