### PR TITLE
Fix total percentage not equalling 100%

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -726,7 +726,7 @@ window.FormValidation =
         totalOverseasTradePercentage += parseFloat($(this).val())
       else
         missingOverseasTradeValue = true
-    if totalOverseasTradePercentage != 100
+    if totalOverseasTradePercentage.toFixed(2) != (100).toFixed(2)
       errorMessage = "% of your total overseas trade should add up to 100"
       @logThis(question, "validateGoodsServicesPercentage", errorMessage)
       @appendMessage(question, errorMessage)

--- a/forms/qae_form_builder/by_trade_goods_and_services_label_question.rb
+++ b/forms/qae_form_builder/by_trade_goods_and_services_label_question.rb
@@ -28,7 +28,7 @@ class QaeFormBuilder
 
       total = 0
       question.answers["trade_goods_and_services_explanations"]&.each do |product|
-        total += product["total_overseas_trade"].to_i
+        total += product["total_overseas_trade"].to_f.round(2)
       end
       if total != 100
         result[question.key] ||= {}


### PR DESCRIPTION
## 📝 A short description of the changes

* using parseFloat can lead to additional decimals giving greater than 100%. Fixed decimals to 2 places and compare with fixed percentage value.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205441327773733/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

