### PR TITLE
Updates CF buildpack to 1.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Pre-requisites
 
 - Ruby 3.2.2
-- `gem install bundler -v 2.4.8`
+- `gem install bundler -v 2.4.19`
 - Rails 7.0.5
 - Postgresql 9.5+
 - Redis 2.8

--- a/bin/deploy
+++ b/bin/deploy
@@ -12,7 +12,7 @@ curl -X POST \
 $SLACK_WEBHOOK
 
 # Pin ruby buildpack
-export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.10.3"
+export CF_BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#v1.10.4"
 
 cf create-app-manifest "$CF_APP"-worker
 cf set-env "$CF_APP"-worker RELEASE $git_hash


### PR DESCRIPTION
 ## 📝 A short description of the changes

* Updates bundler version in readme.
* Updates CF buildpack version from 1.10.3 to 1.10.4
* Current versions ruby 3.2.2, node 18.17.1 and bundler 2.4.19 all compatible.
https://github.com/cloudfoundry/ruby-buildpack/releases/

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205641320590993/f 

## :shipit: Deployment implications

* Can't be deployed to production yet as still on ruby 2.7.7

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

