### PR TITLE
Fix displaying of financial data within EAR report

### DIFF
--- a/app/pdf_generators/audit_certificate_pdf.rb
+++ b/app/pdf_generators/audit_certificate_pdf.rb
@@ -24,7 +24,7 @@ class AuditCertificatePdf < Prawn::Document
     @award_type = form_answer.award_type_full_name.downcase
     @award_type_full_name = "#{@form_answer.award_type_full_name} #{form_answer.award_year.year}"
     @company_name = @form_answer.company_name
-    @financial_pointer = FormFinancialPointer.new(@form_answer, {
+    @financial_pointer = FinancialSummaryPointer.new(@form_answer, {
       exclude_ignored_questions: true,
       financial_summary_view: true
     })

--- a/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
+++ b/app/pdf_generators/pdf_audit_certificates/general/shared_elements.rb
@@ -93,9 +93,15 @@ module PdfAuditCertificates::General::SharedElements
     res
   end
 
-  def render_financial_row(row, index)
+  def render_date_row(row, index)
+    res = ["#{index}. " + I18n.t("#{financials_i18_prefix}.years_row.financial_year_changed_dates")]
+    res << row.values
+    res.flatten
+  end
+
+  def render_financial_row(row, index, key: nil)
     award_specific_key = "row"
-    key = row.keys.first
+    key ||= row.keys.first
 
     if form_answer.innovation? && key == :sales
       award_specific_key = "innovation"


### PR DESCRIPTION
## 📝 A short description of the changes

Fixed displaying of financial data within EAR report if the date when company started trading doesn't match the date innovation was launched. Instead of year indexes we are now displaying actual financial years. 

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1205783148825314/f

## :shipit: Deployment implications

None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="748" alt="Screenshot 2023-10-23 at 23 48 29" src="https://github.com/bitzesty/qae/assets/13330910/03a3acb8-1b08-4a4a-8738-1c591cb3878a">

<img width="733" alt="Screenshot 2023-10-23 at 23 48 42" src="https://github.com/bitzesty/qae/assets/13330910/42f6e678-9811-4a59-b3eb-f7744cf1ebbc">



