### PR TITLE
Use noon and midnight for deadline time if 12

### DIFF
--- a/app/mailers/account_mailers/reminder_to_submit_mailer.rb
+++ b/app/mailers/account_mailers/reminder_to_submit_mailer.rb
@@ -4,7 +4,9 @@ class AccountMailers::ReminderToSubmitMailer < AccountMailers::BaseMailer
     @user = @form_answer.user
 
     submission_deadline = Settings.current_submission_deadline
-    @deadline = submission_deadline.strftime("%l%P on %A %d %B %Y")
+    deadline_time = formatted_deadline_time(submission_deadline)
+    deadline_date = submission_deadline.trigger_at.strftime("%A %d %B %Y")
+    @deadline = "#{deadline_time} on #{deadline_date}"
 
     ordinal = submission_deadline.trigger_at.day.ordinal
     subject_deadline = submission_deadline.strftime("%e#{ordinal} %B")

--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -92,7 +92,8 @@ class MailRenderer
 
     assigns[:user] = dummy_user("Jon", "Doe", "Jane's Company")
     assigns[:form_answer] = form_answer
-    assigns[:deadline] = deadline_str("submission_end", "%I%P on %A %d %B %Y")
+    deadline_time = deadline_time("submission_end")
+    assigns[:deadline] = deadline_str("submission_end", "#{deadline_time} on %A %d %B %Y")
 
     render(assigns, "account_mailers/reminder_to_submit_mailer/preview/notify")
   end


### PR DESCRIPTION
## 📝 A short description of the changes

* Uses deadline time method to convert 12 pm/am to noon/midnight

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205351937187211/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
![Screenshot 2023-08-25 at 10 42 08](https://github.com/bitzesty/qae/assets/65811538/0ca65577-0a28-46ba-b55b-1723f6487424)

