### PR TITLE
Updates user reports task to take year variable

### DIFF
--- a/lib/tasks/users_reports.rake
+++ b/lib/tasks/users_reports.rake
@@ -1,15 +1,15 @@
 namespace :users_reports do
 
   desc "CSV of users for sending them a survey"
-  task export_csv: :environment do
+  task :export_csv, [:year] => :environment do |task, args|
     output_directory = Rails.root.join('tmp').to_s
 
     CSV.open(Rails.root.join('tmp', "submitted.csv").to_s , "wb") do |submitted_csv|
       CSV.open(Rails.root.join('tmp', "not_submitted.csv").to_s , "wb") do |not_submitted_csv|
         User.includes(:form_answers).find_each do |user|
-          if user.form_answers.for_year(2023).submitted.any?
+          if user.form_answers.for_year(args[:year]).submitted.any?
             submitted_csv << [user.email, user.first_name, user.last_name]
-          elsif user.form_answers.for_year(2023).any?
+          elsif user.form_answers.for_year(args[:year]).any?
             not_submitted_csv << [user.email, user.first_name, user.last_name]
           end
         end


### PR DESCRIPTION
## 📝 A short description of the changes

* The year for the user reports is hardcoded, so this switches the task to take a year variable instead of updating each year.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205548536379370/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
