### PR TITLE
Generic flash messages on remote forms

### DIFF
--- a/app/assets/javascripts/admin/comments.js.coffee
+++ b/app/assets/javascripts/admin/comments.js.coffee
@@ -1,5 +1,5 @@
 ready = ->
-  $('body').on 'submit', '.new_comment', (e) ->
+  $(document).on 'submit', '.new_comment', (e) ->
     that = $(this)
     e.preventDefault()
     $.ajax
@@ -30,8 +30,9 @@ ready = ->
         else
           signatureWrapper.html("")
 
+        window.fire(that[0], 'ajax:x:success', data)
 
-  $('body').on 'submit', '.destroy-comment', (e) ->
+  $(document).on 'submit', '.destroy-comment', (e) ->
     e.preventDefault()
     $.ajax
       url: $(this).attr('action')

--- a/app/assets/javascripts/admin/financial_data.js.coffee
+++ b/app/assets/javascripts/admin/financial_data.js.coffee
@@ -6,13 +6,12 @@ jQuery ->
     overallBenchmarksTable = ($ "#overall-financial-benchmarks")
     financialTable = ($ "#financial-table")
 
-    ($ "input", form).on "change keyup keydown paste", ->
-      timer ||= setTimeout(saveFinancials, 500 )
+    $("input", form).on "change keyup keydown paste", ->
+      timer ||= setTimeout(saveFinancials, 500)
 
     ($ "button", form).on "click", (event) ->
       do event.preventDefault
       $(this).closest(".form-group").removeClass("form-edit")
-
 
     updateExportsGrowth = (exports) ->
       exportsGrowth = ($ 'tr.exports-growth td.value', benchmarksTable)
@@ -91,13 +90,13 @@ jQuery ->
       url = form.attr('action')
       formData = form.serialize()
       updateBenchmarks()
-
-      jqXHR = $.ajax({
+      $.ajax
         url: url
         data: formData
         type: 'POST'
-        dataType: 'js'
-      })
+        dataType: 'script'
+        success: (_data) ->
+          window.fire(form[0], 'ajax:x:success', null)
 
       ($ 'td.value', financialTable).each (i, td) ->
         input = ($ 'input', ($ td))

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -434,8 +434,8 @@ editFormAnswerAutoUpdate = ->
   $(".sic-code .form-save-link").on "click", (e) ->
     e.preventDefault()
     e.stopPropagation()
-    that = $("#form_answer_sic_code")
-    form = $(".edit_form_answer")
+    input = $("#form_answer_sic_code")
+    form = $(e.target).closest('form')
     $.ajax
       action: form.attr("action")
       data: form.serialize()
@@ -443,15 +443,19 @@ editFormAnswerAutoUpdate = ->
       dataType: "json"
 
       success: (result) ->
-        formGroup = that.parents(".form-group")
+        formGroup = input.parents(".form-group")
         formGroup.removeClass("form-edit")
-        formGroup.find(".form-value p").text(that.find("option:selected").text())
+        console.log(formGroup, input)
+        formGroup.find(".form-value p").text(input.val())
         sicCodes = result["form_answer"]["sic_codes"]
         counter = 1
         for row in $(".sector-average-growth td")
           $(row).text(sicCodes[counter.toString()])
           counter += 1
         $(".avg-growth-legend").text(result["form_answer"]["legend"])
+
+        window.fire(form[0], 'ajax:x:success', null)
+
 bindRags =(klass) ->
   $(document).on "click", "#{klass} .btn-rag .dropdown-menu a", (e) ->
     e.preventDefault()

--- a/app/assets/javascripts/application-admin.js.coffee
+++ b/app/assets/javascripts/application-admin.js.coffee
@@ -26,7 +26,18 @@
 #= require clean-paste
 
 $(document).ready(() ->
-  $("html").removeClass("no-js").addClass("js")
-  ($ ".timepicker").timePicker()
-  ($ ".datepicker").datepicker({dateFormat: "dd/mm/yy"})
+  $('html').removeClass('no-js').addClass('js')
+  ($ '.timepicker').timePicker()
+  ($ '.datepicker').datepicker({dateFormat: 'dd/mm/yy'})
 )
+
+$(document).on 'ajax:success', 'form', (event, data, _status, _xhr) ->
+  fire(this, 'ajax:x:success', data)
+
+$(document).on 'ajax:error', 'form', (event, data, _status, _xhr) ->
+  fire(this, 'ajax:x:error', data)
+
+window.fire = (obj, name, data) ->
+  event = new CustomEvent(name, detail: data, bubbles: true, cancelable: true)
+  obj.dispatchEvent(event)
+  !event.defaultPrevented

--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -19,6 +19,9 @@ class Admin::AdminsController < Admin::UsersController
     authorize @resource, :create?
 
     @resource.save
+
+    render_flash_message_for(@resource)
+
     location = @resource.persisted? ? admin_admins_path : nil
     respond_with :admin, @resource, location: location
   end
@@ -32,6 +35,8 @@ class Admin::AdminsController < Admin::UsersController
       @resource.update_without_password(resource_params)
     end
 
+    render_flash_message_for(@resource)
+    
     respond_with :admin, @resource, location: admin_admins_path
   end
 
@@ -39,6 +44,8 @@ class Admin::AdminsController < Admin::UsersController
     authorize @resource, :destroy?
     @resource.soft_delete!
 
+    render_flash_message_for(@resource)
+    
     respond_with :admin, @resource, location: admin_admins_path
   end
 

--- a/app/controllers/admin/assessors_controller.rb
+++ b/app/controllers/admin/assessors_controller.rb
@@ -20,6 +20,9 @@ class Admin::AssessorsController < Admin::UsersController
 
     @resource.save
     location = @resource.persisted? ? admin_assessors_path : nil
+
+    render_flash_message_for(@resource)
+
     respond_with :admin, @resource, location: location
   end
 
@@ -32,12 +35,16 @@ class Admin::AssessorsController < Admin::UsersController
       @resource.update_without_password(resource_params)
     end
 
+    render_flash_message_for(@resource)
+
     respond_with :admin, @resource, location: admin_assessors_path
   end
 
   def destroy
     authorize @resource, :destroy?
     @resource.soft_delete!
+
+    render_flash_message_for(@resource)
 
     respond_with :admin, @resource, location: admin_assessors_path
   end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -20,6 +20,14 @@ class Admin::BaseController < ApplicationController
     current_admin
   end
 
+  def render_flash_message_for(resource, message: nil)
+    if resource.errors.any?
+      flash[:error] = message || "An unknown error has occurred, please try again."
+    else
+      flash[:notice] = message || "Success!"
+    end
+  end
+
   private
 
   def user_not_authorized

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -27,6 +27,7 @@ class Admin::CommentsController < Admin::BaseController
             head :ok
           end
         else
+          render_flash_message_for(@comment)
           redirect_to admin_form_answer_path(form_answer)
         end
       end
@@ -38,7 +39,10 @@ class Admin::CommentsController < Admin::BaseController
     log_event if resource.update(update_params)
 
     respond_to do |format|
-      format.html { redirect_to([namespace_name, form_answer]) }
+      format.html do 
+        render_flash_message_for(resource)
+        redirect_to([namespace_name, form_answer]) 
+      end
       format.js { head :ok }
     end
   end
@@ -49,8 +53,11 @@ class Admin::CommentsController < Admin::BaseController
     log_event if resource.destroy
 
     respond_to do |format|
-      format.json{ render(json: :ok)}
-      format.html{ redirect_to admin_form_answer_path(form_answer)}
+      format.json { render(json: :ok)}
+      format.html do 
+        render_flash_message_for(resource)
+        redirect_to(admin_form_answer_path(form_answer))
+      end
     end
   end
 

