### PR TITLE
Use latest stable version of `ChromeDriver` within GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
           node-version: '16'
       - run: npm install -g yarn
       - uses: nanasess/setup-chromedriver@master
-        with:
-          chromedriver-version: '116.0.5845.9600'
       - name: Build and run tests
         env:
           DISPLAY_SOCIAL_MOBILITY_AWARD: true


### PR DESCRIPTION
## 📝 A short description of the changes

Not sure if we want to keep specifying ChromeDriver version or we just go with the latest stable version. This should fix the issue I currently have with specs failing on producction due to version mismatch.

## 🔗 Link to the relevant story (or stories)

None. 

## :shipit: Deployment implications

None. 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

