### PR TITLE
Financial summary table: fix save action

### DIFF
--- a/app/assets/javascripts/admin/financial_data.js.coffee
+++ b/app/assets/javascripts/admin/financial_data.js.coffee
@@ -6,12 +6,14 @@ jQuery ->
     overallBenchmarksTable = ($ "#overall-financial-benchmarks")
     financialTable = ($ "#financial-table")
 
-    $("input", form).on "change keyup keydown paste", ->
-      timer ||= setTimeout(saveFinancials, 500)
-
     ($ "button", form).on "click", (event) ->
       do event.preventDefault
       $(this).closest(".form-group").removeClass("form-edit")
+
+
+    ($ ".form-save-button", form).on "click", (event) ->
+      do event.preventDefault
+      saveFinancials()
 
     updateExportsGrowth = (exports) ->
       exportsGrowth = ($ 'tr.exports-growth td.value', benchmarksTable)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,6 +43,7 @@ Rails.application.configure do
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
+  config.action_mailer.default_url_options = { host: "localhost:3000" }  # Raises error for missing translations
 
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise


### PR DESCRIPTION
## 📝 A short description of the changes

* The financial summary section of the form answer in admin view saves on each keystroke, which renders the cancel and save button redundant. This pull request changes the financial summary section to only save when clicking on the save button.

## 🔗 Link to the relevant story (or stories)

asana: https://app.asana.com/0/1200504523179345/1204412218516929/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

