### PR TITLE
Fix for progress calculation

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -516,7 +516,7 @@ class FormAnswer < ApplicationRecord
 
     progress_hash = HashWithIndifferentAccess.new(document || {}).except(*questions_that_dont_count)
     form = award_form.decorate(answers: progress_hash)
-    self.fill_progress = form.required_visible_questions_filled.to_f / (form.required_visible_questions_total - questions_that_dont_count.count)
+    self.fill_progress = (form.required_visible_questions_filled - questions_that_dont_count.count).to_f / (form.required_visible_questions_total - questions_that_dont_count.count)
 
     unless new_record?
       progress = (form_answer_progress || build_form_answer_progress)

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -514,11 +514,15 @@ class FormAnswer < ApplicationRecord
       end
     end
 
+    ## questions that don't count are excluded to show 0% progress for applications not started
     progress_hash = HashWithIndifferentAccess.new(document || {}).except(*questions_that_dont_count)
     form = award_form.decorate(answers: progress_hash)
-    self.fill_progress = (form.required_visible_questions_filled - questions_that_dont_count.count).to_f / (form.required_visible_questions_total - questions_that_dont_count.count)
+    self.fill_progress = form.required_visible_questions_filled.to_f / (form.required_visible_questions_total - questions_that_dont_count.count)
 
     unless new_record?
+      ## section progress should include questions that don't count
+      progress_hash = HashWithIndifferentAccess.new(document || {})
+      form = award_form.decorate(answers: progress_hash)
       progress = (form_answer_progress || build_form_answer_progress)
       progress.assign_sections(form)
       progress.save

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -507,11 +507,7 @@ class FormAnswer < ApplicationRecord
     if award_type == "promotion"
       questions_that_dont_count = []
     else
-      questions_that_dont_count = if award_year.year <= 2019
-        [:company_name]
-      else
-        [:company_name, :queen_award_holder]
-      end
+      questions_that_dont_count = [:company_name]
     end
 
     ## questions that don't count are excluded to show 0% progress for applications not started

--- a/app/views/qae_form/_address_question.html.slim
+++ b/app/views/qae_form/_address_question.html.slim
@@ -85,7 +85,7 @@ div role="group" id="q_#{question.key}"
         .clear
 
         - klass = "#{sub_field_title.parameterize == 'postcode' ? 'govuk-input--width-10' : 'govuk-input--width-20'}"
-        - klass <<(QaeFormBuilder::AddressQuestionValidator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
+        - klass <<(QaeFormBuilder::AddressQuestionDecorator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
         input.govuk-input.js-trigger-autosave[
           class=klass
           type="text"

--- a/app/views/qae_form/_sub_fields_question.html.slim
+++ b/app/views/qae_form/_sub_fields_question.html.slim
@@ -26,7 +26,7 @@ div role="group" id="#{question.key}"
       - else
         - klass = 'govuk-input--width-10'
 
-      - klass <<(QaeFormBuilder::SubFieldsQuestionValidator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
+      - klass <<(QaeFormBuilder::SubFieldsQuestionDecorator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
 
       input.govuk-input.js-trigger-autosave[
         class=klass

--- a/forms/qae_form_builder/address_question.rb
+++ b/forms/qae_form_builder/address_question.rb
@@ -1,14 +1,16 @@
 class QaeFormBuilder
   class AddressQuestionValidator < SubFieldsQuestionValidator
-    NO_VALIDATION_SUB_FIELDS = [:street, :county]
   end
 
   class AddressQuestionDecorator < SubFieldsQuestionDecorator
     include RegionHelper
+    NO_VALIDATION_SUB_FIELDS = [:street, :county]
 
     def required_sub_fields
       if sub_fields.present?
-        sub_fields
+        sub_fields.select do |f|
+          NO_VALIDATION_SUB_FIELDS.exclude?(f.keys.first)
+        end
       else
         [
           { building: "Building" },
@@ -24,7 +26,7 @@ class QaeFormBuilder
       # We are rejecting :street, because :building and :street
       # are rendering together in same block
       # and the :building is the first one
-      required_sub_fields.reject do |f|
+      sub_fields.reject do |f|
         f.keys.include?(:street)
       end.map do |f|
         [f.keys.first, f.values.first]

--- a/forms/qae_form_builder/sub_fields_question.rb
+++ b/forms/qae_form_builder/sub_fields_question.rb
@@ -1,13 +1,12 @@
 class QaeFormBuilder
   class SubFieldsQuestionValidator < QuestionValidator
-    NO_VALIDATION_SUB_FIELDS = [:honours]
     def errors
       result = super
 
       if question.required?
         question.required_sub_fields.each do |sub_field|
           suffix = sub_field.keys[0]
-          if !question.input_value(suffix: suffix).present? && NO_VALIDATION_SUB_FIELDS.exclude?(suffix)
+          if !question.input_value(suffix: suffix).present?
             result[question.hash_key(suffix: suffix)] ||= ""
             result[question.hash_key(suffix: suffix)] << "Question #{question.ref || question.sub_ref} is incomplete. #{suffix.to_s.humanize} is required and and must be filled in."
           end
@@ -22,12 +21,16 @@ class QaeFormBuilder
   end
 
   class SubFieldsQuestionDecorator < QuestionDecorator
+    NO_VALIDATION_SUB_FIELDS = [:honours]
+
     def required_sub_fields
-      sub_fields
+      sub_fields.select do |f|
+        NO_VALIDATION_SUB_FIELDS.exclude?(f.keys.first)
+      end
     end
 
     def rendering_sub_fields
-      required_sub_fields.map do |f|
+      sub_fields.map do |f|
         {key: f.keys.first, title: f.values.first, hint: f.try(:[], :hint)}
       end
     end


### PR DESCRIPTION
## 📝 A short description of the changes

* Includes all questions in step progress calculations. This fixes the issue of step progress completion being less than 100% due to `company_name`
* Fixes sub_field questions. Amends `required_sub_fields` method to exclude `NON_VALIDATION_SUB_FIELDS`. `sub_fields` used to render fields and `required_sub_fields` used for validations. This fixes the issue of step progress completion being less than 100% when `honours` was left empty
* queen_award_holder question was also being deducted from the total, but this hasn't been a question since 2018 and so the fill_progress would always be over by 1 question.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205415026149315/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

