### PR TITLE
Adds aria live span for report loading announcements

### DIFF
--- a/app/assets/javascripts/admin/dashboard.js.coffee
+++ b/app/assets/javascripts/admin/dashboard.js.coffee
@@ -18,3 +18,6 @@ jQuery ->
     $("tbody", wrapper).load href, ->
       link.removeClass("hidden")
       $(".updating-data", wrapper).addClass("hidden")
+      # $(".dashboard-report .sr-only").empty()
+      srWrapper = wrapper.closest(".dashboard-report .sr-only")
+      srWrapper.text("Data updated")

--- a/app/assets/javascripts/admin/dashboard.js.coffee
+++ b/app/assets/javascripts/admin/dashboard.js.coffee
@@ -18,6 +18,8 @@ jQuery ->
     $("tbody", wrapper).load href, ->
       link.removeClass("hidden")
       $(".updating-data", wrapper).addClass("hidden")
-      # $(".dashboard-report .sr-only").empty()
-      srWrapper = wrapper.closest(".dashboard-report .sr-only")
-      srWrapper.text("Data updated")
+      if wrapper.find(".sr-only").text().length == 0
+        wrapper.find(".sr-only").text("Data loaded")
+      else
+        wrapper.find(".sr-only").empty()
+        wrapper.find(".sr-only").text("Data updated")

--- a/app/views/admin/audit_certificate/_form.html.slim
+++ b/app/views/admin/audit_certificate/_form.html.slim
@@ -11,7 +11,7 @@
       .errors
         .alert.alert-danger[data-controller="element-removal" role="alert"']
           = form.object.errors.full_messages.join(", ")
-          button[type="button" class="close" data-action="click->element-removal#remove" aria-label="Close" style="font-size: 18px;"]        
+          button[type="button" class="close" data-action="click->element-removal#remove" aria-label="Close" style="font-size: 18px;"]
             span[aria-hidden="true"] &times;
 
     .attachment-link.if-js-hide

--- a/app/views/admin/dashboard/_applications_report.html.slim
+++ b/app/views/admin/dashboard/_applications_report.html.slim
@@ -3,7 +3,10 @@
     | Load data
   = link_to "Download data", url, class: "btn btn-primary btn--load update-report if-js-hide", aria: { label: "Download #{title} data" }
   button.btn.btn-primary.btn--loading.updating-data.hidden aria-label="Updating #{title} data"
-    | Updating data
+    Updating data
+
+  .sr-only role="status" aria-live="polite"
+    span
 
   table.dashboard-table.dashboard-table--small width="1000"
     caption

--- a/app/views/admin/dashboard/_applications_report.html.slim
+++ b/app/views/admin/dashboard/_applications_report.html.slim
@@ -3,10 +3,9 @@
     | Load data
   = link_to "Download data", url, class: "btn btn-primary btn--load update-report if-js-hide", aria: { label: "Download #{title} data" }
   button.btn.btn-primary.btn--loading.updating-data.hidden aria-label="Updating #{title} data"
-    Updating data
+    | Updating data
 
-  .sr-only role="status" aria-live="polite"
-    span
+  span.sr-only role="status" aria-live="polite" aria-relevant="all"
 
   table.dashboard-table.dashboard-table--small width="1000"
     caption

--- a/app/views/admin/dashboard/totals_by_day/_registrations.html.slim
+++ b/app/views/admin/dashboard/totals_by_day/_registrations.html.slim
@@ -6,6 +6,8 @@
   button.btn.btn-primary.btn--loading.updating-data.hidden
     | Updating data
 
+  span.sr-only role="status" aria-live="polite" aria-relevant="all"
+
   table.dashboard-table.dashboard-table--small width="1000"
     caption
       | New account registrations


### PR DESCRIPTION
## 📝 A short description of the changes

* Screen readers have no way of knowing when the data is loaded for reports. This adds text to a span with aria-live: "polite" to announce when the data is loaded or updated.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1204861597377754/1205043020087836

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

