### PR TITLE
Admin / Assessor UI tweaks

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -102,8 +102,11 @@ ready = ->
     form.find(".errors-holder").text("")
     form.closest(".form-group").removeClass("form-edit")
     formValueBox = form.closest(".form-group").find(".edit-value")
-    formValue = form.find("select :selected").text()
-    formValueBox.text(formValue)
+    selected = form.find("select :selected")
+    if (selected.val() == "")
+      formValueBox.html("<span class='p-empty'>Not assigned</span>")
+    else
+      formValueBox.text(selected.text())
   $(".section-applicant-users form").on "ajax:error", (e, data, status, xhr) ->
     form = $(this)
     errors = ""

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -439,10 +439,12 @@ showErrorForInvalidField = (field, values) ->
   if container
     values.forEach (message) ->
       if (!container.querySelector('.alert'))
-        container.insertAdjacentHTML('afterbegin', buildBannerHtml(message, 'danger'))
+        id = "alert__#{String(Math.random()).slice(2, -1)}"
+        field.setAttribute('aria-errormessage', id)
+        container.insertAdjacentHTML('afterbegin', buildBannerHtml(message, 'danger', id))
 
-buildBannerHtml = (message, type) ->
-  id = "alert__#{String(Math.random()).slice(2, -1)}"
+buildBannerHtml = (message, type, identifier = null) ->
+  id = identifier || "alert__#{String(Math.random()).slice(2, -1)}"
   
   "<div id='#{id}' class='alert alert-#{type}' data-controller='element-removal' role='alert' style='padding-top: 6px; padding-bottom: 6px; margin-bottom: 8px;'>
     #{message}
@@ -452,8 +454,11 @@ buildBannerHtml = (message, type) ->
   </div>"
 
 removeExistingErrorMessages = (element) ->
-  element.querySelectorAll('.field-with-errors').forEach (banner) ->
-    banner.classList.remove('field-with-errors')
+  element.querySelectorAll('.field-with-errors').forEach (el) ->
+    el.classList.remove('field-with-errors')
+
+  element.querySelectorAll('[aria-errormessage]').forEach (el) ->
+    el.removeAttribute('aria-errormessage')
 
   element.querySelectorAll('.alert').forEach (banner) ->
     banner.remove()

--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -341,7 +341,7 @@ ready = ->
       message = "Case summary submitted"
 
     removeExistingErrorMessages(panel)
-    container.insertAdjacentHTML('afterbegin', buildBannerHtml(message, 'success'))
+    panel.insertAdjacentHTML('afterbegin', buildBannerHtml(message, 'success'))
 
     $(this).find('input:submit').remove()
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -28,7 +28,7 @@ class Admin::UsersController < Admin::BaseController
     @resource.save
     location = @resource.persisted? ? admin_users_path : nil
 
-    render_flash_message_for(@resource)
+    render_flash_message_for(@resource, message: @resource.errors.none? ? nil : @resource.errors.full_messages.join(", "))
 
     respond_with :admin, @resource, location: location
   end
@@ -42,7 +42,7 @@ class Admin::UsersController < Admin::BaseController
       @resource.update_without_password(resource_params)
     end
 
-    render_flash_message_for(@resource)
+    render_flash_message_for(@resource, message: @resource.errors.none? ? nil : @resource.errors.full_messages.join(", "))
 
     respond_with :admin, @resource, location: admin_users_path
   end

--- a/app/controllers/assessor/base_controller.rb
+++ b/app/controllers/assessor/base_controller.rb
@@ -19,6 +19,14 @@ class Assessor::BaseController < ApplicationController
     current_assessor
   end
 
+  def render_flash_message_for(resource, message: nil)
+    if resource.errors.any?
+      flash[:error] = message || "An unknown error has occurred, please try again."
+    else
+      flash[:notice] = message || "Success!"
+    end
+  end
+
   private
 
   helper_method :namespace_name, :current_subject

