### PR TITLE
Move `after_action` to the concern [dev]

### DIFF
--- a/app/controllers/admin/press_summaries_controller.rb
+++ b/app/controllers/admin/press_summaries_controller.rb
@@ -1,4 +1,3 @@
 class Admin::PressSummariesController < Admin::BaseController
-  after_action :log_event, only: [:create, :update, :submit, :signoff]
   include PressSummaryMixin
 end

--- a/app/controllers/assessor/press_summaries_controller.rb
+++ b/app/controllers/assessor/press_summaries_controller.rb
@@ -1,4 +1,3 @@
 class Assessor::PressSummariesController < Assessor::BaseController
-  after_action :log_event, only: [:create, :update, :submit, :signoff]
   include PressSummaryMixin
 end

--- a/app/controllers/concerns/press_summary_mixin.rb
+++ b/app/controllers/concerns/press_summary_mixin.rb
@@ -4,6 +4,7 @@ module PressSummaryMixin
   def self.included(base)
     base.before_action :load_form_answer
     base.before_action :load_press_summary, except: :create
+    base.after_action :log_event, only: [:create, :update, :submit, :signoff]
   end
 
   def create


### PR DESCRIPTION
## 📝 A short description of the changes
Cherry-picked from #2450 

This fixes failing specs on production in which `after_action` callback seems to be executed after tables are truncated. The issue started after merging #2440 into production branch. Before tests were passing OK.

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/1200504523179345/1205134082167608/f (but not really related to the work there)

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

