### PR TITLE
Dynamic fields validation fixes

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -167,33 +167,34 @@ window.FormValidation =
   addSubfieldError: (question, subquestion) ->
     questionRef = question.attr("data-question_ref")
     input = $(subquestion).find('input,textarea,select').filter(':visible')
-    label = @extractText(input.attr('id'))
-    incompleteMessage = "Question #{questionRef} is incomplete. It is required and must be filled in."
+    if input.length
+      label = @extractText(input.attr('id'))
+      incompleteMessage = "Question #{questionRef} is incomplete. It is required and must be filled in."
 
-    if question.hasClass('date-DDMMYYYY')
-      errorMessage = "#{incompleteMessage} Use the format DD/MM/YYYY."
-      @logThis(question, "validateRequiredSubQuestion", errorMessage)
-      @addErrorMessage($(subquestion), errorMessage)
-    else if question.hasClass('date-MMYYYY')
-      errorMessage = "#{incompleteMessage} Use the format MM/YYYY."
-      @logThis(question, "validateRequiredSubQuestion", errorMessage)
-      @addErrorMessage($(subquestion), errorMessage)
-    else if question.hasClass('date-YYYY')
-      errorMessage = "#{incompleteMessage} Use the format YYYY."
-      @logThis(question, "validateRequiredSubQuestion", errorMessage)
-      @addErrorMessage($(subquestion), errorMessage)
-    else if input.hasClass("autocomplete__input")
-      errorMessage = "Question #{questionRef} is incomplete. #{label} is required and an option must be selected from the following dropdown list."
-      @logThis(question, "validateRequiredSubQuestion", errorMessage)
-      @addErrorMessage($(subquestion), errorMessage)
-    else
-      if question.find(".js-financial-year-latest").length
-        #avoid duplicate errors for financial year questions
-        return
-      else
-        errorMessage = "Question #{questionRef} is incomplete. #{label} is required and must be filled in."
+      if question.hasClass('date-DDMMYYYY')
+        errorMessage = "#{incompleteMessage} Use the format DD/MM/YYYY."
         @logThis(question, "validateRequiredSubQuestion", errorMessage)
         @addErrorMessage($(subquestion), errorMessage)
+      else if question.hasClass('date-MMYYYY')
+        errorMessage = "#{incompleteMessage} Use the format MM/YYYY."
+        @logThis(question, "validateRequiredSubQuestion", errorMessage)
+        @addErrorMessage($(subquestion), errorMessage)
+      else if question.hasClass('date-YYYY')
+        errorMessage = "#{incompleteMessage} Use the format YYYY."
+        @logThis(question, "validateRequiredSubQuestion", errorMessage)
+        @addErrorMessage($(subquestion), errorMessage)
+      else if input.hasClass("autocomplete__input")
+        errorMessage = "Question #{questionRef} is incomplete. #{label} is required and an option must be selected from the following dropdown list."
+        @logThis(question, "validateRequiredSubQuestion", errorMessage)
+        @addErrorMessage($(subquestion), errorMessage)
+      else
+        if question.find(".js-financial-year-latest").length
+          #avoid duplicate errors for financial year questions
+          return
+        else
+          errorMessage = "Question #{questionRef} is incomplete. #{label} is required and must be filled in."
+          @logThis(question, "validateRequiredSubQuestion", errorMessage)
+          @addErrorMessage($(subquestion), errorMessage)
 
   addQuestionError: (question) ->
     questionRef = question.attr("data-question_ref")

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -16,6 +16,7 @@ window.FormValidation =
       container.closest("td").find(".govuk-error-message").empty()
     else
       container.closest(".question-block").find(".govuk-error-message").empty()
+    container.closest(".question-block").removeClass("govuk-form-group--error")
     container.closest(".govuk-form-group--error").removeClass("govuk-form-group--error")
 
   clearAriaDescribedby: (container) ->


### PR DESCRIPTION
## 📝 A short description of the changes
- fixed clearing of parent block when error is resolved for sub-question (red stripe was persisting despite all errors being cleared)
- fixed validation when all errors are cleared (somehow we were trying to validate non-input fields)

## 🔗 Link to the relevant story (or stories)
Asana card here: https://app.asana.com/0/1200504523179343/1205386169866005/f

## :shipit: Deployment implications
None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