--- a/app/controllers/concerns/assessment_submission_mixin.rb
+++ b/app/controllers/concerns/assessment_submission_mixin.rb
@@ -36,7 +36,7 @@ module AssessmentSubmissionMixin
 
   def json_response
     json = @service.as_json
-    resp = { json: json }
+    resp = { json: @service.errors }
     resp[:status] = :unprocessable_entity if json.present?
     resp
   end

--- a/app/controllers/concerns/assessment_submission_mixin.rb
+++ b/app/controllers/concerns/assessment_submission_mixin.rb
@@ -8,7 +8,7 @@ module AssessmentSubmissionMixin
     respond_to do |format|
       format.json { render(json_response) }
       format.html do
-        render_flash_message_for(resource, message: resource.errors.none? ? nil : resource.errors.full_messages.join(", "))
+        render_flash_message_for(resource, message: flash_message)
         redirect_to [namespace_name, resource.form_answer]
       end
     end
@@ -33,6 +33,11 @@ module AssessmentSubmissionMixin
   end
 
   private
+
+  def flash_message
+    return nil if resource.errors.none?
+    resource.errors.full_messages.join(", ")
+  end
 
   def json_response
     json = @service.as_json

--- a/app/controllers/concerns/assessment_submission_mixin.rb
+++ b/app/controllers/concerns/assessment_submission_mixin.rb
@@ -8,6 +8,7 @@ module AssessmentSubmissionMixin
     respond_to do |format|
       format.json { render(json_response) }
       format.html do
+        render_flash_message_for(resource, message: resource.errors.none? ? nil : resource.errors.full_messages.join(", "))
         redirect_to [namespace_name, resource.form_answer]
       end
     end

--- a/app/javascript/controllers/element_scroll_controller.js
+++ b/app/javascript/controllers/element_scroll_controller.js
@@ -1,0 +1,35 @@
+import { scrollToElement } from '../helpers'; // eslint-disable-line import/no-unresolved
+
+export default class extends ApplicationController {
+  static targets = ['accordion'];
+
+  connect() {
+    if (this.firstInvalidField) {
+      if (!this.visible(this.firstInvalidField)) {
+        const collapsible = this.accordionTargets.find((target) => {
+          return target.contains(this.firstInvalidField);
+        });
+        if (collapsible) $(collapsible).collapse('show');
+      }
+
+      setTimeout(() => {
+        this.firstInvalidField.focus();
+        scrollToElement(this.firstInvalidField);
+      }, 300);
+    }
+  }
+
+  // Private
+
+  visible(el) {
+    return !el.hidden && (!el.type || el.type != 'hidden') && (el.offsetWidth > 0 || el.offsetHeight > 0);
+  }
+
+  get formFields() {
+    return Array.from(this.element.elements);
+  }
+
+  get firstInvalidField() {
+    return this.formFields.find((field) => field.ariaInvalid == 'true');
+  }
+}

