### PR TITLE
Remove questions that dont count from filled total

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -516,7 +516,7 @@ class FormAnswer < ApplicationRecord
 
     progress_hash = HashWithIndifferentAccess.new(document || {}).except(*questions_that_dont_count)
     form = award_form.decorate(answers: progress_hash)
-    self.fill_progress = form.required_visible_questions_filled.to_f / (form.required_visible_questions_total - questions_that_dont_count.count)
+    self.fill_progress = (form.required_visible_questions_filled - questions_that_dont_count.count).to_f / (form.required_visible_questions_total - questions_that_dont_count.count)
 
     unless new_record?
       progress = (form_answer_progress || build_form_answer_progress)


### PR DESCRIPTION
## 📝 A short description of the changes

* Applications are showing as fill progress of 1.01388888 because the total number of required filled in questions is greater than the total required. This is due to `company_name` not counting as part of the total (when opening a new application the company name can be automatically filled if the application has not yet been started). This fix also deducts questions that don't count from the filled in total

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205415026149315/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
