### PR TITLE
adds download csv button for non-js admin reports

### DIFF
--- a/app/controllers/admin/dashboard_reports_controller.rb
+++ b/app/controllers/admin/dashboard_reports_controller.rb
@@ -10,44 +10,56 @@ class Admin::DashboardReportsController < Admin::BaseController
   # that represents the type of the application
 
   def all_applications
-    authorize :dashboard, :reports?
-
-    @report = Reports::Dashboard::ApplicationsReport.new(kind: params[:kind])
-    render partial: "admin/dashboard/totals_#{params[:kind]}/table_body"
+    render_or_download_report nil, params[:kind], params[:format]
   end
 
   def international_trade
-    authorize :dashboard, :reports?
-
-    @report = Reports::Dashboard::ApplicationsReport.new(kind: params[:kind], award_type: :trade)
-    render partial: "admin/dashboard/totals_#{params[:kind]}/table_body"
+    render_or_download_report :trade, params[:kind], params[:format]
   end
 
   def innovation
-    authorize :dashboard, :reports?
-
-    @report = Reports::Dashboard::ApplicationsReport.new(kind: params[:kind], award_type: :innovation)
-    render partial: "admin/dashboard/totals_#{params[:kind]}/table_body"
+    render_or_download_report :innovation, params[:kind], params[:format]
   end
 
   def social_mobility
-    authorize :dashboard, :reports?
-
-    @report = Reports::Dashboard::ApplicationsReport.new(kind: params[:kind], award_type: :mobility)
-    render partial: "admin/dashboard/totals_#{params[:kind]}/table_body"
+    render_or_download_report :mobility, params[:kind], params[:format]
   end
 
   def sustainable_development
-    authorize :dashboard, :reports?
-
-    @report = Reports::Dashboard::ApplicationsReport.new(kind: params[:kind], award_type: :development)
-    render partial: "admin/dashboard/totals_#{params[:kind]}/table_body"
+    render_or_download_report :development, params[:kind], params[:format]
   end
 
   def account_registrations
     authorize :dashboard, :reports?
 
     @report = Reports::Dashboard::UsersReport.new(kind: params[:kind])
-    render partial: "admin/dashboard/totals_#{params[:kind]}/users_table_body"
+
+    respond_to do |format|
+      format.csv do
+        send_data @report.as_csv, filename: @report.csv_filename
+      end
+
+      format.html do
+        render partial: "admin/dashboard/totals_#{params[:kind]}/users_table_body"
+      end
+    end
+  end
+
+  private
+
+  def render_or_download_report award_type, kind, format
+    authorize :dashboard, :reports?
+
+    @report = Reports::Dashboard::ApplicationsReport.new(kind: kind, award_type: award_type)
+
+    respond_to do |format|
+      format.csv do
+        send_data @report.as_csv, filename: @report.csv_filename
+      end
+
+      format.html do
+        render partial: "admin/dashboard/totals_#{kind}/table_body"
+      end
+    end
   end
 end

--- a/app/models/reports/dashboard/applications_report.rb
+++ b/app/models/reports/dashboard/applications_report.rb
@@ -80,4 +80,33 @@ class Reports::Dashboard::ApplicationsReport < Reports::Dashboard::Base
       ["&nbsp;".html_safe, "&nbsp;".html_safe]
     end
   end
+
+  def as_csv
+    CSV.generate do |csv|
+      headers = ["Year"]
+      case kind
+      when "by_month"
+        columns = ["By end of April", "By end of May", "By end of June", "By end of July", "By end of August", "Totals on deadline"]
+      when "by_week"
+        columns = ["6 weeks before deadline", "5 weeks before deadline", "4 weeks before deadline", "3 weeks before deadline", "2 weeks before deadline", "1 week before deadline", "Totals on deadline"]
+      when "by_day"
+        columns = ["6 days before deadline", "5 days before deadline", "4 days before deadline", "3 days before deadline", "2 days before deadline", "1 day before deadline", "Totals on deadline"]
+      end
+      csv << (headers + columns.map{|c| [c] << nil}).flatten
+      subheaders =[""]
+      columns.each{subheaders << ["In progress", "Submitted"]}
+      csv << subheaders.flatten
+      
+      stats.each do |row|
+        content = []
+        content << row.label
+        row.content.each{|c| content << (c == "&nbsp;" ? nil : c)}
+        csv << content
+      end
+    end
+  end
+
+  def csv_filename
+    "#{award_type || "all"}_applications_report_#{kind}.csv"
+  end
 end

--- a/app/models/reports/dashboard/users_report.rb
+++ b/app/models/reports/dashboard/users_report.rb
@@ -69,4 +69,30 @@ class Reports::Dashboard::UsersReport < Reports::Dashboard::Base
       "&nbsp;".html_safe
     end
   end
