### PR TITLE
Format deadline time to use midnight and noon

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -164,7 +164,7 @@ class Settings < ApplicationRecord
     end
 
     def submission_deadline_title
-      formatted_datetime = current_submission_deadline.strftime("%d %b %Y at %H:%M%P")
+      formatted_datetime = current_submission_deadline.decorate.formatted_trigger_time(false)
       "Submission deadline: #{formatted_datetime}"
     end
 

--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -121,8 +121,8 @@ module QaePdfForms::General::DrawElements
     render_text("The application process:", size: 14, style: :bold)
 
     bullet = "\u2000\u2000\u2000\u2022"
-    deadline = Settings.current_submission_deadline.trigger_at
-    deadline = deadline.try(:strftime, "%d %b %Y at %H:%M%P") || "-"
+    deadline = Settings.current_submission_deadline
+    deadline = deadline.decorate.formatted_trigger_time
 
     block_1 = %(1. Complete the online eligibility questionnaire before you start preparing the answers
       #{bullet} This is to ensure that your organisation meets the key eligibility criteria for an award.


### PR DESCRIPTION
## 📝 A short description of the changes

* Use trigger time decorator to display mindnight and noon for deadline on PDF

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1205364676770322/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

![Screenshot 2023-08-29 at 16 26 34](https://github.com/bitzesty/qae/assets/65811538/33242c86-0e2a-4ce3-8e78-b870432f80e9)
![Screenshot 2023-08-29 at 16 26 43](https://github.com/bitzesty/qae/assets/65811538/c8c23dbe-cef0-4107-a6b4-639cd06d457a)
