### PR TITLE
Fix for case summary downloads for admins and judges

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -30,7 +30,7 @@ class Admin::ReportsController < Admin::BaseController
                     type: "application/pdf",
                     disposition: 'attachment'
         else
-          redirect_to pdf.data
+          redirect_to pdf.data, allow_other_host: true
         end
       end
     end

--- a/app/controllers/judge/case_summaries_controller.rb
+++ b/app/controllers/judge/case_summaries_controller.rb
@@ -16,7 +16,7 @@ class Judge::CaseSummariesController < Judge::BaseController
                     type: "application/pdf",
                     disposition: 'attachment'
         else
-          redirect_to pdf.data
+          redirect_to pdf.data, allow_other_host: true
         end
       end
     end


### PR DESCRIPTION
## 📝 A short description of the changes

* Downloading case summary reports for admins and judges gives an error https://appsignal.com/bit-zesty/sites/601be1447478201f97fc2b74/exceptions/incidents/636. This adds `allow_other_host: true` to pdf redirects

## 🔗 Link to the relevant story (or stories)

* Row 7 & 8 - https://docs.google.com/spreadsheets/d/1ND1sISLYLwfWZX9DfKx5e4Vq4zIwxtB7dURhZNMZflk/edit#gid=1625100881

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

