### PR TITLE
Reverse changes to autocomplete label

### DIFF
--- a/app/views/qae_form/_by_years_question.html.slim
+++ b/app/views/qae_form/_by_years_question.html.slim
@@ -15,7 +15,7 @@
                   = y
                   - if y == c.years
                     '  (most recent)
-            span.js-year-text.hide-if-empty.govuk-label
+                span.js-year-text.hide-if-empty
             span.govuk-error-message class="govuk-!-margin-bottom-0 govuk-!-margin-top-1"
             span class="#{'govuk-input__wrapper' if question.type == :money}"
               - if question.type == :money


### PR DESCRIPTION
## 📝 A short description of the changes

* Reverses changes to by_years_question view which is needed to autocomplete the year end label.

## 🔗 Link to the relevant story (or stories)

* None

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

