### PR TITLE
Only allow whole numbers for matrix question inputs

### DIFF
--- a/app/assets/javascripts/frontend/matrix.js
+++ b/app/assets/javascripts/frontend/matrix.js
@@ -1,0 +1,4 @@
+$(document).on("input", ".matrix-question-input", function() {
+  // allow only numbers on input
+  this.value = this.value.replace(/\D/g,'');
+});

--- a/app/views/qae_form/_matrix_question.html.slim
+++ b/app/views/qae_form/_matrix_question.html.slim
@@ -41,7 +41,7 @@ table.matrix-question-table.govuk-table class="#{'auto-totals-column' if questio
               ]
               span.govuk-error-message aria-live="polite"
                 - if @form_answer.validator_errors && @form_answer.validator_errors["#{question.hash_key}_#{x_heading.key}_#{y_heading.key}"].present?
-                  | Required
+                  = @form_answer.validator_errors["#{question.hash_key}_#{x_heading.key}_#{y_heading.key}"]
                   span.govuk-visually-hidden id="error_for_#{question.key}"
                     | Error:
                   =< @form_answer.validator_errors[question.hash_key]

--- a/forms/qae_form_builder/matrix_question.rb
+++ b/forms/qae_form_builder/matrix_question.rb
@@ -8,10 +8,17 @@ class QaeFormBuilder
         question.y_headings.each do |y_heading|
           question.x_headings.each do |x_heading|
             suffix = "#{x_heading.key}_#{y_heading.key}"
-            if !question.input_value(suffix: suffix).present? && !AUTO_CALCULATED_HEADINGS.any? { |excluded| question.input_name(suffix: suffix).include?(excluded) }
-              if (question.required_row_parent && question.required_rows.include?(y_heading.key)) || !question.required_row_parent
-                result[question.hash_key(suffix: suffix)] ||= ""
-                result[question.hash_key(suffix: suffix)] << "Required"
+            if !AUTO_CALCULATED_HEADINGS.any? { |excluded| question.input_name(suffix: suffix).include?(excluded) }
+              if !question.input_value(suffix: suffix).present?
+                if (question.required_row_parent && question.required_rows.include?(y_heading.key)) || !question.required_row_parent
+                  result[question.hash_key(suffix: suffix)] ||= ""
+                  result[question.hash_key(suffix: suffix)] << "Required"
+                end
+              else
+                if !/\A\d+\z/.match(question.input_value(suffix: suffix).to_s)
+                  result[question.hash_key(suffix: suffix)] ||= ""
+                  result[question.hash_key(suffix: suffix)] << "Must be a whole number"
+                end
               end
             end
           end


### PR DESCRIPTION
## 📝 A short description of the changes

Front end validation
* only allows whole numbers on input to matrix field

Back end validation
* adds back end check for positive whole numbers in matrix vaildator and adds custom error.
* replaces hardcoded "Required" error with custom error on matrix question view 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205728016100849/f

## :shipit: Deployment implications

* none

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="840" alt="Screenshot 2023-10-17 at 17 30 57" src="https://github.com/bitzesty/qae/assets/65811538/0e4bd486-533f-4764-8964-60a63943b50e">