--- a/app/controllers/admin/custom_emails_controller.rb
+++ b/app/controllers/admin/custom_emails_controller.rb
@@ -15,8 +15,10 @@ class Admin::CustomEmailsController < Admin::BaseController
     @form = CustomEmailForm.new(custom_email_form_attributes)
     if @form.valid?
       CustomEmailWorker.perform_async(custom_email_form_attributes)
+      render_flash_message_for(@form)
       redirect_to admin_custom_email_path, notice: "Email was successfully scheduled"
     else
+      render_flash_message_for(@form)
       render :show
     end
   end

--- a/app/controllers/admin/judges_controller.rb
+++ b/app/controllers/admin/judges_controller.rb
@@ -20,6 +20,9 @@ class Admin::JudgesController < Admin::UsersController
 
     @resource.save
     location = @resource.persisted? ? admin_judges_path : nil
+
+    render_flash_message_for(@resource)
+
     respond_with :admin, @resource, location: location
   end
 
@@ -32,12 +35,16 @@ class Admin::JudgesController < Admin::UsersController
       @resource.update_without_password(resource_params)
     end
 
+    render_flash_message_for(@resource)
+
     respond_with :admin, @resource, location: admin_judges_path
   end
 
   def destroy
     authorize @resource, :destroy?
     @resource.soft_delete!
+
+    render_flash_message_for(@resource)
 
     respond_with :admin, @resource, location: admin_judges_path
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,6 +27,9 @@ class Admin::UsersController < Admin::BaseController
 
     @resource.save
     location = @resource.persisted? ? admin_users_path : nil
+
+    render_flash_message_for(@resource)
+
     respond_with :admin, @resource, location: location
   end
 
@@ -38,6 +41,8 @@ class Admin::UsersController < Admin::BaseController
     else
       @resource.update_without_password(resource_params)
     end
+
+    render_flash_message_for(@resource)
 
     respond_with :admin, @resource, location: admin_users_path
   end

--- a/app/controllers/concerns/admin_shortlisted_docs_context.rb
+++ b/app/controllers/concerns/admin_shortlisted_docs_context.rb
@@ -18,6 +18,7 @@ module AdminShortlistedDocsContext
 
       respond_to do |format|
         format.html do
+          render_flash_message_for(attachment)
           redirect_to [namespace_name, form_answer]
         end
 
@@ -30,7 +31,8 @@ module AdminShortlistedDocsContext
     else
       respond_to do |format|
         format.html do
-          redirect_to [namespace_name, form_answer], alert: attachment.errors.full_messages.join(", ")
+          render_flash_message_for(attachment)
+          redirect_to [namespace_name, form_answer]
         end
 
         format.js do
@@ -55,6 +57,7 @@ module AdminShortlistedDocsContext
         if request.xhr? || request.format.js?
           head :ok
         else
+          render_flash_message_for(resource)
           redirect_to [namespace_name, form_answer]
         end
       end

--- a/app/controllers/concerns/admin_shortlisted_docs_submission_context.rb
+++ b/app/controllers/concerns/admin_shortlisted_docs_submission_context.rb
@@ -6,6 +6,8 @@ module AdminShortlistedDocsSubmissionContext
 
     respond_to do |format|
       format.html do
+        render_flash_message_for(resource)
+
         redirect_to [namespace_name, form_answer], alert: render_errors
       end
 

--- a/app/controllers/concerns/draft_notes_mixin.rb
+++ b/app/controllers/concerns/draft_notes_mixin.rb
@@ -9,6 +9,7 @@ module DraftNotesMixin
 
     respond_to do |format|
       format.html do
+        render_flash_message_for(resource)
         redirect_to [namespace_name, form_answer]
       end
 
@@ -28,6 +29,7 @@ module DraftNotesMixin
 
     respond_to do |format|
       format.html do
+        render_flash_message_for(resource)
         redirect_to [namespace_name, form_answer]
       end
 

--- a/app/javascript/controllers/form_flash_controller.js
+++ b/app/javascript/controllers/form_flash_controller.js
@@ -1,0 +1,67 @@
+export default class extends ApplicationController {
+  static values = {
+    error: String,
+    success: String,
+  };
+
+  connect() {
+    this.element.addEventListener('ajax:x:success', this.onSuccess);
+    this.element.addEventListener('ajax:x:error', this.onError);
+  }
+
+  disconnect() {
+    this.element.removeEventListener('ajax:x:success', this.onSuccess);
+    this.element.removeEventListener('ajax:x:error', this.onError);
+  }
+
+  success(event) {
+    return this.onSuccess(event);
+  }
+
+  error(event) {
+    return this.onError(event);
+  }
+
+  onSuccess = (event) => {
+    const msg = this.hasSuccessValue ? this.successValue : 'Success!';
+    const [alert, identifier] = this.createAlert('success', msg);
+
+    setTimeout(() => this.showAlert(alert, identifier), 50);
+  };
+
+  onError = (event) => {
+    const msg = this.hasErrorValue ? this.errorValue : 'An unknown error has occurred, please try again.';
+    const [alert, identifier] = this.createAlert('danger', msg);
+
+    setTimeout(() => this.showAlert(alert, identifier), 50);
+  };
+
+  createAlert = (type, message) => {
+    const id = 'alert__' + String(Math.random()).slice(2, -1);
+    const element = `
+      <div id='${id}' class='alert alert-${type}' data-controller='element-removal' role='alert' style='padding-top: 6px; padding-bottom: 6px; margin-bottom: 8px;'>
+        ${message}
+        <button type='button' class='close' data-action='click->element-removal#remove' aria-label='Close' style='font-size: 18px;'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+    `;
+
+    return [element, id];
+  };
+
+  showAlert = (alert, identifier) => {
+    const form = document.getElementById(this.element.id);
+    const container = form.parentNode;
+    const element =
+      container && (container.classList.contains('form-container') || container.classList.contains('form-group'))
+        ? container
+        : form;
+    element.insertAdjacentHTML('afterbegin', alert);
+    console.log('element', element);
+    setTimeout(() => {
+      const inserted = document.getElementById(identifier);
+      if (inserted) inserted.remove();
+    }, 4000);
+  };
+}

