### PR TITLE
non-JS form fixes (after QA) [cherry-picked for staging]

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -36,6 +36,16 @@ window.FormValidation =
       el.append(" #{message}")
     @validates = false
 
+  extractText: (identifier) ->
+    text = $("label[for='#{identifier}'] > span > span").toArray().map((el) ->
+      $(el).text()
+    ).join(' ')
+
+    if (text.length == 0)
+      text = $("label[for='#{identifier}']").text()
+
+    text
+
   addAriaDescribedByToInput: (container, message) ->
     input = container.find('input,textarea,select').filter(':visible')
     input_id = input.attr('id')
@@ -158,7 +168,7 @@ window.FormValidation =
   addSubfieldError: (question, subquestion) ->
     questionRef = question.attr("data-question_ref")
     input = $(subquestion).find('input,textarea,select').filter(':visible')
-    label = $("label[for='#{input.attr('id')}']").text()
+    label = @extractText(input.attr('id'))
     incompleteMessage = "Question #{questionRef} is incomplete. It is required and must be filled in."
 
     if question.hasClass('date-DDMMYYYY')
@@ -347,7 +357,7 @@ window.FormValidation =
 
       if shownQuestion
         subq = $(subquestion)
-        label = $("label[for='#{subq.attr('id')}']").text()
+        label = @extractText(subq.attr('id'))
         if not subq.val() and question.hasClass("question-required")
           @logThis(question, "validateEmployeeMin", "This field is required")
           # his error is duplicated on employee question.
@@ -456,8 +466,7 @@ window.FormValidation =
 
       if shownQuestion
         inputCellsCounter += 1
-        label = $("label[for='#{subq.attr('id')}']").text()
-
+        label = @extractText(subq.attr('id'))
         if not subq.val() and question.hasClass("question-required")
           @logThis(question, "validateNumberByYears", "This field is required")
           @appendMessage(errContainer, "Question #{questionRef} is incomplete. #{label} is required and must be filled in.")
@@ -490,9 +499,10 @@ window.FormValidation =
         inputCellsCounter += 1
 
         if not subq.val() and question.hasClass("question-required")
-          @logThis(question, "validateMoneyByYears", "This field is required")
-          label = $("label[for='#{subq.attr('id')}']").text()
-          @appendMessage(errContainer, "Question #{questionRef} is incomplete. #{label} is required and must be filled in. Enter '0' if none.")
+          label = @extractText(subq.attr('id'))
+          errorMessage = "Question #{questionRef} is incomplete. #{label} is required and must be filled in. Enter '0' if none."
+          @logThis(question, "validateMoneyByYears", errorMessage)
+          @appendMessage(errContainer, errorMessage)
           @addErrorClass(question)
           continue
         else if not subq.val()

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -148,7 +148,8 @@ class FormController < ApplicationController
         end
 
         if redirected
-          redirect_to dashboard_url
+          @form_answer.save(validate: false)
+          redirect_to(dashboard_url)
         else
           if submitted && saved
             redirect_to submit_confirm_url(@form_answer)

--- a/app/views/qae_form/_by_years_label_question.html.slim
+++ b/app/views/qae_form/_by_years_label_question.html.slim
@@ -1,11 +1,9 @@
-- has_errors = question.by_year_conditions.map { |c| (1..c.years).any? { |y| @form_answer.validator_errors&.dig(question.hash_key(suffix: "#{y}of#{c.years}")).present? } }.flatten.compact_blank.present?
-
 div role="group" id="q_#{question.key}"
   .js-financial-year-changed-dates
     - for c in question.by_year_conditions
       - question_visible = question.fields_count == c.years
   
-      .js-conditional-question.by-years-wrapper class=(class_names("govuk-form-group--error" => has_errors, "show-question" => question_visible)) data=(c.question_value.respond_to?(:call) ? c.options.dig(:data).merge(question: question.step.form[c.question_key].parameterized_title) : {question: question.step.form[c.question_key].parameterized_title, value: c.question_value})
+      .js-conditional-question.by-years-wrapper class=(class_names("show-question" => question_visible)) data=(c.question_value.respond_to?(:call) ? c.options.dig(:data).merge(question: question.step.form[c.question_key].parameterized_title) : {question: question.step.form[c.question_key].parameterized_title, value: c.question_value})
         .if-js-hide
           label.govuk-label
             strong

--- a/app/views/qae_form/_by_years_question.html.slim
+++ b/app/views/qae_form/_by_years_question.html.slim
@@ -1,6 +1,4 @@
-- has_errors = question.by_year_conditions.map { |c| (1..c.years).any? { |y| @form_answer.validator_errors&.dig(question.hash_key(suffix: "#{y}of#{c.years}")).present? } }.flatten.compact_blank.present?
-
-.js-financial-conditional class=(" govuk-form-group--error" if has_errors) data-first-year-min-value=question.first_year_min_value data-first-year-min-validation-message=question.first_year_validation_message id="q_#{question.key}" role="group"
+.js-financial-conditional data-first-year-min-value=question.first_year_min_value data-first-year-min-validation-message=question.first_year_validation_message id="q_#{question.key}" role="group"
   - for c in question.by_year_conditions
     - question_visible = question.fields_count == c.years
 

--- a/app/views/qae_form/_question.html.slim
+++ b/app/views/qae_form/_question.html.slim
@@ -11,7 +11,7 @@
 - elsif question.label_as_legend?
   div class=question.fieldset_classes data=question.fieldset_data_hash data-question_ref="#{ref}"
     = condition_divs question do
-      .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && @form_answer.validator_errors[question.hash_key])
+      .govuk-form-group class=(" govuk-form-group--error" if @form_answer.validator_errors && ((question.delegate_obj.respond_to?(:by_year_conditions) && question.delegate_obj.by_year_conditions.map { |c| (1..c.years).any? { |y| @form_answer.validator_errors&.dig(question.hash_key(suffix: "#{y}of#{c.years}")).present? } }.flatten.compact_blank.present?) || @form_answer.validator_errors[question.hash_key]))
         - if question.title != "" || question.show_ref_always.present?
           legend.govuk-fieldset__legend aria-describedby=("hint_for_#{question.key}" if question.context || question.form_hint)
             - if question.ref || question.sub_ref

--- a/app/views/qae_form/_turnover_exports_calculation_question_standart_block.html.slim
+++ b/app/views/qae_form/_turnover_exports_calculation_question_standart_block.html.slim
@@ -1,6 +1,5 @@
 - for c in question.by_year_conditions
   - question_visible = question.fields_count == c.years
-  = question.fields_count
 
   .js-conditional-question.turnover-exports-calculation-wrapper class=(class_names("show-question" => question_visible)) data=(c.question_value.respond_to?(:call) ? c.options.dig(:data).merge(question: question.step.form[c.question_key].parameterized_title) : {question: question.step.form[c.question_key].parameterized_title, value: c.question_value})
     .row


### PR DESCRIPTION
## 📝 A short description of the changes
Related to #2503 - fixes after QA and cherry-picked from #2512

- JS validation errors if extracted from multiple HTML elements, have the space fixed
- for non-JS fix to have *Save and come back later* work properly. Now it saves the form regardless of errors.

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/0/1205212499617362/f
Google s/sheet here: https://docs.google.com/spreadsheets/d/1o8kr7fL0Ile-Ny0THF9lpfCGpWW12NNQSCxHwozofgI/edit#gid=0
IDs 8, 10, 11, 19, 20, ~21~, 23

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