+
+  def as_csv
+    CSV.generate do |csv|
+      headers = ["Year"]
+      case kind
+      when "by_month"
+        columns = ["By end of April", "By end of May", "By end of June", "By end of July", "By end of August", "Totals on deadline"]
+      when "by_week"
+        columns = ["6 weeks before deadline", "5 weeks before deadline", "4 weeks before deadline", "3 weeks before deadline", "2 weeks before deadline", "1 week before deadline", "Totals on deadline"]
+      when "by_day"
+        columns = ["6 days before deadline", "5 days before deadline", "4 days before deadline", "3 days before deadline", "2 days before deadline", "1 day before deadline", "Totals on deadline"]
+      end
+      csv << (headers + columns).flatten
+      
+      stats.each do |row|
+        content = []
+        content << row.label
+        row.content.each{|c| content << (c == "&nbsp;" ? nil : c)}
+        csv << content
+      end
+    end
+  end
+
+  def csv_filename
+    "account_registrations_#{kind}.csv"
+  end
 end

--- a/app/views/admin/dashboard/_applications_report.html.slim
+++ b/app/views/admin/dashboard/_applications_report.html.slim
@@ -1,6 +1,7 @@
 .dashboard-table__wrapper.dashboard-report
-  button.btn.btn-primary.btn--load.update-report href=url aria-label="Load #{title} data"
+  button.btn.btn-primary.btn--load.update-report.if-no-js-hide href=url aria-label="Load #{title} data"
     | Load data
+  = link_to "Download data", url, class: "btn btn-primary btn--load update-report if-js-hide", aria: { label: "Download #{title} data" }
   button.btn.btn-primary.btn--loading.updating-data.hidden aria-label="Updating #{title} data"
     | Updating data
 

--- a/app/views/admin/dashboard/totals_by_day.html.slim
+++ b/app/views/admin/dashboard/totals_by_day.html.slim
@@ -9,15 +9,25 @@
     p.dashboard__subheading
       | Running totals compared to previous years
 
-  .dashboard__section
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: all_applications_admin_dashboard_reports_path(kind: "by_day"), title: "All applications", kind: "by_day"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: all_applications_admin_dashboard_reports_path(kind: "by_day", format: :csv), title: "All applications", kind: "by_day"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: international_trade_admin_dashboard_reports_path(kind: "by_day"), title: "International trade", kind: "by_day"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: international_trade_admin_dashboard_reports_path(kind: "by_day", format: :csv), title: "International trade", kind: "by_day"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: innovation_admin_dashboard_reports_path(kind: "by_day"), title: "Innovation", kind: "by_day"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: innovation_admin_dashboard_reports_path(kind: "by_day", format: :csv), title: "Innovation", kind: "by_day"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: social_mobility_admin_dashboard_reports_path(kind: "by_day"), title: "Social mobility", kind: "by_day"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: social_mobility_admin_dashboard_reports_path(kind: "by_day", format: :csv), title: "Social mobility", kind: "by_day"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: sustainable_development_admin_dashboard_reports_path(kind: "by_day"), title: "Sustainable development", kind: "by_day"
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: sustainable_development_admin_dashboard_reports_path(kind: "by_day", format: :csv), title: "Sustainable development", kind: "by_day"
   .dashboard__section
     = render "admin/dashboard/totals_by_day/registrations"

--- a/app/views/admin/dashboard/totals_by_day/_registrations.html.slim
+++ b/app/views/admin/dashboard/totals_by_day/_registrations.html.slim
@@ -1,6 +1,8 @@
 .dashboard-table__wrapper.dashboard-report
-  button.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_day") aria-label="Load data for new account registrations table"
+  button.btn.btn-primary.btn--load.update-report.if-no-js-hide href=account_registrations_admin_dashboard_reports_path(kind: "by_day") aria-label="Load data for new account registrations table"
     | Load data
+  = link_to "Download data", account_registrations_admin_dashboard_reports_path(kind: "by_day", format: :csv),
+    class: "btn btn-primary btn--load update-report if-js-hide", aria: { label: "Download registration totals by day" }
   button.btn.btn-primary.btn--loading.updating-data.hidden
     | Updating data
 

--- a/app/views/admin/dashboard/totals_by_month.html.slim
+++ b/app/views/admin/dashboard/totals_by_month.html.slim
@@ -9,15 +9,25 @@
     p.dashboard__subheading
       | Running totals compared to previous years
 
