### PR TITLE
Fixes errors on invalid dates

### DIFF
--- a/forms/qae_form_builder/innovation_financial_year_date_question.rb
+++ b/forms/qae_form_builder/innovation_financial_year_date_question.rb
@@ -9,10 +9,16 @@ class QaeFormBuilder
       end
 
       date << Date.today.year.to_s
+      day = question.input_value(suffix: "day")
+      month = question.input_value(suffix: "month")
 
-      date = Date.parse(date.join("/")) rescue nil
+      if day.blank? || month.blank?
+        date = nil
+      else
+        date = Date.parse(date.join("/")) rescue nil
+      end
 
-      if !date && question.required?
+      if question.required? && !date
         result[question.hash_key] ||= ""
         result[question.hash_key] << "#{question.ref || question.sub_ref} is incomplete. Year-end is required. Use the format MM/YYYY"
       end

--- a/forms/qae_form_builder/question.rb
+++ b/forms/qae_form_builder/question.rb
@@ -233,9 +233,13 @@ class QaeFormBuilder
                        end
 
           if day.present? && month.present?
-            date = Date.new(2000, month.to_i, day.to_i)
-            from, to = condition.options.dig(:range)
-            date.between?(from, to)
+            date = Date.parse("#{day.to_i}/#{month.to_i}/2000") rescue nil
+            if date
+              from, to = condition.options.dig(:range)
+              date.between?(from, to)
+            else
+              false
+            end
           else
             false
           end


### PR DESCRIPTION
## 📝 A short description of the changes

* The innovation form crashes when entering an invalid date in question D1. A rescue guard is added if the answers are not in the correct format.

The validation is also working incorrectly as a blank string can be parsed to a Date. Therefore a check is added for values of day and month, otherwise an error is returned.

## 🔗 Link to the relevant story (or stories)

* Row 18 - https://docs.google.com/spreadsheets/d/1o8kr7fL0Ile-Ny0THF9lpfCGpWW12NNQSCxHwozofgI/edit#gid=0

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