--- a/app/javascript/controllers/inline_flash_controller.js
+++ b/app/javascript/controllers/inline_flash_controller.js
@@ -1,17 +1,23 @@
 export default class extends ApplicationController {
+  static targets = ['form', 'link'];
+
   static values = {
     error: String,
     success: String,
   };
 
   connect() {
-    this.element.addEventListener('ajax:x:success', this.onSuccess);
-    this.element.addEventListener('ajax:x:error', this.onError);
+    this.formTargets.forEach((el) => {
+      el.addEventListener('ajax:x:success', this.onSuccess);
+      el.addEventListener('ajax:x:error', this.onError);
+    });
   }
 
   disconnect() {
-    this.element.removeEventListener('ajax:x:success', this.onSuccess);
-    this.element.removeEventListener('ajax:x:error', this.onError);
+    this.formTargets.forEach((el) => {
+      el.removeEventListener('ajax:x:success', this.onSuccess);
+      el.removeEventListener('ajax:x:error', this.onError);
+    });
   }
 
   success(event) {
@@ -26,14 +32,14 @@ export default class extends ApplicationController {
     const msg = this.hasSuccessValue ? this.successValue : 'Success!';
     const [alert, identifier] = this.createAlert('success', msg);
 
-    setTimeout(() => this.showAlert(alert, identifier), 50);
+    setTimeout(() => this.showAlert(alert, identifier), 1);
   };
 
   onError = (event) => {
     const msg = this.hasErrorValue ? this.errorValue : 'An unknown error has occurred, please try again.';
     const [alert, identifier] = this.createAlert('danger', msg);
 
-    setTimeout(() => this.showAlert(alert, identifier), 50);
+    setTimeout(() => this.showAlert(alert, identifier), 1);
   };
 
   createAlert = (type, message) => {
@@ -51,14 +57,11 @@ export default class extends ApplicationController {
   };
 
   showAlert = (alert, identifier) => {
-    const form = document.getElementById(this.element.id);
-    const container = form.parentNode;
-    const element =
-      container && (container.classList.contains('form-container') || container.classList.contains('form-group'))
-        ? container
-        : form;
-    element.insertAdjacentHTML('afterbegin', alert);
-    console.log('element', element);
+    const existing = this.element.querySelector('[id*=alert__]')
+    if (existing) existing.remove()
+
+    this.element.insertAdjacentHTML('afterbegin', alert);
+
     setTimeout(() => {
       const inserted = document.getElementById(identifier);
       if (inserted) inserted.remove();

--- a/app/views/admin/audit_certificate/_form.html.slim
+++ b/app/views/admin/audit_certificate/_form.html.slim
@@ -3,7 +3,7 @@
 / whether file was saved or not
 .span
   = hidden_field_tag "valid", "false", id: "form-audit_certificate-valid"
-= form_for [namespace_name, form_answer, audit_certificate], html: { multipart: true } do |form|
+= form_for [namespace_name, form_answer, audit_certificate], html: { multipart: true, data: { inline_flash_target: "form" } } do |form|
   .well.js-attachment-form
     h3 Attach document
 

--- a/app/views/admin/email_notifications/create.js.erb
+++ b/app/views/admin/email_notifications/create.js.erb
@@ -6,6 +6,8 @@ wrapper = $("#email_notification_" + "<%= @email_notification.kind %>");
 
   $(".new_email_notification .timepicker", wrapper).val(null);
   $(".new_email_notification .datepicker", wrapper).val(null);
+  window.fire($(".new_email_notification", wrapper)[0], 'ajax:x:success', null)
 <% else %>
   $(".notification-form input", wrapper).closest(".input").addClass("field-with-errors");
+  window.fire($(".new_email_notification", wrapper)[0], 'ajax:x:error', null)
 <% end %>

--- a/app/views/admin/email_notifications/update.js.erb
+++ b/app/views/admin/email_notifications/update.js.erb
@@ -7,6 +7,8 @@ wrapper = $("#notification-" + "<%= @email_notification.id %>");
   $(".notification-edit-form input.datepicker", wrapper).val("<%= @email_notification.formatted_trigger_at_date %>");
   $(".notification-edit-form input.timepicker", wrapper).val("<%= @email_notification.formatted_trigger_at_time %>");
   $(".trigger-at", wrapper).html("<%= @email_notification.decorate.formatted_trigger_time %>");
+  window.fire($(".edit_email_notification", wrapper)[0], 'ajax:x:success', null)
 <% else %>
   $(".notification-edit-form input", wrapper).closest(".input").addClass("field-with-errors");
+  window.fire($(".edit_email_notification", wrapper)[0], 'ajax:x:error', null)
 <% end %>

--- a/app/views/admin/feedbacks/_section.html.slim
+++ b/app/views/admin/feedbacks/_section.html.slim
@@ -1,6 +1,6 @@
 - feedback = form_answer.feedback.present? ? form_answer.feedback : form_answer.build_feedback
 - url = feedback.persisted? ? polymorphic_url([namespace_name, form_answer, feedback]) : polymorphic_url([namespace_name, form_answer, :feedbacks])
-= simple_form_for feedback, url: url, remote: true, authenticity_token: true, html: { "data-type" => "json" } do |f|
+= simple_form_for feedback, url: url, remote: true, authenticity_token: true, html: { data: { type: "json", controller: "form-flash" } } do |f|
   - if !form_answer.promotion?
     = render "admin/feedbacks/overall_feedback_field", f: f, feedback: feedback
   - FeedbackForm.fields_for_award_type(form_answer.object).each do |feedback_field, feedback_field_value|

--- a/app/views/admin/feedbacks/_section.html.slim
+++ b/app/views/admin/feedbacks/_section.html.slim
@@ -1,6 +1,6 @@
 - feedback = form_answer.feedback.present? ? form_answer.feedback : form_answer.build_feedback
 - url = feedback.persisted? ? polymorphic_url([namespace_name, form_answer, feedback]) : polymorphic_url([namespace_name, form_answer, :feedbacks])
-= simple_form_for feedback, url: url, remote: true, authenticity_token: true, html: { data: { type: "json", controller: "form-flash" } } do |f|
+= simple_form_for feedback, url: url, remote: true, authenticity_token: true, html: { data: { type: "json", inline_flash_target: "form" } } do |f|
   - if !form_answer.promotion?
     = render "admin/feedbacks/overall_feedback_field", f: f, feedback: feedback
   - FeedbackForm.fields_for_award_type(form_answer.object).each do |feedback_field, feedback_field_value|

--- a/app/views/admin/figures_and_vat_returns/_form.html.slim
+++ b/app/views/admin/figures_and_vat_returns/_form.html.slim
@@ -3,7 +3,7 @@
 / whether file was saved or not
 .span
   = hidden_field_tag "valid", "false", id: "#{attachment.model_name.param_key}-valid"
-= form_for [namespace_name, form_answer, attachment], html: { multipart: true } do |form|
+= form_for [namespace_name, form_answer, attachment], html: { multipart: true, data: { inline_flash_target: "form" } } do |form|
   .well.js-attachment-form
     h3 Attach document
 

--- a/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
+++ b/app/views/admin/form_answer_attachments/_form_answer_attachment.html.slim
@@ -4,7 +4,7 @@
     - if show_remove_form_answer_attachment?(form_answer_attachment)
       small.pull-right
         = form_for([namespace_name, form_answer_attachment.form_answer, form_answer_attachment],
-                   html: { method: :delete, style: "display:inline-block;"}) do |f|
+                   html: { data: { inline_flash_target: "form" }, method: :delete, style: "display: inline-block;" }) do |f|
 
           = f.submit 'Remove', class: 'if-js-hide'
 

--- a/app/views/admin/form_answers/_assessors_section.html.slim
+++ b/app/views/admin/form_answers/_assessors_section.html.slim
@@ -12,7 +12,7 @@
         = resource.lead_assessors
       .clear
 
-    li.form-group.primary-assessor-assignment[data-controller="element-focus"]
+    li.form-group.primary-assessor-assignment[data-controller="element-focus inline-flash"]
       label[for='assessor_assignment_primary_assessor_id']
         ' Primary:
       .form-value class=("ellipsis edit-value" if policy(resource).assign_assessor?)
@@ -25,7 +25,7 @@
       - if policy(resource).assign_assessor?
         = form_for [namespace_name, resource.assessor_assignments.primary],
                    remote: true,
-                   html: { data: { type: "json", controller: "form-flash" } },
+                   html: { data: { type: "json", inline_flash_target: "form" } },
                    authenticity_token: true do |form|
 
           .form-fields
@@ -46,7 +46,7 @@
           .errors-holder
       .clear
 
-    li.form-group.secondary-assessor-assignment[data-controller="element-focus"]
+    li.form-group.secondary-assessor-assignment[data-controller="element-focus inline-flash"]
       label[for='assessor_assignment_secondary_assessor_id']
         span.assessor-label Secondary:
       .form-value class=("ellipsis edit-value" if policy(resource).assign_assessor?)
@@ -59,7 +59,7 @@
       - if policy(resource).assign_assessor?
         = form_for [namespace_name, resource.assessor_assignments.secondary],
                    remote: true,
-                   html: { data: { type: "json", controller: "form-flash" } },
+                   html: { data: { type: "json", inline_flash_target: "form" } },
                    authenticity_token: true do |form|
 
           .form-fields

--- a/app/views/admin/form_answers/_assessors_section.html.slim
+++ b/app/views/admin/form_answers/_assessors_section.html.slim
@@ -25,7 +25,7 @@
       - if policy(resource).assign_assessor?
         = form_for [namespace_name, resource.assessor_assignments.primary],
                    remote: true,
-                   html: { "data-type" => "json"},
+                   html: { data: { type: "json", controller: "form-flash" } },
                    authenticity_token: true do |form|
 
           .form-fields
@@ -59,7 +59,7 @@
       - if policy(resource).assign_assessor?
         = form_for [namespace_name, resource.assessor_assignments.secondary],
                    remote: true,
-                   html: { "data-type" => "json" },
+                   html: { data: { type: "json", controller: "form-flash" } },
                    authenticity_token: true do |form|
 
           .form-fields

--- a/app/views/admin/form_answers/_financials_review.html.slim
+++ b/app/views/admin/form_answers/_financials_review.html.slim
@@ -6,7 +6,8 @@
     - if policy(review_audit_certificate).create?
       = simple_form_for([namespace_name, review_audit_certificate],
                         remote: true,
-                        authenticity_token: true) do |f|
+                        authenticity_token: true,
+                        html: { controller: "inline-flash", inline_flash_target: "form" }) do |f|
 
         = f.input :form_answer_id, as: :hidden
 
@@ -49,7 +50,8 @@
                         remote: true,
                         url: [namespace_name, :review_commercial_figures],
                         method: :post,
-                        authenticity_token: true) do |f|
+                        authenticity_token: true,
+                        html: { controller: "inline-flash", inline_flash_target: "form" }) do |f|
 
         = f.input :form_answer_id, as: :hidden
 

--- a/app/views/admin/form_answers/_section_admin_comments.html.slim
+++ b/app/views/admin/form_answers/_section_admin_comments.html.slim
@@ -19,7 +19,7 @@
     .panel-body
       .comments-container data-comment-form=new_admin_form_answer_comment_path(@form_answer)
         - if !(defined? read_only)
-          = form_for([:admin, @form_answer, @form_answer.comments.new(section: "admin")], html: { id: "admin_comment_form" }) do |f|
+          = form_for([:admin, @form_answer, @form_answer.comments.new(section: "admin")], html: { id: "admin_comment_form", data: { controller: "form-flash" } }) do |f|
             = render('admin/comments/form', f: f)
           .comment-insert
         - if !(defined? read_only)

--- a/app/views/admin/form_answers/_section_admin_comments.html.slim
+++ b/app/views/admin/form_answers/_section_admin_comments.html.slim
@@ -17,9 +17,9 @@
 
   #section-admin-comments.section-admin-comments.panel-collapse.collapse aria-labelledby="admin-comments-heading"
     .panel-body
-      .comments-container data-comment-form=new_admin_form_answer_comment_path(@form_answer)
+      .comments-container[data-comment-form=new_admin_form_answer_comment_path(@form_answer) data-controller="inline-flash"]
         - if !(defined? read_only)
-          = form_for([:admin, @form_answer, @form_answer.comments.new(section: "admin")], html: { id: "admin_comment_form", data: { controller: "form-flash" } }) do |f|
+          = form_for([:admin, @form_answer, @form_answer.comments.new(section: "admin")], html: { id: "admin_comment_form", data: { inline_flash_target: "form" } }) do |f|
             = render('admin/comments/form', f: f)
           .comment-insert
         - if !(defined? read_only)

--- a/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
@@ -7,12 +7,12 @@
           small
             = moderated_assessment.last_editor_info
 
-  #section-appraisal-form-moderated.section-appraisal-form.section-appraisal-form-moderated.panel-collapse.collapse aria-labelledby="appraisal-form-moderated-heading"
-    .panel-body
+  #section-appraisal-form-moderated.section-appraisal-form.section-appraisal-form-moderated.panel-collapse.collapse[aria-labelledby="appraisal-form-moderated-heading"]
+    .panel-body[data-controller="inline-flash"]
       = simple_form_for([namespace_name, moderated_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "json", controller: "form-flash" } }) do |f|
+                        html: { data: { type: "json", inline_flash_target: "form" } }) do |f|
 
         = render_section(resource, f)
         = hidden_field_tag :updated_section

