### PR TITLE
FIX: PDF auto calculated fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,7 +520,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -579,7 +579,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -28,6 +28,15 @@ body.js-enabled {
   margin: 0 !important;
 }
 
+.govuk-form-group {
+  input[readonly],
+  textarea[readonly] {
+    background-color: rgba(0, 0, 0, 0.03);
+    color: rgb(84, 84, 84);
+    cursor: not-allowed;
+  }
+}
+
 .pagination {
   @supports (flex-wrap: wrap) {
     margin-bottom: 3rem;

--- a/app/views/qae_form/_matrix_question.html.slim
+++ b/app/views/qae_form/_matrix_question.html.slim
@@ -28,7 +28,7 @@ table.matrix-question-table.govuk-table class="#{'auto-totals-column' if questio
                 = "#{y_heading.label} numbers for #{x_heading.label}"
               input.js-trigger-autosave.matrix-question-input.govuk-input [
                 type="number"
-                disabled=disabled_input.present?
+                readonly=disabled_input.present?
                 data-required-row-parent=question.required_row_parent
                 min="0"
                 step="1"


### PR DESCRIPTION
## 📝 A short description of the changes
If field is disabled, its value is not persisted, so the solution is to use readonly. The issue that could raise is that field can be now focused (we can disable pointer events, but that would not prevent field to be accessible by keyboard) but cannot be interacted.

## 🔗 Link to the relevant story (or stories)
Issue described here: https://docs.google.com/spreadsheets/d/1ND1sISLYLwfWZX9DfKx5e4Vq4zIwxtB7dURhZNMZflk/edit#gid=1625100881&range=F14

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

