### PR TITLE
Changes form answer state when unlocking assessor verdict

### DIFF
--- a/app/controllers/concerns/assessment_submission_mixin.rb
+++ b/app/controllers/concerns/assessment_submission_mixin.rb
@@ -17,6 +17,7 @@ module AssessmentSubmissionMixin
   def unlock
     authorize resource, :can_unlock?
     resource.update_column(:locked_at, nil)
+    form_answer.state_machine.perform_simple_transition(:assessment_in_progress)
     log_event
 
     render_flash_message_for(resource, message: flash_message)

--- a/app/services/assessment_submission_service.rb
+++ b/app/services/assessment_submission_service.rb
@@ -22,11 +22,7 @@ class AssessmentSubmissionService
         end
       end
 
-      if resource.moderated?
-        form_answer.state_machine.assign_lead_verdict(resource.verdict_rate, current_subject)
-      end
-
-      if resource.case_summary?
+      if resource.moderated? || resource.case_summary?
         perform_state_transition!
       end
     end
@@ -43,6 +39,10 @@ class AssessmentSubmissionService
     if set_submitted_at_as_now!
       if resource.primary?
         populate_feedback
+      end
+
+      if resource.moderated?
+        perform_state_transition!
       end
     end
   end
@@ -142,9 +142,9 @@ class AssessmentSubmissionService
         secondary_grade_label = get_answer_label(labels, secondary_grade)
 
         discrepancies << [
-          rate_key, 
+          rate_key,
           appraisal_title,
-          primary_grade_label, 
+          primary_grade_label,
           secondary_grade_label
         ]
       end
@@ -171,7 +171,7 @@ class AssessmentSubmissionService
   end
 
   def primary_and_secondary_assessments_submitted?
-    primary_assessment.submitted? && 
+    primary_assessment.submitted? &&
     secondary_assessment.submitted?
   end
 
@@ -188,12 +188,12 @@ class AssessmentSubmissionService
   end
 
   def question_answer_labels(key)
-    q_type = if key.to_s == "corporate_social_responsibility" 
+    q_type = if key.to_s == "corporate_social_responsibility"
       "CSR_RAG"
     else
       get_question_type(key)
     end
-    
+
     AppraisalForm.const_get("#{q_type.upcase}_OPTIONS_#{form_answer.award_year.year}")
   end
 
@@ -202,8 +202,8 @@ class AssessmentSubmissionService
   end
 
   def get_answer_label(labels, grade)
-    labels.detect do |el| 
-      el[1] == grade 
+    labels.detect do |el|
+      el[1] == grade
     end[0]
   end
 


### PR DESCRIPTION
 ## 📝 A short description of the changes

* On resubmit the form status was not updated if the verdict changed. This method is updated to change the state if the resource is `moderated`.
* On unlock the state is also changed to `"assessment_in_progress"` as this helps admins track the status of applications.
* Refactor of `AssessmentSubmissionService#perform` as `perform_state_transition!` calls `form_answer.state_machine.assign_lead_verdict(resource.verdict_rate, current_subject)`

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1205783140433715/f 

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
