### PR TITLE
Upgrade bundler version ahead of buildpack upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           DISPLAY_SOCIAL_MOBILITY_AWARD: true
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/qae_test"
-          BUNDLER_VERSION: 2.4.8
+          BUNDLER_VERSION: 2.4.16
           DOCKER_TLS_CERTDIR: ""
         run: |
           sudo apt update

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -18,7 +18,7 @@ COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
 RUN bundle config set --local path 'vendor/bundle'
 RUN bundle config set --local without 'development test'
-RUN gem install bundler:2.4.8 && bundle install --jobs 4 --retry 3
+RUN gem install bundler:2.4.16 && bundle install --jobs 4 --retry 3
 
 COPY . /app
 RUN yarn install


### PR DESCRIPTION
## 📝 A short description of the changes

* Only needed to update bundler version, Ruby and Yarn versions still compatible
* https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.10.3

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205211144920199/f

## :shipit: Deployment implications

* Will need to update the specified version of buildpack used in bin/deploy to v1.10.3

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

