### PR TITLE
Use hide instead of visuallyhidden class

### DIFF
--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -34,25 +34,19 @@ h1.admin-page-heading
 
 = simple_form_for @search, url: assessor_form_answers_path, method: :get, as: :search, html: { class: 'search-form', id: 'application_table_search_form' } do |f|
   = hidden_field_tag :award_type, category_picker.current_award_type, id: "award_type_application_table_search_form"
-  label for="year" class="visuallyhidden" aria-hidden="true"
-    ' Award year
-  = text_field_tag :year, @award_year.year, class: "visuallyhidden", aria: { hidden: true }
+  = hidden_field_tag :year, @award_year.year
 
   - # status filters need to be here because the filtering is done in the other form above, so in order not to break filtering, we need to duplicate it here
   = f.simple_fields_for [:filters, @search.filters] do |h|
-    = h.label :status, class: "visuallyhidden", for: "status_application_table_search_form", aria: { hidden: true }
     = h.input :status,
               collection: FormAnswerStatus::AssessorFilter.options,
               label: false,
-              input_html: { multiple: true, class: 'visuallyhidden', id: 'status_application_table_search_form' },
-              aria: { hidden: true }
+              input_html: { multiple: true, id: 'status_application_table_search_form', class: 'hide' }
 
-    = h.label :sub_status, class: "visuallyhidden", for: "sub_status_application_table_search_form", aria: { hidden: true }
     = h.input :sub_status,
               collection: FormAnswerStatus::AssessorFilter.sub_options(current_assessor),
               label: false,
-              input_html: { multiple: true, class: 'visuallyhidden', id: 'sub_status_application_table_search_form'},
-              aria: { hidden: true }
+              input_html: { multiple: true, id: 'sub_status_application_table_search_form', class: 'hide'}
 
   .row
     .col-xs-12
@@ -61,7 +55,6 @@ h1.admin-page-heading
           tr
             - if current_subject.categories_as_lead.include?(category_picker.current_award_type)
               th
-                span.visuallyhidden Select for bulk action
                 span.if-no-js-hide
                   = check_box_tag :check_all, "Check all", false, aria: { label: "Select all applications for bulk action" }
             th.sortable width="250"


### PR DESCRIPTION
## 📝 A short description of the changes

* The `visuallyhidden` class positions elements off screen but they can still be navigated to using a keyboard so it is better to use `hide` class which has `display: none`. Also removed labels - these fields are duplicated to allow search to function and so will always be hidden and no labels are needed.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1204861597377754/1204979853681157

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