--- a/app/javascript/controllers/html5_form_validation_controller.js
+++ b/app/javascript/controllers/html5_form_validation_controller.js
@@ -1,0 +1,67 @@
+export default class extends ApplicationController {
+  static values = {
+    selectors: Array,
+  };
+
+  validate = (event) => {
+    let counter = 0;
+
+    this.filteredFields.forEach((field) => {
+      if (field && this.shouldValidateField(field)) {
+        field.required = true;
+
+        if (!field.checkValidity()) {
+          counter += 1;
+        }
+      }
+    });
+
+    if (counter > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    this.firstInvalidField && this.firstInvalidField.reportValidity();
+  };
+
+  discard = (event) => {
+    this.filteredFields.forEach((field) => {
+      field.removeAttribute('required');
+    });
+  };
+
+  shouldValidateField(field) {
+    return (
+      !field.disabled &&
+      field.type !== undefined &&
+      this.visible(field) &&
+      !['file', 'reset', 'submit', 'button'].includes(field.type)
+    );
+  }
+
+  visible(field) {
+    return (
+      !field.hidden && (!field.type || field.type != 'hidden') && (field.offsetWidth > 0 || field.offsetHeight > 0)
+    );
+  }
+
+  get filteredFields() {
+    return this.formFields.filter((f) => this.selectors.includes(f.tagName)).filter(this.visible);
+  }
+
+  get formFields() {
+    return Array.from(this.element.elements);
+  }
+
+  get selectors() {
+    if (this.hasSelectorsValue) {
+      return this.selectorsValue.map((selector) => selector.toUpperCase());
+    } else {
+      return [];
+    }
+  }
+
+  get firstInvalidField() {
+    return this.filteredFields.find((field) => !field.checkValidity());
+  }
+}

--- a/app/javascript/helpers/index.js
+++ b/app/javascript/helpers/index.js
@@ -1,0 +1,1 @@
+export { scrollToElement } from './scroll_helper';

--- a/app/javascript/helpers/scroll_helper.js
+++ b/app/javascript/helpers/scroll_helper.js
@@ -1,0 +1,15 @@
+import smoothscroll from 'smoothscroll-polyfill';
+
+const smoothSupported = 'scrollBehavior' in document.documentElement.style;
+
+let smoothPolyfilled;
+async function polyfillSmooth() {
+  if (smoothPolyfilled) return;
+  smoothPolyfilled = true;
+  smoothscroll.polyfill();
+}
+
+export async function scrollToElement(element, { behavior = 'smooth', block = 'start', inline = 'nearest' } = {}) {
+  if (behavior === 'smooth' && !smoothSupported) await polyfillSmooth();
+  element.scrollIntoView({ behavior, block, inline });
+}

--- a/app/services/assessment_submission_service.rb
+++ b/app/services/assessment_submission_service.rb
@@ -47,7 +47,7 @@ class AssessmentSubmissionService
     end
   end
 
-  delegate :as_json, to: :resource
+  delegate :as_json, :errors, to: :resource
 
   private
 

--- a/app/views/admin/audit_certificate/_form.html.slim
+++ b/app/views/admin/audit_certificate/_form.html.slim
@@ -8,7 +8,11 @@
     h3 Attach document
 
     - if form.object.errors.any?
-      .errors = form.object.errors.full_messages.join(", ")
+      .errors
+        .alert.alert-danger[data-controller="element-removal" role="alert"']
+          = form.object.errors.full_messages.join(", ")
+          button[type="button" class="close" data-action="click->element-removal#remove" aria-label="Close" style="font-size: 18px;"]        
+            span[aria-hidden="true"] &times;
 
     .attachment-link.if-js-hide
       = form.file_field :attachment

--- a/app/views/admin/comments/_form.html.slim
+++ b/app/views/admin/comments/_form.html.slim
@@ -2,7 +2,7 @@
   label
     ' Add a comment
   = f.hidden_field :section, id: "#{f.object.section}_section_hidden_field"
-  = f.text_area :body, id: "#{f.object.section}_comment_body", autofocus: true, class: 'form-control', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.section}-new-comment"
+  = f.text_area :body, id: "#{f.object.section}_comment_body", autofocus: true, class: 'form-control', rows: 4, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-#{f.object.section}-new-comment", required: true
   .comment-actions
     = f.check_box :flagged, id: "#{f.object.section}_flagged_hidden_checkbox"
     = link_to "#flag-comment", class: "link-flag-comment js-link-flag-comment"

--- a/app/views/admin/figures_and_vat_returns/_form.html.slim
+++ b/app/views/admin/figures_and_vat_returns/_form.html.slim
@@ -8,7 +8,11 @@
     h3 Attach document
 
     - if form.object.errors.any?
-      .errors = form.object.errors.full_messages.join(", ")
+      .errors
+        .alert.alert-danger[data-controller="element-removal" role="alert"']
+          = form.object.errors.full_messages.join(", ")
+          button[type="button" class="close" data-action="click->element-removal#remove" aria-label="Close" style="font-size: 18px;"]        
+            span[aria-hidden="true"] &times;
 
     .attachment-link.if-js-hide
       = form.file_field :attachment

--- a/app/views/admin/form_answers/_assessors_section.html.slim
+++ b/app/views/admin/form_answers/_assessors_section.html.slim
@@ -12,7 +12,7 @@
         = resource.lead_assessors
       .clear
 
-    li.form-group.primary-assessor-assignment[data-controller="element-focus inline-flash"]
+    li.form-group.primary-assessor-assignment[data-controller="element-focus"]
       label[for='assessor_assignment_primary_assessor_id']
         ' Primary:
       .form-value class=("ellipsis edit-value" if policy(resource).assign_assessor?)
@@ -25,7 +25,7 @@
       - if policy(resource).assign_assessor?
         = form_for [namespace_name, resource.assessor_assignments.primary],
                    remote: true,
-                   html: { data: { type: "json", inline_flash_target: "form" } },
+                   html: { data: { type: "json" } },
                    authenticity_token: true do |form|
 
           .form-fields
@@ -43,10 +43,9 @@
             span.if-no-js-hide
               = link_to "Cancel", "#", class: "btn btn-default form-cancel-link", data: { element_focus_target: "dismiss" }
             = form.submit "Save", class: "btn btn-primary form-save-button"
-          .errors-holder
       .clear
 
-    li.form-group.secondary-assessor-assignment[data-controller="element-focus inline-flash"]
+    li.form-group.secondary-assessor-assignment[data-controller="element-focus"]
       label[for='assessor_assignment_secondary_assessor_id']
         span.assessor-label Secondary:
       .form-value class=("ellipsis edit-value" if policy(resource).assign_assessor?)
@@ -59,7 +58,7 @@
       - if policy(resource).assign_assessor?
         = form_for [namespace_name, resource.assessor_assignments.secondary],
                    remote: true,
-                   html: { data: { type: "json", inline_flash_target: "form" } },
+                   html: { data: { type: "json" } },
                    authenticity_token: true do |form|
 
           .form-fields
@@ -77,5 +76,4 @@
             span.if-no-js-hide
               = link_to "Cancel", "#", class: "btn btn-default form-cancel-link", data: { element_focus_target: "dismiss" }
             = form.submit "Save", class: "btn btn-primary form-save-button"
-          .errors-holder
       .clear

--- a/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_moderated.html.slim
@@ -12,7 +12,7 @@
       = simple_form_for([namespace_name, moderated_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "json", inline_flash_target: "form" } }) do |f|
+                        html: { data: { type: "json", inline_flash_target: "form", controller: "html5-form-validation", html5_form_validation_selectors_value: ["textarea"] } }) do |f|
 
         = render_section(resource, f)
         = hidden_field_tag :updated_section

