### PR TITLE
Adds labels to 2FA form

### DIFF
--- a/app/views/devise/enable_authy.html.slim
+++ b/app/views/devise/enable_authy.html.slim
@@ -1,0 +1,26 @@
+.page-header
+  h1
+    = I18n.t('authy_register_title', scope: 'devise')
+
+= enable_authy_form do
+  .panel-group
+    .panel
+      .panel-body
+        .form-inputs-group
+          .form-inputs
+            .question-group
+              h2
+                label.form-label for="authy-countries"
+                  = I18n.t('devise.country')
+              .row
+                .col-lg-2.col-md-3.col-sm-4
+                  = text_field_tag :country_code, '', :autocomplete => :off, :id => "authy-countries", wrapper_html: { class: "form-group" }, input_html: { class: "form-control"}
+            .question-group
+              h2
+                label.form-label for="authy-cellphone"
+                  = I18n.t('devise.cellphone')
+              .row
+                .col-lg-2.col-md-3.col-sm-4
+                  = text_field_tag :cellphone, '', :autocomplete => :off, :id => "authy-cellphone", wrapper_html: { class: "form-group" }, input_html: { class: "form-control"}
+        .form-actions
+          = submit_tag I18n.t('enable_authy', scope: 'devise'), class: 'btn btn-primary btn-md'

--- a/app/views/layouts/twofactor.html.slim
+++ b/app/views/layouts/twofactor.html.slim
@@ -29,12 +29,14 @@ html.no-js
 
     = yield(:head) if content_for?(:head)
 
-  body#admin-layout class="admin-layout #{controller_name}-page #{action_name}-page #{controller_name}-#{action_name}-page #{yield :page_class}"
+  body#admin-layout data-autosave-token="#{current_admin.try(:autosave_token)}" class="admin-layout #{controller_name}-page #{action_name}-page #{controller_name}-#{action_name}-page #{yield :page_class} #{'layout-dev' if Rails.env.development?}"
     #site-wrapper
       #site-wrapper-margin
-        #site-header
+        a href="#main-container" class="btn btn-lg skip-main-content" onclick="document.getElementById('main-container').focus()" role="button"
+          | Skip to main content
+        #site-header.clearfix
           .navbar.clearfix role="navigation"
-            .container
+            .container.clearfix
               .navbar-header
                 button.navbar-toggle.collapsed type="button" data-toggle="collapse" data-target="#nav-main-collapse"
                   span.sr-only Toggle navigation
@@ -45,7 +47,10 @@ html.no-js
                 = link_to admin_root_path, class:'navbar-brand' do
                   = image_tag 'logo-admin.png', alt: "King's Awards for Enterprise - Admin"
 
-              .navbar-collapse.collapse#nav-main-collapse
+              .navbar-collapse.collapse#nav-main-collapse.clearfix
+                ul.nav.navbar-nav
+                  li class=('active' if controller_name == 'dashboard')
+                    = link_to "Dashboard", admin_dashboard_index_path
 
                 ul.nav.navbar-nav.navbar-right
                   li.dropdown
@@ -57,7 +62,8 @@ html.no-js
                         = link_to "Sign out",
                                   destroy_admin_session_path,
                                   method: :delete
-
+          = render "shared/dev_or_staging_banner"
+          = render "shared/non_js_banner"
 
         #main-container role="main"
           .container


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds labels to 2FA form. The app uses `devise-authy` so a new view is created to replace the default.
* Adds dashboard nav link to allow users a path back

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1204861597377754/1204956542987154

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="1792" alt="Screenshot 2023-08-02 at 11 17 56" src="https://github.com/bitzesty/qae/assets/65811538/82d70d08-1cba-4279-b4b9-7bd8eae72786">