--- a/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
@@ -12,7 +12,7 @@
       = simple_form_for([namespace_name, moderated_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { "data-type" => "json"}) do |f|
+                        html: { data: { type: "json", controller: "form-flash" } }) do |f|
 
         = render_section(resource, f)
         = hidden_field_tag :updated_section

--- a/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
@@ -7,12 +7,11 @@
           small
             = primary_assessment.last_editor_info
   #section-appraisal-form-primary.section-appraisal-form.section-appraisal-form-primary.panel-collapse.collapse aria-labelledby="appraisal-form-primary-heading"
-    .panel-body
-
+    .panel-body[data-controller="inline-flash"]
       = simple_form_for([namespace_name, primary_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "json", controller: "form-flash" }, id: "primary_appraisal_form" }) do |f|
+                        html: { data: { type: "json", inline_flash_target: "form" }, id: "primary_appraisal_form" }) do |f|
 
         = hidden_field_tag :updated_section, nil, id: "primary_updated_section_hidden_field"
         = render_section(resource, f)

--- a/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
@@ -12,7 +12,7 @@
       = simple_form_for([namespace_name, primary_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { "data-type" => "json", id: "primary_appraisal_form" }) do |f|
+                        html: { data: { type: "json", controller: "form-flash" }, id: "primary_appraisal_form" }) do |f|
 
         = hidden_field_tag :updated_section, nil, id: "primary_updated_section_hidden_field"
         = render_section(resource, f)

--- a/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
@@ -12,7 +12,7 @@
       = simple_form_for([namespace_name, secondary_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { "data-type" => "json", id: "secondary_appraisal_form"}) do |f|
+                        html: { data: { type: "json", controller: "form-flash" }, id: "secondary_appraisal_form"}) do |f|
 
         = hidden_field_tag :updated_section, nil, id: "secondary_updated_section_hidden_field"
         = render_section(resource, f)

--- a/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
@@ -7,12 +7,11 @@
           small
             = secondary_assessment.last_editor_info
   #section-appraisal-form-secondary.section-appraisal-form.section-appraisal-form-secondary.panel-collapse.collapse aria-labelledby="appraisal-form-secondary-heading"
-    .panel-body
-
+    .panel-body[data-controller="inline-flash"]
       = simple_form_for([namespace_name, secondary_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "json", controller: "form-flash" }, id: "secondary_appraisal_form"}) do |f|
+                        html: { data: { type: "json", inline_flash_target: "form" }, id: "secondary_appraisal_form"}) do |f|
 
         = hidden_field_tag :updated_section, nil, id: "secondary_updated_section_hidden_field"
         = render_section(resource, f)

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -13,7 +13,7 @@
                 = "Updated by #{message_author_name(assessment.editable)} - #{format_date(assessment.updated_at)}"
       .panel-collapse.collapse aria-labelledby="case-summary-heading-#{assessment.position}" id="section-case-summary-#{assessment.position}" class="section-case-summary-#{assessment.position}"
 
-        .panel-body
+        .panel-body[data-controller="inline-flash"]
           /.alert.alert-glyphicon.alert-info
             span.glyphicon.glyphicon-info-sign
             p.todo-placeholder
@@ -23,7 +23,7 @@
           / For Primary Assessor
           / It becomes read-only for primary assessor after submission
 
