### PR TITLE
.minmax should be called on arrays

### DIFF
--- a/app/models/award_year.rb
+++ b/app/models/award_year.rb
@@ -314,8 +314,8 @@ class AwardYear < ApplicationRecord
       end_date = Date.new(AwardYear.current.year - 1 - from, month, day)
 
       if opts[:minmax] == true
-        return (start_date..end_date).minmax.map { |d| d.strftime("%d/%m/%Y") } if opts[:format] == true
-        (start_date..end_date).minmax
+        return [start_date, end_date].minmax.map { |d| d.strftime("%d/%m/%Y") } if opts[:format] == true
+        [start_date, end_date]
       else
         start_date..end_date
       end
@@ -333,8 +333,8 @@ class AwardYear < ApplicationRecord
       to = to.change(year: year)
 
       if opts[:minmax] == true
-        return (from..to).minmax.map { |d| d.strftime("%d/%m/%Y") } if opts[:format] == true
-        (from..to).minmax
+        return [from, to].minmax.map { |d| d.strftime("%d/%m/%Y") } if opts[:format] == true
+        [from, to]
       else
         from..to
       end


### PR DESCRIPTION
## 📝 A short description of the changes

* This was causing the error `undefined method strftime for nil:NilClass` 
* `(from..to).minmax` was returning [nil, nil]
* .minmax cannot be called on a range, so this converts (from..to) to [from, to] array

https://appsignal.com/bit-zesty/sites/601bea9d7478202eb7a88e16/exceptions/incidents/122/samples/last

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205732709868441/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