--- a/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_primary.html.slim
@@ -11,7 +11,7 @@
       = simple_form_for([namespace_name, primary_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "json", inline_flash_target: "form" }, id: "primary_appraisal_form" }) do |f|
+                        html: { data: { type: "json", inline_flash_target: "form", html5_form_validation_selectors_value: ["textarea"], controller: "html5-form-validation" }, id: "primary_appraisal_form" }) do |f|
 
         = hidden_field_tag :updated_section, nil, id: "primary_updated_section_hidden_field"
         = render_section(resource, f)

--- a/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
+++ b/app/views/admin/form_answers/_section_appraisal_form_secondary.html.slim
@@ -11,7 +11,7 @@
       = simple_form_for([namespace_name, secondary_assessment],
                         remote: true,
                         authenticity_token: true,
-                        html: { data: { type: "json", inline_flash_target: "form" }, id: "secondary_appraisal_form"}) do |f|
+                        html: { data: { type: "json", inline_flash_target: "form", controller: "html5-form-validation", html5_form_validation_selectors_value: ["textarea"] }, id: "secondary_appraisal_form"}) do |f|
 
         = hidden_field_tag :updated_section, nil, id: "secondary_updated_section_hidden_field"
         = render_section(resource, f)

--- a/app/views/admin/form_answers/_section_case_summary.html.slim
+++ b/app/views/admin/form_answers/_section_case_summary.html.slim
@@ -23,7 +23,7 @@
           / For Primary Assessor
           / It becomes read-only for primary assessor after submission
 