-  .dashboard__section
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: all_applications_admin_dashboard_reports_path(kind: "by_month"), title: "All applications", kind: "by_month"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: all_applications_admin_dashboard_reports_path(kind: "by_month", format: :csv), title: "All applications", kind: "by_month"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: international_trade_admin_dashboard_reports_path(kind: "by_month"), title: "International trade", kind: "by_month"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: international_trade_admin_dashboard_reports_path(kind: "by_month", format: :csv), title: "International trade", kind: "by_month"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: innovation_admin_dashboard_reports_path(kind: "by_month"), title: "Innovation", kind: "by_month"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: innovation_admin_dashboard_reports_path(kind: "by_month", format: :csv), title: "Innovation", kind: "by_month"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: social_mobility_admin_dashboard_reports_path(kind: "by_month"), title: "Social mobility", kind: "by_month"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: social_mobility_admin_dashboard_reports_path(kind: "by_month", format: :csv), title: "Social mobility", kind: "by_month"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: sustainable_development_admin_dashboard_reports_path(kind: "by_month"), title: "Sustainable development", kind: "by_month"
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: sustainable_development_admin_dashboard_reports_path(kind: "by_month", format: :csv), title: "Sustainable development", kind: "by_month"
   .dashboard__section
     = render "admin/dashboard/totals_by_month/registrations"

--- a/app/views/admin/dashboard/totals_by_month/_registrations.html.slim
+++ b/app/views/admin/dashboard/totals_by_month/_registrations.html.slim
@@ -1,6 +1,8 @@
 .dashboard-table__wrapper.dashboard-report
   button.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_month") aria-label="Load data for new account registrations table"
     | Load data
+  = link_to "Download data", account_registrations_admin_dashboard_reports_path(kind: "by_month", format: :csv),
+    class: "btn btn-primary btn--load update-report if-js-hide", aria: { label: "Download registration totals by month" }
   button.btn.btn-primary.btn--loading.updating-data.hidden
     | Updating data
 

--- a/app/views/admin/dashboard/totals_by_week.html.slim
+++ b/app/views/admin/dashboard/totals_by_week.html.slim
@@ -9,15 +9,25 @@
     p.dashboard__subheading
       | Running totals compared to previous years
 
-  .dashboard__section
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: all_applications_admin_dashboard_reports_path(kind: "by_week"), title: "All applications", kind: "by_week"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: all_applications_admin_dashboard_reports_path(kind: "by_week", format: :csv), title: "All applications", kind: "by_week"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: international_trade_admin_dashboard_reports_path(kind: "by_week"), title: "International trade", kind: "by_week"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: international_trade_admin_dashboard_reports_path(kind: "by_week", format: :csv), title: "International trade", kind: "by_week"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: innovation_admin_dashboard_reports_path(kind: "by_week"), title: "Innovation", kind: "by_week"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: innovation_admin_dashboard_reports_path(kind: "by_week", format: :csv), title: "Innovation", kind: "by_week"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: social_mobility_admin_dashboard_reports_path(kind: "by_week"), title: "Social mobility", kind: "by_week"
-  .dashboard__section
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: social_mobility_admin_dashboard_reports_path(kind: "by_week", format: :csv), title: "Social mobility", kind: "by_week"
+  .dashboard__section.if-no-js-hide
     = render "admin/dashboard/applications_report", url: sustainable_development_admin_dashboard_reports_path(kind: "by_week"), title: "Sustainable development", kind: "by_week"
+  .dashboard__section.if-js-hide
+    = render "admin/dashboard/applications_report", url: sustainable_development_admin_dashboard_reports_path(kind: "by_week", format: :csv), title: "Sustainable development", kind: "by_week"
   .dashboard__section
     = render "admin/dashboard/totals_by_week/registrations"

--- a/app/views/admin/dashboard/totals_by_week/_registrations.html.slim
+++ b/app/views/admin/dashboard/totals_by_week/_registrations.html.slim
@@ -1,6 +1,8 @@
 .dashboard-table__wrapper.dashboard-report
-  button.btn.btn-primary.btn--load.update-report href=account_registrations_admin_dashboard_reports_path(kind: "by_week") aria-label="Load data for new account registrations table"
+  button.btn.btn-primary.btn--load.update-report.if-no-js-hide href=account_registrations_admin_dashboard_reports_path(kind: "by_week") aria-label="Load data for new account registrations table"
     | Load data
+  = link_to "Download data", account_registrations_admin_dashboard_reports_path(kind: "by_week", format: :csv),
+    class: "btn btn-primary btn--load update-report if-js-hide", aria: { label: "Download registration totals by week" }
   button.btn.btn-primary.btn--loading.updating-data.hidden
     | Updating data
 


### PR DESCRIPTION
## 📝 A short description of the changes

* Load data does not work when javascript is disabled. Therefore a button is added to download a csv file for the reports when javascript is not available.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1204861597377754/1205093698476480

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="1792" alt="Screenshot 2023-07-31 at 18 06 38" src="https://github.com/bitzesty/qae/assets/65811538/3b69f7ef-03df-4268-98d8-7cae9da67d29">
