### PR TITLE
Avoid current_year_deadline method for buckingham_palace_reception_deadline, use form answer award year settings

### DIFF
--- a/app/models/award_year.rb
+++ b/app/models/award_year.rb
@@ -256,8 +256,8 @@ class AwardYear < ApplicationRecord
       res
     end
 
-    def buckingham_palace_reception_deadline
-      current_year_deadline("buckingham_palace_attendees_invite")
+    def buckingham_palace_reception_deadline(award_year)
+      award_year.settings.deadlines.where(kind: "buckingham_palace_attendees_invite").first
     end
 
     def buckingham_palace_reception_date

--- a/app/views/palace_invites/edit.html.slim
+++ b/app/views/palace_invites/edit.html.slim
@@ -1,5 +1,5 @@
 - title "Buckingham Palace Attendee"
-
+- award_year = @invite.form_answer.award_year
 div
   header.group.page-header.page-header-wider
     div
@@ -10,7 +10,7 @@ div
       .inner
         p.govuk-body
           ' On
-          =< AwardYear.buckingham_palace_reception_deadline.decorate.formatted_trigger_date("with_year")
+          =< AwardYear.buckingham_palace_reception_deadline(award_year).decorate.formatted_trigger_date("with_year")
           ' , in the early evening at a time to be confirmed, a Royal reception at Buckingham Palace will be held for organisations who have received this year's King's Award/s. Successful organisations can send one attendee per award won.
 
         br

--- a/spec/features/users/expired_palace_invite_spec.rb
+++ b/spec/features/users/expired_palace_invite_spec.rb
@@ -23,7 +23,7 @@ describe "expired reception attendee information deadline" do
   }
 
   before do
-    AwardYear.buckingham_palace_reception_deadline.update_column(:trigger_at, Time.current.end_of_year)
+    AwardYear.buckingham_palace_reception_deadline(form_answer.award_year).update_column(:trigger_at, Time.current.end_of_year)
 
     expect(Settings).to receive(:buckingham_palace_invites_stage?)
                           .with(invite.form_answer.award_year.settings)
@@ -41,7 +41,7 @@ describe "expired reception attendee information deadline" do
   end
 
   it "allows user to fill the form within due date" do
-    award_date = AwardYear.buckingham_palace_reception_deadline.decorate.formatted_trigger_date("with_year")
+    award_date = AwardYear.buckingham_palace_reception_deadline(form_answer.award_year).decorate.formatted_trigger_date("with_year")
     deadline.update_column(:trigger_at, Time.current + 1.day)
 
     visit edit_palace_invite_path(id: invite.token)


### PR DESCRIPTION
## 📝 A short description of the changes

* buckingham_palace_reception_deadline was previously using current_year_deadline method which was populating the invite date with that of the previous year
* Using @invite.form_answer.award_year ensures only the date used by the year relevant to the user's form answer is displayed

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1204861596097564/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