-          = simple_form_for([namespace_name, assessment], remote: true, authenticity_token: true) do |f|
+          = simple_form_for([namespace_name, assessment], remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form" } }) do |f|
             = render partial: "admin/form_answers/appraisal_form_components/application_background_section",
               locals: { f: f}
             = render_section(resource, f)

--- a/app/views/admin/form_answers/_section_company_details.html.slim
+++ b/app/views/admin/form_answers/_section_company_details.html.slim
@@ -8,17 +8,29 @@
             = "Updated by: #{resource.company_details_editable.decorate.full_name} - #{format_date(resource.company_details_updated_at)}"
 
   #section-company-details.section-company-details.panel-collapse.collapse aria-labelledby="company-details-heading"
-    .panel-body.company-details-forms
-      = render "admin/form_answers/company_details/company_name_form"
-      = render "admin/form_answers/company_details/organisation_type_form"
-      = render "admin/form_answers/company_details/address_form"
-      = render "admin/form_answers/company_details/previous_wins_form"
-      = render "admin/form_answers/company_details/sic_form"
-      = render "admin/form_answers/company_details/this_entry_relates_to_form"
-      = render "admin/form_answers/company_details/goods_services_form"
-      = render "admin/form_answers/company_details/registration_number_form"
-      = render "admin/form_answers/company_details/date_trading_form"
-      = render "admin/form_answers/company_details/website_form"
-      = render "admin/form_answers/company_details/organisation_head_form"
-      = render "admin/form_answers/company_details/parent_company_form"
+    .panel-body.company-details-forms.space-y-3
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/company_name_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/organisation_type_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/address_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/previous_wins_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/sic_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/this_entry_relates_to_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/goods_services_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/registration_number_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/date_trading_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/website_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/organisation_head_form"
+      div[data-controller="inline-flash"]
+        = render "admin/form_answers/company_details/parent_company_form"
       = render "admin/form_answers/company_details/user_accounts"

--- a/app/views/admin/form_answers/_section_critical_comments.html.slim
+++ b/app/views/admin/form_answers/_section_critical_comments.html.slim
@@ -18,7 +18,7 @@
   #section-critical-comments.section-critical-comments.panel-collapse.collapse aria-labelledby="critical-comments-heading"
     .panel-body
       .comments-container.comment-assessor
-        = form_for([namespace_name, @form_answer, @form_answer.comments.new(section: "critical")]) do |f|
+        = form_for([namespace_name, @form_answer, @form_answer.comments.new(section: "critical")], html: { data: { controller: "form-flash" } }) do |f|
           = render("admin/comments/form", f: f)
         .comment-insert
         = render(collection: @form_answer.comments.critical, partial: "admin/form_answers/comment")

--- a/app/views/admin/form_answers/_section_critical_comments.html.slim
+++ b/app/views/admin/form_answers/_section_critical_comments.html.slim
@@ -16,9 +16,9 @@
               = "Updated by #{message_author_name(last_comment.author)} - #{l(last_comment.created_at, format: :date_at_time)}"
 
   #section-critical-comments.section-critical-comments.panel-collapse.collapse aria-labelledby="critical-comments-heading"
-    .panel-body
+    .panel-body[data-controller="inline-flash"]
       .comments-container.comment-assessor
-        = form_for([namespace_name, @form_answer, @form_answer.comments.new(section: "critical")], html: { data: { controller: "form-flash" } }) do |f|
+        = form_for([namespace_name, @form_answer, @form_answer.comments.new(section: "critical")], html: { data: { inline_flash_target: "form" } }) do |f|
           = render("admin/comments/form", f: f)
         .comment-insert
         = render(collection: @form_answer.comments.critical, partial: "admin/form_answers/comment")

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -34,7 +34,7 @@
       - if @form_answer.audit_certificate.blank? && Settings.after_shortlisting_stage?
         .sidebar-section.no-margin-bottom.space-y-3
           - if @form_answer.requires_vocf?
-            #audit-certificate-form
+            #audit-certificate-form[data-controller="inline-flash"]
               - audit_certificate = @form_answer.build_audit_certificate
               = render "admin/audit_certificate/form", form_answer: @form_answer, audit_certificate: audit_certificate 
 
@@ -43,9 +43,9 @@
 
       = render(partial: "admin/figures_and_vat_returns/status", locals: { form_answer: @form_answer, figures_form: figures_form })
 
-      #vat-returns-section
+      #vat-returns-section[data-controller="inline-flash"]
         = render(partial: "admin/figures_and_vat_returns/vat_returns", locals: { form_answer: @form_answer, figures_form: figures_form })
-      #commercial-figures-section
+      #commercial-figures-section[data-controller="inline-flash"]
         = render(partial: "admin/figures_and_vat_returns/actual_figures", locals: { form_answer: @form_answer, figures_form: figures_form })
 
   / TODO Only appears for EP but for now we need to think more on it

--- a/app/views/admin/form_answers/_section_draft_notes.html.slim
+++ b/app/views/admin/form_answers/_section_draft_notes.html.slim
@@ -8,11 +8,11 @@
         - if @form_answer.draft_note.decorate.try(:last_updated_by).present?
           small= @form_answer.draft_note.decorate.try(:last_updated_by)
   #section-draft-notes.section-draft-notes.panel-collapse.collapse aria-labelledby="draft-notes-heading"
-    .panel-body
+    .panel-body[data-controller="inline-flash"]
       = simple_form_for([namespace_name, @form_answer, @form_answer.draft_note],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "json",  controller: "form-flash" } }) do |f|
+                        html: { data: { type: "json", inline_flash_target: "form" } }) do |f|
 
         .form-group[class="#{'form-edit' if f.object.content.blank?}" data-controller="element-focus"]
           .form-container

--- a/app/views/admin/form_answers/_section_draft_notes.html.slim
+++ b/app/views/admin/form_answers/_section_draft_notes.html.slim
@@ -12,7 +12,7 @@
       = simple_form_for([namespace_name, @form_answer, @form_answer.draft_note],
                         remote: true,
                         authenticity_token: true,
-                        html: { "data-type" => "json" }) do |f|
+                        html: { data: { type: "json",  controller: "form-flash" } }) do |f|
 
         .form-group[class="#{'form-edit' if f.object.content.blank?}" data-controller="element-focus"]
           .form-container

--- a/app/views/admin/form_answers/_section_palace_attendees.html.slim
+++ b/app/views/admin/form_answers/_section_palace_attendees.html.slim
@@ -14,5 +14,5 @@
         - palace_invite.prebuild_if_necessary.palace_attendees.each_with_index do |pa, index|
           = render(partial: "admin/form_answers/winners_components/palace_attendee", locals: { index: index, pa: pa, palace_invite: palace_invite })
 
-      #palace-invite-submit-form
+      #palace-invite-submit-form[data-controller="inline-flash"]
         = render "admin/form_answers/winners_components/palace_invite_submit_form", palace_invite: palace_invite

--- a/app/views/admin/form_answers/_submitted_view.html.slim
+++ b/app/views/admin/form_answers/_submitted_view.html.slim
@@ -44,7 +44,7 @@
               small
                 = @form_answer.feedback_updated_by
       #section-feedback.section-application-info.panel-collapse.collapse aria-labelledby="feedback-heading"
-        .panel-body
+        .panel-body[data-controller="inline-flash"]
           = render "admin/feedbacks/section", form_answer: @form_answer
 
   - if show_winners_section?

--- a/app/views/admin/form_answers/company_details/_address_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_address_form.html.slim
@@ -32,7 +32,7 @@
 
           = simple_form_for([namespace_name, resource],
                             remote: true,
-                            authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "address_form_admin_appraisal" }) do |f|
+                            authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "address_form_admin_appraisal" }) do |f|
 
             = hidden_field_tag :section, "address"
             .input.form-group.form-fields.form-block