-          = simple_form_for([namespace_name, assessment], remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form" } }) do |f|
+          = simple_form_for([namespace_name, assessment], remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form", controller: "html5-form-validation", html5_form_validation_selectors_value: ["textarea"] } }) do |f|
             = render partial: "admin/form_answers/appraisal_form_components/application_background_section",
               locals: { f: f}
             = render_section(resource, f)

--- a/app/views/admin/form_answers/_section_draft_notes.html.slim
+++ b/app/views/admin/form_answers/_section_draft_notes.html.slim
@@ -26,7 +26,8 @@
                       wrapper_html: { class: "form-group" },
                       input_html: { class: "form-control", rows: 10, "data-behavior" => "autosave", "data-autosave-key" => "#{@form_answer.id}-new-content" },
                       as: :text,
-                      label: false
+                      label: false,
+                      required: true
 
             = link_to "#", class: "form-edit-link pull-right", data: { element_focus_target: "reveal" }
               span.glyphicon.glyphicon-pencil

--- a/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_application_background_section.html.slim
@@ -23,5 +23,5 @@
       = link_to "#", class: "form-edit-link pull-right", data: { element_focus_target: "reveal" }
         span.glyphicon.glyphicon-pencil
         ' Edit
-      = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide"
+      = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", data: { action: "click->html5-form-validation#validate" }
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_non_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_non_rag_section.html.slim
@@ -26,6 +26,6 @@
         span.glyphicon.glyphicon-pencil
         ' Edit
       .form-actions.text-right
-        = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide", data: { element_focus_target: "dismiss" }
-        = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", "data-updated-section" => section.desc
+        = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide", data: { element_focus_target: "dismiss", action: "click->html5-form-validation#discard" }
+        = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", data: { action: "click->html5-form-validation#validate", updated_section: section.desc }
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -46,6 +46,6 @@
         span.glyphicon.glyphicon-pencil
         ' Edit
       .form-actions.text-right
-        = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide", data: { element_focus_target: "dismiss" }
-        = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", "data-updated-section" => section.desc
+        = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide", data: { element_focus_target: "dismiss", action: "click->html5-form-validation#discard" }
+        = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", data: { action: "click->html5-form-validation#validate", updated_section: section.desc }
       .clear

--- a/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
@@ -1,7 +1,9 @@
 - if policy(assessment).can_be_submitted? || policy(assessment).can_be_re_submitted?
   = form_tag(url_for([namespace_name, :assessment_submissions]),
             authenticity_token: true,
-            class: "submit-assessment")
+            remote: true,
+            class: "submit-assessment",
+            "data-type" => "json")
 
     = hidden_field_tag :assessment_id, assessment.id, id: "#{assessment.position}_assessment_id_submit_appraisal_form_hidden_field"
 

--- a/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_submit_appraisal_form.html.slim
@@ -3,7 +3,7 @@
             authenticity_token: true,
             remote: true,
             class: "submit-assessment",
-            "data-type" => "json")
+            data: { type: "json" })
 
     = hidden_field_tag :assessment_id, assessment.id, id: "#{assessment.position}_assessment_id_submit_appraisal_form_hidden_field"
 

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -44,6 +44,6 @@
         span.glyphicon.glyphicon-pencil
         ' Edit
       .form-actions.text-right
-        = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide", data: { element_focus_target: "dismiss" }
-        = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", "data-updated-section" => section.desc
+        = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide", data: { element_focus_target: "dismiss", action: "click->html5-form-validation#discard" }
+        = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide", data: { action: "click->html5-form-validation#validate" }
       .clear

