### PR TITLE
Fixes account dropdown for admins and adds non-js signout button

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -14,7 +14,7 @@ a {
   }
 }
 
-.btn, button, a, [role=menuitem] {
+.btn, button, a, [role=menuitem], .button_to {
   &:focus, &:focus-within {
     background-color: $govuk-highlight-yellow !important;
     border-color: $govuk-highlight-yellow;
@@ -34,8 +34,8 @@ input[type=checkbox], select {
   }
 }
 
-.btn-primary {
-  &:focus {
+.btn-primary, .button_to {
+  &:focus, &:focus-within {
     border-bottom-color: $black !important;
     border-bottom-width: 2px !important;
     border-bottom-style: solid !important;

--- a/app/assets/stylesheets/admin/header-footer.scss
+++ b/app/assets/stylesheets/admin/header-footer.scss
@@ -240,16 +240,21 @@
       line-height: 1.42857143;
       color: #333333;
       white-space: nowrap;
+
+      @include screen-sm-max {
+        padding: 0;
+      }
     }
 
     > li > a,
     > li > span,
-    > li > .button_to {
+    > li > .button_to > input[type="submit"] {
       @include screen-sm-max {
         padding: 15px;
         padding-left: 35px;
         color: $white-true;
         text-transform: uppercase;
+        text-align: left;
       }
 
       .lte-ie8 & {
@@ -291,8 +296,6 @@
         background-color: $grey-lightest;
       }
     }
-
-
   }
 
   .open .dropdown-toggle {

--- a/app/assets/stylesheets/admin/header-footer.scss
+++ b/app/assets/stylesheets/admin/header-footer.scss
@@ -231,7 +231,8 @@
       z-index: 999999 !important;
     }
 
-    > li > span {
+    > li > span,
+    > li > .button_to {
       display: block;
       padding: 3px 20px;
       clear: both;
@@ -242,7 +243,8 @@
     }
 
     > li > a,
-    > li > span {
+    > li > span,
+    > li > .button_to {
       @include screen-sm-max {
         padding: 15px;
         padding-left: 35px;
@@ -256,7 +258,8 @@
       }
     }
 
-    > li > a {
+    > li > a,
+    > li > .button_to {
       &:hover,
       &:focus {
         @include screen-sm-max {
@@ -268,6 +271,28 @@
         }
       }
     }
+
+    .button_to {
+      display: inline;
+
+      input[type="submit"] {
+        background: none;
+        padding: 0;
+        border: none;
+        color: black;
+        text-decoration: underline;
+
+        .lte-ie7 & {
+          font-size: 16px;
+        }
+      }
+
+      &:hover {
+        background-color: $grey-lightest;
+      }
+    }
+
+
   }
 
   .open .dropdown-toggle {

--- a/app/assets/stylesheets/admin/header-footer.scss
+++ b/app/assets/stylesheets/admin/header-footer.scss
@@ -38,7 +38,6 @@
     }
   }
 
-
   .container {
     .lte-ie8 & {
       width: 90% !important;

--- a/app/assets/stylesheets/admin/header-footer.scss
+++ b/app/assets/stylesheets/admin/header-footer.scss
@@ -99,7 +99,8 @@
       }
     }
 
-    .navbar-nav > li > a {
+    .navbar-nav > li > a,
+    .navbar-nav > li > details {
       padding-top: 24px;
       padding-bottom: 23px;
       color: $white-true;
@@ -114,6 +115,11 @@
 
       @include screen-sm-max {
         padding: 20px 15px;
+      }
+
+      > .dropdown-menu {
+        display: block;
+        text-transform: none;
       }
     }
   }
@@ -151,7 +157,7 @@
       margin-right: 0;
     }
 
-    > a {
+    > a, > details {
       .lte-ie8 & {
         display: block !important;
         padding-top: 26px !important;
@@ -167,6 +173,7 @@
       &:hover,
       &:focus {
         background-color: $header-hover;
+        cursor: pointer;
 
         @include is-ios {
           background-color: transparent;
@@ -176,6 +183,23 @@
       &:focus {
         @include screen-sm-max {
           background-color: transparent;
+        }
+      }
+    }
+
+    > details {
+      padding: 0 10px;
+
+      &:focus-within {
+        background-color: $govuk-highlight-yellow !important;
+        color: $black !important;
+        outline: none !important;
+        border-bottom-color: $black !important;
+        border-bottom-width: 2px !important;
+        border-bottom-style: solid !important;
+
+        summary {
+          outline: none !important;
         }
       }
     }

--- a/app/views/layouts/application-admin.html.slim
+++ b/app/views/layouts/application-admin.html.slim
@@ -79,8 +79,25 @@ html.no-js
                     = link_to "Data Export Log", admin_audit_logs_path
 
                 ul.nav.navbar-nav.navbar-right
-                  li.dropdown
-                    a.dropdown-toggle href="#" data-toggle="dropdown" role="button" aria-expanded="false"
+                  li
+                    details.if-js-hide
+                      summary My Account
+                      ul.dropdown-menu
+                        li
+                          span
+                            strong = current_subject.decorate.full_name
+                            br
+                            small = current_subject.email
+                        li.divider
+                        - unless current_admin.authy_enabled
+                          li
+                            = link_to "Enable 2FA", admin_enable_authy_path
+                        li
+                          = link_to "Sign out",
+                              destroy_admin_session_path,
+                              method: :delete
+
+                    a.dropdown-toggle.if-no-js-hide href="#" data-toggle="dropdown" role="button" aria-expanded="false"
                       ' My account
                       span.caret
                     ul.dropdown-menu

--- a/app/views/layouts/application-admin.html.slim
+++ b/app/views/layouts/application-admin.html.slim
@@ -96,7 +96,7 @@ html.no-js
                           = button_to "Sign out",
                               destroy_admin_session_path,
                               method: :delete,
-                              class: "btn btn-link as-link"
+                              class: "btn as-link"
 
                     a.dropdown-toggle.if-no-js-hide href="#" data-toggle="dropdown" role="button" aria-expanded="false"
                       ' My account

--- a/app/views/layouts/application-admin.html.slim
+++ b/app/views/layouts/application-admin.html.slim
@@ -93,9 +93,10 @@ html.no-js
                           li
                             = link_to "Enable 2FA", admin_enable_authy_path
                         li
-                          = link_to "Sign out",
+                          = button_to "Sign out",
                               destroy_admin_session_path,
-                              method: :delete
+                              method: :delete,
+                              class: "btn btn-link as-link"
 
                     a.dropdown-toggle.if-no-js-hide href="#" data-toggle="dropdown" role="button" aria-expanded="false"
                       ' My account

--- a/app/views/layouts/application-admin.html.slim
+++ b/app/views/layouts/application-admin.html.slim
@@ -80,8 +80,10 @@ html.no-js
 
                 ul.nav.navbar-nav.navbar-right
                   li
-                    details.if-js-hide
-                      summary My Account
+                    details.if-js-hide.dropdown-toggle
+                      summary
+                        ' My Account
+                        span.caret
                       ul.dropdown-menu
                         li
                           span

--- a/app/views/layouts/application-assessor.html.slim
+++ b/app/views/layouts/application-assessor.html.slim
@@ -62,7 +62,9 @@ html.no-js
                 ul.nav.navbar-nav.navbar-right
                   li
                     details.if-js-hide
-                      summary My Account
+                      summary
+                        ' My Account
+                        span.caret
                       ul.dropdown-menu
                         li
                           span

--- a/app/views/layouts/application-assessor.html.slim
+++ b/app/views/layouts/application-assessor.html.slim
@@ -60,8 +60,23 @@ html.no-js
                       = link_to "Reports", assessor_reports_path(year: @award_year.year), role: "tab"
 
                 ul.nav.navbar-nav.navbar-right
-                  li.dropdown
-                    a.dropdown-toggle href="#" data-toggle="dropdown" role="button" aria-expanded="false"
+                  li
+                    details.if-js-hide
+                      summary My Account
+                      ul.dropdown-menu
+                        li
+                          span
+                            strong = current_subject.decorate.full_name
+                            br
+                            small = current_subject.email
+                        li.divider
+                        li
+                          = button_to "Sign out",
+                              destroy_assessor_session_path,
+                              method: :delete,
+                              class: "btn as-link"
+
+                    a.dropdown-toggle.if-no-js-hide href="#" data-toggle="dropdown" role="button" aria-expanded="false"
                       ' My account
                       span.caret
                     ul.dropdown-menu

--- a/app/views/layouts/application-judge.html.slim
+++ b/app/views/layouts/application-judge.html.slim
@@ -57,8 +57,23 @@ html.no-js
                     = link_to "Downloads", judge_case_summaries_path
 
                 ul.nav.navbar-nav.navbar-right role="navigation"
-                  li.dropdown
-                    a.dropdown-toggle href="#" data-toggle="dropdown" role="button" aria-expanded="false"
+                  li
+                    details.if-js-hide
+                      summary My Account
+                      ul.dropdown-menu
+                        li
+                          span
+                            strong = current_subject.decorate.full_name
+                            br
+                            small = current_subject.email
+                        li.divider
+                        li
+                          = button_to "Sign out",
+                              destroy_judge_session_path,
+                              method: :delete,
+                              class: "btn as-link"
+
+                    a.dropdown-toggle.if-no-js-hide href="#" data-toggle="dropdown" role="button" aria-expanded="false"
                       ' My account
                       span.caret
                     ul.dropdown-menu

--- a/app/views/layouts/application-judge.html.slim
+++ b/app/views/layouts/application-judge.html.slim
@@ -59,7 +59,9 @@ html.no-js
                 ul.nav.navbar-nav.navbar-right role="navigation"
                   li
                     details.if-js-hide
-                      summary My Account
+                      summary
+                        ' My Account
+                        span.caret
                       ul.dropdown-menu
                         li
                           span

--- a/app/views/layouts/twofactor.html.slim
+++ b/app/views/layouts/twofactor.html.slim
@@ -48,8 +48,17 @@ html.no-js
               .navbar-collapse.collapse#nav-main-collapse
 
                 ul.nav.navbar-nav.navbar-right
-                  li.dropdown
-                    a.dropdown-toggle href="#" data-toggle="dropdown" role="button" aria-expanded="false"
+                  li
+                    details.if-js-hide
+                      summary My Account
+                      ul.dropdown-menu
+                        li
+                          = button_to "Sign out",
+                              destroy_admin_session_path,
+                              method: :delete,
+                              class: "btn btn-link as-link"
+
+                    a.dropdown-toggle.if-no-js-hide href="#" data-toggle="dropdown" role="button" aria-expanded="false"
                       ' My account
                       span.caret
                     ul.dropdown-menu

--- a/app/views/layouts/twofactor.html.slim
+++ b/app/views/layouts/twofactor.html.slim
@@ -50,7 +50,9 @@ html.no-js
                 ul.nav.navbar-nav.navbar-right
                   li
                     details.if-js-hide
-                      summary My Account
+                      summary
+                        ' My Account
+                        span.caret
                       ul.dropdown-menu
                         li
                           = button_to "Sign out",


### PR DESCRIPTION
## 📝 A short description of the changes

* Admin users are unable to signout with javascript disabled. Firstly the accordion relies on javascript to toggle so the button could not be reached, and secondly method: :delete can't be used with links resulting in a route error.

For non-js `details` element has been introduced to handle the toggle of the dropdown menu. Second the logout link is replaced with a button.

The changes are also implemented for assessor and judge layouts, as well as the 2FA layout.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1204861597377754/1205070567333664

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="944" alt="Screenshot 2023-08-01 at 14 22 36" src="https://github.com/bitzesty/qae/assets/65811538/2b0fe2ad-a3ed-4ef2-a00b-b096a46c49a0">