@@ -145,7 +145,7 @@
       - if resource.submitted_and_after_the_deadline? && CompanyDetailPolicy.new(pundit_user, resource).can_manage_address?
         = simple_form_for([namespace_name, resource],
                           remote: true,
-                          authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "address_form_admin_appraisal" }) do |f|
+                          authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "address_form_admin_appraisal" }) do |f|
 
           = hidden_field_tag :section, "address", id: "section_address_hidden_field"
           .input.form-group.form-fields.form-block
@@ -262,7 +262,7 @@
         - if resource.submitted_and_after_the_deadline? && CompanyDetailPolicy.new(pundit_user, resource).can_manage_address?
           = simple_form_for([namespace_name, resource],
                             remote: true,
-                            authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "address_form_admin_appraisal" }) do |f|
+                            authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "address_form_admin_appraisal" }) do |f|
             = hidden_field_tag :section, "address"
             .input.form-group.form-fields.form-block
               = f.simple_fields_for(:data) do |f|

--- a/app/views/admin/form_answers/company_details/_address_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_address_form.html.slim
@@ -30,10 +30,9 @@
             - if @form_answer.nominee_region.present?
               = @form_answer.nominee_region
 
-        - if user_can_edit(@form_answer, :address)
           = simple_form_for([namespace_name, resource],
                             remote: true,
-                            authenticity_token: true, html: { "data-type" => "html", id: "address_form_admin_appraisal" }) do |f|
+                            authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "address_form_admin_appraisal" }) do |f|
 
             = hidden_field_tag :section, "address"
             .input.form-group.form-fields.form-block
@@ -146,7 +145,7 @@
       - if resource.submitted_and_after_the_deadline? && CompanyDetailPolicy.new(pundit_user, resource).can_manage_address?
         = simple_form_for([namespace_name, resource],
                           remote: true,
-                          authenticity_token: true, html: { "data-type" => "html" }) do |f|
+                          authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "address_form_admin_appraisal" }) do |f|
 
           = hidden_field_tag :section, "address", id: "section_address_hidden_field"
           .input.form-group.form-fields.form-block
@@ -263,7 +262,7 @@
         - if resource.submitted_and_after_the_deadline? && CompanyDetailPolicy.new(pundit_user, resource).can_manage_address?
           = simple_form_for([namespace_name, resource],
                             remote: true,
-                            authenticity_token: true, html: { "data-type" => "html" }) do |f|
+                            authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "address_form_admin_appraisal" }) do |f|
             = hidden_field_tag :section, "address"
             .input.form-group.form-fields.form-block
               = f.simple_fields_for(:data) do |f|

--- a/app/views/admin/form_answers/company_details/_company_name_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_company_name_form.html.slim
@@ -4,7 +4,7 @@
     = simple_form_for [namespace_name, @form_answer],
                       remote: true,
                       authenticity_token: true,
-                      html: { data: { type: "html", controller: "form-flash" }, class: "company-name-form", id: "company_name_form_admin_appraisal"} do |f|
+                      html: { data: { type: "html", inline_flash_target: "form" }, class: "company-name-form", id: "company_name_form_admin_appraisal"} do |f|
 
       = hidden_field_tag :section, "company_name", id: "section_company_name_hidden_field"
       .form-container

--- a/app/views/admin/form_answers/company_details/_company_name_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_company_name_form.html.slim
@@ -4,7 +4,7 @@
     = simple_form_for [namespace_name, @form_answer],
                       remote: true,
                       authenticity_token: true,
-                      html: { "data-type" => "html", class: "company-name-form", id: "company_name_form_admin_appraisal"} do |f|
+                      html: { data: { type: "html", controller: "form-flash" }, class: "company-name-form", id: "company_name_form_admin_appraisal"} do |f|
 
       = hidden_field_tag :section, "company_name", id: "section_company_name_hidden_field"
       .form-container

--- a/app/views/admin/form_answers/company_details/_date_trading_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_date_trading_form.html.slim
@@ -3,7 +3,7 @@
     .form-group[data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "date_trading_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "date_trading_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "date_trading", id: "section_date_trading_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_date_trading_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_date_trading_form.html.slim
@@ -3,7 +3,7 @@
     .form-group[data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { "data-type" => "html", id: "date_trading_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "date_trading_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "date_trading", id: "section_date_trading_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_goods_services_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_goods_services_form.html.slim
@@ -15,7 +15,7 @@
                   p
                     = service["desc_short"]
       - if user_can_edit(@form_answer, :goods_services)
-        = simple_form_for [namespace_name, resource], remote: true, authenticity_token: true, html: { "data-type" => "html", id: "goods_services_form_admin_appraisal" } do |f|
+        = simple_form_for [namespace_name, resource], remote: true, authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "goods_services_form_admin_appraisal" } do |f|
           = hidden_field_tag :section, "goods_services", id: "section_goods_services_hidden_field"
           .form-fields.form-block
             = f.simple_fields_for(:data) do |f|

--- a/app/views/admin/form_answers/company_details/_goods_services_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_goods_services_form.html.slim
@@ -15,7 +15,7 @@
                   p
                     = service["desc_short"]
       - if user_can_edit(@form_answer, :goods_services)
-        = simple_form_for [namespace_name, resource], remote: true, authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "goods_services_form_admin_appraisal" } do |f|
+        = simple_form_for [namespace_name, resource], remote: true, authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "goods_services_form_admin_appraisal" } do |f|
           = hidden_field_tag :section, "goods_services", id: "section_goods_services_hidden_field"
           .form-fields.form-block
             = f.simple_fields_for(:data) do |f|

