### PR TITLE
Adds message for previous winners of trade within 5 years

### DIFF
--- a/app/assets/javascripts/frontend/custom_questions/won_international_trade_award.coffee
+++ b/app/assets/javascripts/frontend/custom_questions/won_international_trade_award.coffee
@@ -4,25 +4,36 @@ window.WonInternationalTradeAwardQuestion = init: ->
   do maybeDisplayAwardHelp = ->
     container = $("[data-container~=#{identifier}]")
 
-    conditionFulfilled = false
+    currentHolder = false
+    recentWinner = false
 
     rows = container.find("li")
 
     $.each rows, (_idx, row) ->
-      validations = $.map ["category", "year", "outcome"], (type) ->
+      validations = $.map ["category", "outcome"], (type) ->
         input = $(row).find("select[data-input-value~=#{type}]")
         input.val() == container.data("#{type}-value").toString()
       if (validations.every(Boolean))
-        conditionFulfilled = true
-        return false
+        yearInput = $(row).find("select[data-input-value~=year]")
+        if yearInput.val() == container.data("year-value").toString()
+          currentHolder = true
+          return false
+        else if yearInput.val() < container.data("year-value").toString() && yearInput.val() > (container.data("year-value")-5).toString()
+          recentWinner = true
+          return false
 
-    helpBlock = $("#help-block")
+    currentHolderHelpBlock = $(".help-block #current-holder")
+    recentWinnerHelpBlock = $(".help-block #recent-winner")
 
-    if helpBlock
-      if conditionFulfilled
-        helpBlock.show()
-      else
-        helpBlock.hide()
+    if currentHolder
+      currentHolderHelpBlock.removeClass("hide")
+      recentWinnerHelpBlock.addClass("hide")
+    else if recentWinner
+      recentWinnerHelpBlock.removeClass("hide")
+      currentHolderHelpBlock.addClass("hide")
+    else
+      currentHolderHelpBlock.addClass("hide")
+      recentWinnerHelpBlock.addClass("hide")
 
   $(document).on "change", "[data-container~=#{identifier}] select", ->
     maybeDisplayAwardHelp()

--- a/app/views/qae_form/_queen_award_applications_question.html.slim
+++ b/app/views/qae_form/_queen_award_applications_question.html.slim
@@ -136,7 +136,9 @@ a.govuk-button.govuk-button--secondary.js-button-add.if-no-js-hide href="#" aria
                          "data-entity" => "award"
 
 
-.question-block#help-block style="display: none;"
+.question-block.help-block
   .govuk-form-group
-    p class="govuk-body govuk-!-font-weight-bold"
+    p class="govuk-body govuk-!-font-weight-bold hide" id="current-holder"
       | As you currently hold a King's Award for International Trade, you cannot apply for another Award. You may apply in future years but can only use one year's financial performance from your Award winning application.
+    p class="govuk-body govuk-!-font-weight-bold hide" id="recent-winner"
+      | As you currently hold a King's Award in International Trade, you can only apply for the Outstanding Achievement Award (3 years).


### PR DESCRIPTION
## 📝 A short description of the changes

* There should be an additional message for previous winners of International Trade if they have won within the last 5 years. This builds upon the previously used data-year-value to add further checks and add a message if the year selected is within 5 years of the current year.

## 🔗 Link to the relevant story (or stories)

* #ID3 - https://docs.google.com/spreadsheets/d/1ND1sISLYLwfWZX9DfKx5e4Vq4zIwxtB7dURhZNMZflk/

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

![Screenshot 2023-08-17 at 11 16 07](https://github.com/bitzesty/qae/assets/65811538/b5e21fae-1202-4232-941a-a7b35087ca10)
