### PR TITLE
Accessible autocomplete initialization

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -1150,7 +1150,6 @@ jQuery ->
           if li_size + 1 >= add_limit_attr
             question.find(".js-button-add").addClass("visuallyhidden")
 
-
         if can_add
           add_eg = add_eg.replace(/((\w+|_)\[(\w+|_)\]\[)(\d+)\]/g, "$1#{li_size}]")
           add_eg = add_eg.replace(/((\w+|_)\[(\w+|_)\]\[)(\{index\})\]/g, "$1#{li_size}]")
@@ -1181,6 +1180,9 @@ jQuery ->
           if (textareas = question.find(".list-add > li:last .js-char-count")).length
             textareas.removeCharcountElements()
             textareas.charcount()
+
+          if (selectFields = question.find(".list-add > li:last .custom-select")).length
+            selectFields.siblings().remove()
 
           # remove the default reached class to allow removing again
           questionAddDefaultReached(question.find(".list-add"))

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -1184,6 +1184,17 @@ jQuery ->
           if (selectFields = question.find(".list-add > li:last .custom-select")).length
             selectFields.siblings().remove()
 
+            selectFields.each ->
+              field = $(this)[0]
+              if $(this).is(':disabled') or $(this).is('[readonly]')
+                return
+
+              accessibleAutocomplete.enhanceSelectElement
+                selectElement: field
+                showAllValues: true
+                dropdownArrow: ->
+                  '<span class=\'autocomplete__arrow\'></span>'
+
           # remove the default reached class to allow removing again
           questionAddDefaultReached(question.find(".list-add"))
           window.FormValidation.validateStep()

--- a/app/assets/javascripts/frontend/custom_selects.js
+++ b/app/assets/javascripts/frontend/custom_selects.js
@@ -1,17 +1,43 @@
-$(document).ready(function() {
-  $(".custom-select").each(function() {
+$(document).ready(function () {
+  $('.custom-select').each(function () {
     var field = $(this)[0];
 
-    if ($(this).is(":disabled") || $(this).is("[readonly]")) {
+    if ($(this).is(':disabled') || $(this).is('[readonly]')) {
       return;
     }
 
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: field,
-      showAllValues: true, 
-      dropdownArrow: function() {
+      showAllValues: true,
+      dropdownArrow: () => {
         return "<span class='autocomplete__arrow'></span>";
-      }
-    })
+      },
+    });
+  });
+
+  const observer = new MutationObserver((mutations) => {
+    return mutations.forEach((mutation) => {
+      return mutation.addedNodes.forEach((node) => {
+        if (node instanceof HTMLElement) {
+          const elements = node.querySelectorAll('select.custom-select');
+          if (elements.length > 0) {
+            Array.from(elements).forEach((element) => {
+              accessibleAutocomplete.enhanceSelectElement({
+                selectElement: element,
+                showAllValues: true,
+                dropdownArrow: () => {
+                  return "<span class='autocomplete__arrow'></span>";
+                },
+              });
+            });
+          }
+        }
+      });
+    });
+  });
+
+  observer.observe(document.body, {
+    subtree: true,
+    childList: true,
   });
 });

--- a/app/assets/javascripts/frontend/custom_selects.js
+++ b/app/assets/javascripts/frontend/custom_selects.js
@@ -14,30 +14,4 @@ $(document).ready(function () {
       },
     });
   });
-
-  const observer = new MutationObserver((mutations) => {
-    return mutations.forEach((mutation) => {
-      return mutation.addedNodes.forEach((node) => {
-        if (node instanceof HTMLElement) {
-          const elements = node.querySelectorAll('select.custom-select');
-          if (elements.length > 0) {
-            Array.from(elements).forEach((element) => {
-              accessibleAutocomplete.enhanceSelectElement({
-                selectElement: element,
-                showAllValues: true,
-                dropdownArrow: () => {
-                  return "<span class='autocomplete__arrow'></span>";
-                },
-              });
-            });
-          }
-        }
-      });
-    });
-  });
-
-  observer.observe(document.body, {
-    subtree: true,
-    childList: true,
-  });
 });


### PR DESCRIPTION
## 📝 A short description of the changes
If the field is added dynamically, autocomplete is not initialized properly. Instead the HTML is just copied so it looks like autocomplete but without proper functionality. Initialization then only duplicates the field. So as a solution we just check for any `.custom-select` select tag, remove already copied autocomplete HTML and re-initialize.

## 🔗 Link to the relevant story (or stories)
-

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

