### PR TITLE
create new policy for palace invite updates

### DIFF
--- a/app/controllers/concerns/palace_attendees_mixin.rb
+++ b/app/controllers/concerns/palace_attendees_mixin.rb
@@ -3,13 +3,13 @@ module PalaceAttendeesMixin
     invite = PalaceInvite.find(params[:palace_invite_id])
     @enable_edition = true
     @form_answer = invite.form_answer
-    authorize @form_answer, :update?
+    authorize invite, :update?
     palace_attendee = invite.palace_attendees.build
     render_attendee_form(palace_attendee, invite)
   end
 
   def create
-    authorize form_answer, :update?
+    authorize palace_invite, :update?
     limit = palace_invite.attendees_limit
     if palace_invite.palace_attendees.count < limit
       palace_attendee = palace_invite.palace_attendees.create(create_params)
@@ -21,7 +21,7 @@ module PalaceAttendeesMixin
   end
 
   def update
-    authorize form_answer, :update?
+    authorize palace_invite, :update?
 
     palace_attendee = palace_invite.palace_attendees.find(params[:id])
     log_event if palace_attendee.update(create_params)
@@ -29,7 +29,7 @@ module PalaceAttendeesMixin
   end
 
   def destroy
-    authorize form_answer, :update?
+    authorize palace_invite, :update?
     palace_attendee = palace_invite.palace_attendees.find(params[:id])
     log_event if palace_attendee.destroy
     respond_to do |format|

--- a/app/controllers/concerns/palace_invites_mixin.rb
+++ b/app/controllers/concerns/palace_invites_mixin.rb
@@ -1,7 +1,7 @@
 module PalaceInvitesMixin
   def submit
     @invite = PalaceInvite.find(params[:id])
-    authorize @invite.form_answer, :update?
+    authorize @invite, :update?
 
     @invite.submit!
 

--- a/app/policies/palace_invite_policy.rb
+++ b/app/policies/palace_invite_policy.rb
@@ -1,0 +1,6 @@
+class PalaceInvitePolicy < ApplicationPolicy
+  def update?
+    admin? ||
+      subject.lead_or_assigned?(record.form_answer)
+  end
+end


### PR DESCRIPTION
## 📝 A short description of the changes

* when trying to edit and then save the palace invite I get the 'LS is already defined' error and the UI breaks

## 🔗 Link to the relevant story (or stories)

* ID 16 https://docs.google.com/spreadsheets/d/1ND1sISLYLwfWZX9DfKx5e4Vq4zIwxtB7dURhZNMZflk/edit#gid=1625100881
* https://app.asana.com/0/1200504523179345/1204412218516929/f

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

