### PR TITLE
Use bool for disabled attr

### DIFF
--- a/app/views/qae_form/_matrix_question.html.slim
+++ b/app/views/qae_form/_matrix_question.html.slim
@@ -28,7 +28,7 @@ table.matrix-question-table.govuk-table class="#{'auto-totals-column' if questio
                 = "#{y_heading.label} numbers for #{x_heading.label}"
               input.js-trigger-autosave.matrix-question-input.govuk-input [
                 type="number"
-                disabled=(disabled_row_input || disabled_col_input)
+                disabled=disabled_input.present?
                 data-required-row-parent=question.required_row_parent
                 min="0"
                 step="1"


### PR DESCRIPTION
## 📝 A short description of the changes

* Uses a boolean instead of string for the disabled attribute on cells

## 🔗 Link to the relevant story (or stories)

* https://appsignal.com/bit-zesty/sites/601be1447478201f97fc2b74/exceptions/incidents/427

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