--- a/app/views/admin/form_answers/company_details/_organisation_head_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_organisation_head_form.html.slim
@@ -3,7 +3,7 @@
     .form-group[data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "organisation_head_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "organisation_head_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "organisation_head", id: "section_organisation_head_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_organisation_head_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_organisation_head_form.html.slim
@@ -3,7 +3,7 @@
     .form-group[data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { "data-type" => "html", id: "organisation_head_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "organisation_head_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "organisation_head", id: "section_organisation_head_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_organisation_type_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_organisation_type_form.html.slim
@@ -5,7 +5,7 @@
     .form-group[class="#{'form-edit' if @form_answer.organisation_type.blank?}" data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "organisation_type_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "organisation_type_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "organisation_type", id: "section_organisation_type_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_organisation_type_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_organisation_type_form.html.slim
@@ -5,7 +5,7 @@
     .form-group[class="#{'form-edit' if @form_answer.organisation_type.blank?}" data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { "data-type" => "html", id: "organisation_type_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "organisation_type_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "organisation_type", id: "section_organisation_type_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_registration_number_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_registration_number_form.html.slim
@@ -4,7 +4,7 @@
       = simple_form_for [namespace_name, resource],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "html", controller: "form-flash" }, class: "registration-number-form", id: "registration_number_form_admin_appraisal" } do |f|
+                        html: { data: { type: "html", inline_flash_target: "form" }, class: "registration-number-form", id: "registration_number_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "registration_number", id: "section_registration_number_hidden_field"
         .form-container
           label.form-label Company/charity registration number

--- a/app/views/admin/form_answers/company_details/_registration_number_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_registration_number_form.html.slim
@@ -4,7 +4,7 @@
       = simple_form_for [namespace_name, resource],
                         remote: true,
                         authenticity_token: true,
-                        html: { "data-type" => "html", class: "registration-number-form", id: "registration_number_form_admin_appraisal" } do |f|
+                        html: { data: { type: "html", controller: "form-flash" }, class: "registration-number-form", id: "registration_number_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "registration_number", id: "section_registration_number_hidden_field"
         .form-container
           label.form-label Company/charity registration number

--- a/app/views/admin/form_answers/company_details/_sic_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_sic_form.html.slim
@@ -7,7 +7,7 @@
       = simple_form_for [namespace_name, @form_answer],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "html", controller: "form-flash" }, id: "sic_code_form_admin_appraisal" } do |f|
+                        html: { data: { type: "html", inline_flash_target: "form" }, id: "sic_code_form_admin_appraisal" } do |f|
 
         = hidden_field_tag :section, "sic_code", id: "section_sic_code_hidden_field"
 

--- a/app/views/admin/form_answers/company_details/_sic_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_sic_form.html.slim
@@ -7,7 +7,7 @@
       = simple_form_for [namespace_name, @form_answer],
                         remote: true,
                         authenticity_token: true,
-                        html: { "data-type" => "html", id: "sic_code_form_admin_appraisal" } do |f|
+                        html: { data: { type: "html", controller: "form-flash" }, id: "sic_code_form_admin_appraisal" } do |f|
 
         = hidden_field_tag :section, "sic_code", id: "section_sic_code_hidden_field"
 

--- a/app/views/admin/form_answers/company_details/_this_entry_relates_to_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_this_entry_relates_to_form.html.slim
@@ -5,7 +5,7 @@
     .form-group[class="#{'form-edit' if @form_answer.this_entry_relates_to.blank?}" data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { "data-type" => "html", id: "this_entry_relates_to_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "this_entry_relates_to_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "this_entry_relates_to", id: "section_this_entry_relates_to_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_this_entry_relates_to_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_this_entry_relates_to_form.html.slim
@@ -5,7 +5,7 @@
     .form-group[class="#{'form-edit' if @form_answer.this_entry_relates_to.blank?}" data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "this_entry_relates_to_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "this_entry_relates_to_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "this_entry_relates_to", id: "section_this_entry_relates_to_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_website_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_website_form.html.slim
@@ -3,7 +3,7 @@
     .form-group[class="#{'form-edit' if @form_answer.website_url.blank?}" data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "website_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" }, id: "website_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "website", id: "section_website_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/_website_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_website_form.html.slim
@@ -3,7 +3,7 @@
     .form-group[class="#{'form-edit' if @form_answer.website_url.blank?}" data-controller="element-focus"]
       = simple_form_for [namespace_name, resource],
                         remote: true,
-                        authenticity_token: true, html: { "data-type" => "html", id: "website_form_admin_appraisal" } do |f|
+                        authenticity_token: true, html: { data: { type: "html", controller: "form-flash" }, id: "website_form_admin_appraisal" } do |f|
         = hidden_field_tag :section, "website", id: "section_website_hidden_field"
 
         .form-container

--- a/app/views/admin/form_answers/company_details/parent_company/_form.html.slim
+++ b/app/views/admin/form_answers/company_details/parent_company/_form.html.slim
@@ -1,7 +1,7 @@
 .form-group.form-group-multiple[class="#{'form-edit' if @form_answer.parent_company.blank?}" data-controller="element-focus"]
   = simple_form_for [namespace_name, resource],
                     remote: true,
-                    authenticity_token: true, html: { "data-type" => "html" } do |f|
+                    authenticity_token: true, html: { data: { type: "html", controller: "form-flash" } } do |f|
     = hidden_field_tag :section, "parent_company", id: "section_parent_company_hidden_field"
 
     .form-container

--- a/app/views/admin/form_answers/company_details/parent_company/_form.html.slim
+++ b/app/views/admin/form_answers/company_details/parent_company/_form.html.slim
@@ -1,7 +1,7 @@
 .form-group.form-group-multiple[class="#{'form-edit' if @form_answer.parent_company.blank?}" data-controller="element-focus"]
   = simple_form_for [namespace_name, resource],
                     remote: true,
-                    authenticity_token: true, html: { data: { type: "html", controller: "form-flash" } } do |f|
+                    authenticity_token: true, html: { data: { type: "html", inline_flash_target: "form" } } do |f|
     = hidden_field_tag :section, "parent_company", id: "section_parent_company_hidden_field"
 
     .form-container

--- a/app/views/admin/form_answers/company_details/previous_wins/_form.html.slim
+++ b/app/views/admin/form_answers/company_details/previous_wins/_form.html.slim
@@ -1,7 +1,7 @@
 = simple_form_for [namespace_name, @form_answer],
                   remote: true,
                   authenticity_token: true,
-                  html: { "data-type" => "html", id: "previous_wins_form" } do |f|
+                  html: { data: { type: "html", controller: "form-flash" }, id: "previous_wins_form" } do |f|
 
   = hidden_field_tag :section, "previous_wins", id: "previous_wins_section_hidden_field"
   .form-container[data-controller="element-focus"]

--- a/app/views/admin/form_answers/company_details/previous_wins/_form.html.slim
+++ b/app/views/admin/form_answers/company_details/previous_wins/_form.html.slim
@@ -1,7 +1,7 @@
 = simple_form_for [namespace_name, @form_answer],
                   remote: true,
                   authenticity_token: true,
-                  html: { data: { type: "html", controller: "form-flash" }, id: "previous_wins_form" } do |f|
+                  html: { data: { type: "html", inline_flash_target: "form" }, id: "previous_wins_form" } do |f|
 
   = hidden_field_tag :section, "previous_wins", id: "previous_wins_section_hidden_field"
   .form-container[data-controller="element-focus"]

--- a/app/views/admin/form_answers/financial_summary/_list.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_list.html.slim
@@ -1,7 +1,7 @@
 - url = pundit_user.is_a?(Admin) ? update_financials_admin_form_answer_path(@form_answer) : update_financials_assessor_form_answer_path(@form_answer)
 
 .form-group[data-controller="element-focus"]
-  = form_for @form_answer, url: url, html: { data: { controller: "form-flash" }, id: "form-admin-financial-summary" } do |f|
+  = form_for @form_answer, url: url, html: { data: { controller: "inline-flash", inline_flash_target: "form" }, id: "form-admin-financial-summary" } do |f|
     .table-overflow-container
       table.table.table-striped#financial-table
         colgroup

--- a/app/views/admin/form_answers/financial_summary/_list.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_list.html.slim
@@ -1,7 +1,7 @@
 - url = pundit_user.is_a?(Admin) ? update_financials_admin_form_answer_path(@form_answer) : update_financials_assessor_form_answer_path(@form_answer)
 
 .form-group[data-controller="element-focus"]
-  = form_for @form_answer, url: url do |f|
+  = form_for @form_answer, url: url, html: { data: { controller: "form-flash" }, id: "form-admin-financial-summary" } do |f|
     .table-overflow-container
       table.table.table-striped#financial-table
         colgroup

--- a/app/views/admin/form_answers/winners_components/_palace_invite_submit_form.html.slim
+++ b/app/views/admin/form_answers/winners_components/_palace_invite_submit_form.html.slim
@@ -3,7 +3,8 @@
     = simple_form_for([:submit, namespace_name, palace_invite],
       remote: true,
       authenticity_token: true,
-      method: :post) do |f|
+      method: :post,
+      html: { data: { inline_flash_target: "form" } }) do |f|
 
       = f.submit "Submit", class: "btn btn-primary"
       .clear

--- a/app/views/admin/press_summaries/_section.html.slim
+++ b/app/views/admin/press_summaries/_section.html.slim
@@ -1,7 +1,7 @@
 - press_summary = form_answer.press_summary || form_answer.build_press_summary
 - url = press_summary.persisted? ? polymorphic_url([namespace_name, form_answer, press_summary]) : polymorphic_url([namespace_name, form_answer, :press_summaries])
 
-= simple_form_for press_summary, url: url, remote: true, authenticity_token: true, html: { data: { controller: "form-flash" } } do |f|
+= simple_form_for press_summary, url: url, remote: true, authenticity_token: true, html: { data: { controller: "inline-flash", inline_flash_target: "form" } } do |f|
   = f.input :body_update, as: :hidden, input_html: {value: true}
 
   .form-group.press-summary-body-block[data-controller="element-focus"]
@@ -29,7 +29,7 @@
       .clear
 
 - if policy(press_summary).update?
-  = simple_form_for press_summary, url: url, remote: true, authenticity_token: true, html: { data: { controller: "form-flash" } } do |f|
+  = simple_form_for press_summary, url: url, remote: true, authenticity_token: true, html: { data: { controller: "inline-flash", inline_flash_target: "form" } } do |f|
     = f.input :contact_details_update, as: :hidden, input_html: {value: true}
 
     .form-group[data-controller="element-focus"]

--- a/app/views/admin/press_summaries/_section.html.slim
+++ b/app/views/admin/press_summaries/_section.html.slim
@@ -1,7 +1,7 @@
 - press_summary = form_answer.press_summary || form_answer.build_press_summary
 - url = press_summary.persisted? ? polymorphic_url([namespace_name, form_answer, press_summary]) : polymorphic_url([namespace_name, form_answer, :press_summaries])
 
-= simple_form_for press_summary, url: url, remote: true, authenticity_token: true do |f|
+= simple_form_for press_summary, url: url, remote: true, authenticity_token: true, html: { data: { controller: "form-flash" } } do |f|
   = f.input :body_update, as: :hidden, input_html: {value: true}
 
   .form-group.press-summary-body-block[data-controller="element-focus"]
@@ -29,7 +29,7 @@
       .clear
 
 - if policy(press_summary).update?
-  = simple_form_for press_summary, url: url, remote: true, authenticity_token: true do |f|
+  = simple_form_for press_summary, url: url, remote: true, authenticity_token: true, html: { data: { controller: "form-flash" } } do |f|
     = f.input :contact_details_update, as: :hidden, input_html: {value: true}
 
     .form-group[data-controller="element-focus"]

--- a/app/views/admin/settings/_deadline_form.html.slim
+++ b/app/views/admin/settings/_deadline_form.html.slim
@@ -2,13 +2,13 @@
 - deadline = deadline.decorate if deadline.present?
 
 - if deadline.present?
-  .deadline[id="deadline-#{deadline.id}" data-controller="element-focus"]
+  .deadline[id="deadline-#{deadline.id}" data-controller="element-focus inline-flash"]
     span.date-time-text
       => deadline.message
       span.trigger-at
         = deadline.formatted_trigger_time
     .deadline-form.well
-      = simple_form_for deadline, url: admin_settings_deadline_path(deadline, year: params[:year]), remote: true, authenticity_token: true, html: { data: { controller: "form-flash" } } do |f|
+      = simple_form_for deadline, url: admin_settings_deadline_path(deadline, year: params[:year]), remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form" } } do |f|
         .control-date
           label.control-label Set date and time
         .clear

--- a/app/views/admin/settings/_deadline_form.html.slim
+++ b/app/views/admin/settings/_deadline_form.html.slim
@@ -8,7 +8,7 @@
       span.trigger-at
         = deadline.formatted_trigger_time
     .deadline-form.well
-      = simple_form_for deadline, url: admin_settings_deadline_path(deadline, year: params[:year]), remote: true, authenticity_token: true do |f|
+      = simple_form_for deadline, url: admin_settings_deadline_path(deadline, year: params[:year]), remote: true, authenticity_token: true, html: { data: { controller: "form-flash" } } do |f|
         .control-date
           label.control-label Set date and time
         .clear

--- a/app/views/admin/settings/_email_notification.html.slim
+++ b/app/views/admin/settings/_email_notification.html.slim
@@ -19,9 +19,10 @@
 
   = link_to "+ Schedule new email", "#", class: "btn btn-default btn-add-schedule if-no-js-hide", role: "button", aria: {label: "Schedule #{I18n.t("email_buttons.#{kind}")}"}, data: { element_focus_target: "reveal" }
 
-  .notification-form
-    = render "schedule_new", notification: @settings.email_notifications.build(kind: kind), kind: kind
+  div[data-controller="inline-flash"]
+    .notification-form
+      = render "schedule_new", notification: @settings.email_notifications.build(kind: kind), kind: kind
 
-  ul.notifications
-    - notifications.each do |notification|
-      = render 'notification', notification: notification.decorate
+    ul.notifications
+      - notifications.each do |notification|
+        = render "notification", notification: notification.decorate

--- a/app/views/admin/settings/_notification.html.slim
+++ b/app/views/admin/settings/_notification.html.slim
@@ -16,7 +16,7 @@ li id="notification-#{notification.id}"
           '  |
         = button_to "Delete", admin_settings_email_notification_path(notification), { onclick: "return confirm('Are you sure?')", method: :delete, remote: true }
     .notification-edit-form.well
-      = simple_form_for notification, url: admin_settings_email_notification_path(notification, year: params[:year]), remote: true, authenticity_token: true do |f|
+      = simple_form_for notification, url: admin_settings_email_notification_path(notification, year: params[:year]), remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form" } } do |f|
         .control-date
           label.control-label Edit schedule
           = f.input :trigger_at,

--- a/app/views/admin/settings/_schedule_new.html.slim
+++ b/app/views/admin/settings/_schedule_new.html.slim
@@ -3,7 +3,7 @@
 
 .well.question-group.notification-new-form
   h3 Schedule new email
-  = simple_form_for notification, url: admin_settings_email_notifications_path(year: params[:year]), remote: true, authenticity_token: true, html: { id: "new_email_notification_#{kind}" }  do |f|
+  = simple_form_for notification, url: admin_settings_email_notifications_path(year: params[:year]), remote: true, authenticity_token: true, html: { id: "new_email_notification_#{kind}", data: { inline_flash_target: "form" } }  do |f|
     = f.input :kind, as: :hidden, input_html: { id: "email_notification_kind_#{kind}" }
     .control-date
       .form-group

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for [:admin, resource], html: { class: "qae-form", data: { type: "json",  controller: "form-flash" } } do |f|
+= simple_form_for [:admin, resource], html: { class: "qae-form", data: { type: "json",  controller: "inline-flash", inline_flash_target: "form" } } do |f|
   .panel-group#user-form-panel-parent
     .panel.panel-default[data-controller="element-focus"]
       .panel-heading#user-details-heading

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for [:admin, resource], html: { class: "qae-form" } do |f|
+= simple_form_for [:admin, resource], html: { class: "qae-form", data: { type: "json",  controller: "form-flash" } } do |f|
   .panel-group#user-form-panel-parent
     .panel.panel-default[data-controller="element-focus"]
       .panel-heading#user-details-heading

--- a/app/views/assessor/form_answers/_submitted_view.html.slim
+++ b/app/views/assessor/form_answers/_submitted_view.html.slim
@@ -45,7 +45,7 @@
               small
                 = @form_answer.feedback_updated_by
       #section-feedback.section-application-info.panel-collapse.collapse aria-labelledby="feedback-heading"
-        .panel-body
+        .panel-body[data-controller="inline-flash"]
           = render "admin/feedbacks/section", form_answer: @form_answer
 
   - if show_winners_section?


### PR DESCRIPTION
## 📝 A short description of the changes
Added generic flash messages to display when remote form is submitted. Done vie Stimulus controller `inline-flash`, the message disappear after 4 seconds. The messages can be modified, but for now displaying just **_Success!_** or **_An unknown error has occurred, please try again._**

To use add `data-controller="inline-flash"` to the element where the message should be displayed and add `data-inline-flash-target="form"` to the form which will trigger AJAX request.

There is problem with `jquery_ujs` which does not work very well and it would be better to use `rails-ujs` but it's not drop-in replacement so I left it and instead I am trying to listen to `ajax:success` events and emit custom event `ajax:x:success`.

Added also flash messages to display in case JS is disabled.

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/1204861597377754/1205042285225226/f

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