--- a/app/views/admin/settings/_deadline_form.html.slim
+++ b/app/views/admin/settings/_deadline_form.html.slim
@@ -8,18 +8,19 @@
       span.trigger-at
         = deadline.formatted_trigger_time
     .deadline-form.well
-      = simple_form_for deadline, url: admin_settings_deadline_path(deadline, year: params[:year]), remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form" } } do |f|
+      = simple_form_for deadline, url: admin_settings_deadline_path(deadline, year: params[:year]), remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form", controller: "html5-form-validation", html5_form_validation_selectors_value: ["input"] } } do |f|
         .control-date
           label.control-label Set date and time
         .clear
         .deadline-form-wrapper
           = f.input :trigger_at,
                     as: :separated_date_time,
-                    input_html: { id: '' }
+                    input_html: { id: '' },
+                    required: true
 
           .control-action
-            = link_to "Cancel", "#", class: "btn btn-default btn-cancel if-no-js-hide", role: "button", data: { element_focus_target: "dismiss" }
-            input[type="button" value="Save" class="btn btn-primary btn-submit" aria-label="Save #{I18n.t("deadline_buttons.#{kind}")}"]
+            = link_to "Cancel", "#", class: "btn btn-default btn-cancel if-no-js-hide", role: "button", data: { element_focus_target: "dismiss", action: "click->html5-form-validation#discard" }
+            input[type="button" value="Save" class="btn btn-primary btn-submit" aria-label="Save #{I18n.t("deadline_buttons.#{kind}")}" data-action="click->html5-form-validation#validate"]
         .clear
 
     = link_to "Edit", "#", class: "edit-deadline if-no-js-hide", role: "button", aria: {label: "Edit #{I18n.t("deadline_buttons.#{kind}")}"}, data: { element_focus_target: "reveal" }

--- a/app/views/admin/settings/_notification.html.slim
+++ b/app/views/admin/settings/_notification.html.slim
@@ -16,13 +16,14 @@ li id="notification-#{notification.id}"
           '  |
         = button_to "Delete", admin_settings_email_notification_path(notification), { onclick: "return confirm('Are you sure?')", method: :delete, remote: true }
     .notification-edit-form.well
-      = simple_form_for notification, url: admin_settings_email_notification_path(notification, year: params[:year]), remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form" } } do |f|
+      = simple_form_for notification, url: admin_settings_email_notification_path(notification, year: params[:year]), remote: true, authenticity_token: true, html: { data: { inline_flash_target: "form", controller: "html5-form-validation", html5_form_validation_selectors_value: ["input"] } } do |f|
         .control-date
           label.control-label Edit schedule
           = f.input :trigger_at,
                     as: :separated_date_time,
-                    input_html: { id: '' }
+                    input_html: { id: '' },
+                    required: true
         .control-action
-          = link_to "Cancel", "#", class: "btn btn-default btn-cancel if-no-js-hide"
-          = f.submit "Save", class: "btn btn-primary btn-submit"
+          = link_to "Cancel", "#", class: "btn btn-default btn-cancel if-no-js-hide", data: { action: "click->html5-form-validation#discard" }
+          = f.submit "Save", class: "btn btn-primary btn-submit", data: { action: "click->html5-form-validation#validate" }
         .clear

--- a/app/views/admin/settings/_schedule_new.html.slim
+++ b/app/views/admin/settings/_schedule_new.html.slim
@@ -3,16 +3,17 @@
 
 .well.question-group.notification-new-form
   h3 Schedule new email
-  = simple_form_for notification, url: admin_settings_email_notifications_path(year: params[:year]), remote: true, authenticity_token: true, html: { id: "new_email_notification_#{kind}", data: { inline_flash_target: "form" } }  do |f|
+  = simple_form_for notification, url: admin_settings_email_notifications_path(year: params[:year]), remote: true, authenticity_token: true, html: { id: "new_email_notification_#{kind}", data: { inline_flash_target: "form", controller: "html5-form-validation", html5_form_validation_selectors_value: ["input"] } }  do |f|
     = f.input :kind, as: :hidden, input_html: { id: "email_notification_kind_#{kind}" }
     .control-date
       .form-group
         label.control-label Send at
         = f.input :trigger_at,
                   as: :separated_date_time,
-                  input_html: { id: "" }
+                  input_html: { id: "" },
+                  required: true
 
     .control-action
-      = link_to "Cancel", "#", class: "btn btn-default btn-cancel if-no-js-hide", role: "button", data: { element_focus_target: "dismiss" }
-      = f.submit "Save", class: "btn btn-primary btn-submit"
+      = link_to "Cancel", "#", class: "btn btn-default btn-cancel if-no-js-hide", role: "button", data: { element_focus_target: "dismiss", action: "click->html5-form-validation#discard" }
+      = f.submit "Save", class: "btn btn-primary btn-submit", data: { action: "click->html5-form-validation#validate" }
     .clear

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for [:admin, resource], html: { class: "qae-form", data: { type: "json",  controller: "inline-flash", inline_flash_target: "form" } } do |f|
+= simple_form_for [:admin, resource], html: { class: "qae-form", data: { type: "json",  controller: "inline-flash element-scroll", inline_flash_target: "form" } } do |f|
   .panel-group#user-form-panel-parent
     .panel.panel-default[data-controller="element-focus"]
       .panel-heading#user-details-heading
@@ -6,7 +6,7 @@
           a data-toggle="collapse" data-parent="#user-form-panel" href="#user-details" aria-expanded="true" aria-controls="user-details" data-element-focus-target="reveal"
             = controller_name == "users" ? "Applicant" : controller_name.singularize.titleize
             '  Details
-      #user-details.section-user-details.panel-collapse.collapse.in aria-labelledby="user-details-heading"
+      #user-details.section-user-details.panel-collapse.collapse.in[aria-labelledby="user-details-heading" data-element-scroll-target="accordion"]
         .panel-body
           = render "fields_user_details", f: f
 
@@ -15,7 +15,7 @@
         h2.panel-title
           a.collapsed data-toggle="collapse" data-parent="#user-form-panel" href="#organisation-details" aria-expanded="false" aria-controls="organisation-details" data-element-focus-target="reveal"
             ' Organisation Details
-      #organisation-details.section-organisation-details.panel-collapse.collapse aria-labelledby="organisation-details-header"
+      #organisation-details.section-organisation-details.panel-collapse.collapse[aria-labelledby="organisation-details-header" data-element-scroll-target="accordion"]
         .panel-body
           = render "fields_organisation_details", f: f
 
@@ -24,7 +24,7 @@
         h2.panel-title
           a.collapsed data-toggle="collapse" data-parent="#user-form-panel" href="#contact-preferences" aria-expanded="false" aria-controls="contact-preferences" data-element-focus-target="reveal"
             ' Contact Preferences
-      #contact-preferences.section-contact-preferences.panel-collapse.collapse aria-labelledby="contact-preferences-header"
+      #contact-preferences.section-contact-preferences.panel-collapse.collapse[aria-labelledby="contact-preferences-header" data-element-scroll-target="accordion"]
         .panel-body
           = render "fields_contact_preferences", f: f
 
@@ -34,7 +34,7 @@
           h2.panel-title
             a.collapsed data-toggle="collapse" data-parent="#user-form-panel" href="#section-collaborators" aria-expanded="false" aria-controls="section-collaborators" data-element-focus-target="reveal"
               ' Collaborators
-        #section-collaborators.section-collaborators.panel-collapse.collapse aria-labelledby="section-collaborators-header"
+        #section-collaborators.section-collaborators.panel-collapse.collapse[aria-labelledby="section-collaborators-header" data-element-scroll-target="accordion"]
           .panel-body
             = render "fields_collaborators", f: f, resource: resource
 
@@ -43,7 +43,7 @@
         h2.panel-title
           a.collapsed data-toggle="collapse" data-parent="#user-form-panel" href="#section-password" aria-expanded="false" aria-controls="section-password" data-element-focus-target="reveal"
             ' Password
-      #section-password.section-password.panel-collapse.collapse aria-labelledby="section-password-header"
+      #section-password.section-password.panel-collapse.collapse[aria-labelledby="section-password-header" data-element-scroll-target="accordion"]
         .panel-body
           = render "fields_password", f: f
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "node-sass": "^7.0.0",
     "sass": "^1.35.1",
     "sass-loader": "^12.1.0",
+    "smoothscroll-polyfill": "^0.4.4",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.2.0",
     "yarn": "^1.22.19"

--- a/spec/features/assessor/appraisal_form_submission_spec.rb
+++ b/spec/features/assessor/appraisal_form_submission_spec.rb
@@ -23,11 +23,17 @@ describe "Assessor submits appraisal form", %(
 
     it "submits the form" do
       allow_any_instance_of(AssessorAssignment).to receive(:valid?).and_return(true)
+      
       find("#appraisal-form-primary-heading .panel-title a").click
+      
       take_a_nap
+      
       within "#section-appraisal-form-primary" do
         click_button "Submit appraisal"
       end
+
+      visit assessor_form_answer_path form_answer
+      
       expect(form_answer.assessor_assignments.primary).to be_submitted
     end
   end

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -108,7 +108,11 @@ def assert_description_change(section_id, header_id)
       expect(page).to have_selector("textarea", count: 1)
       find("textarea").fill_in(with: text)
     end
+
+    all(".form-cancel-link").each(&:click)
+
     within parent_selector do
+      find(".form-edit-link").click
       find(".form-save-link").click
       wait_for_ajax
     end
@@ -135,6 +139,8 @@ def assert_multiple_description_change(section_id, header_id, prefix)
 
   within section_id do
     fill_in("#{prefix}_verdict", with: text2)
+    all(".form-cancel-link").each(&:click)
+    all(".form-edit-link").last.click
     all(".form-save-link").last.click
     wait_for_ajax
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4474,6 +4474,11 @@ smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
+
 sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"


### PR DESCRIPTION
## 📝 A short description of the changes
 - added flash messages above the input fields or form sections. Some of them display for 4 seconds, some of them persist but all can be closed/dismissed
 - fields which are submitted as one form, have HTML5 validation performed (only required fields). So basically if field is being submitted which should have some input, it is now marked as required. We could mark them all as required but on non-JS that would basically force all fields to be filled at once.
 - errors which are behind closed accordion are now focused and accordion is opened (user form)
 - added `scrollToElement` helper so we can scroll to the error (or whatever element) when needed

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/1204861597377754/1205043020087839/f
Google s/sheet w/ issues here: https://docs.google.com/spreadsheets/d/1W62dDbbK5hkuJHQAz4zxWxvPphfjHHVr7btGUhDtyQU/edit#gid=1660184753

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

- <img width="664" alt="Screenshot 2023-08-01 at 12 55 40" src="https://github.com/bitzesty/qae/assets/13330910/c4b35973-272b-4024-8f9d-84b098b6d4f1">

- <img width="559" alt="Screenshot 2023-08-01 at 12 55 54" src="https://github.com/bitzesty/qae/assets/13330910/80d79450-a1bf-41c3-876b-ac1506cb655d">

- <img width="224" alt="Screenshot 2023-08-01 at 13 03 40" src="https://github.com/bitzesty/qae/assets/13330910/47d647ee-8def-49d7-9687-827cf9313914">

- <img width="309" alt="Screenshot 2023-08-01 at 13 04 17" src="https://github.com/bitzesty/qae/assets/13330910/a6b8269d-6481-4a11-99ab-54c9bab1fcdc">

- <img width="723" alt="Screenshot 2023-08-01 at 13 05 17" src="https://github.com/bitzesty/qae/assets/13330910/5e142a50-bde9-4a58-8e37-afa71f5850b2">
