### PR TITLE
Make the verdict textarea submit through the same JS as the rest

### DIFF
--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -45,5 +45,5 @@
         ' Edit
       .form-actions.text-right
         = link_to "Cancel", "#", class: "btn btn-default form-cancel-link if-no-js-hide", data: { element_focus_target: "dismiss" }
-        = link_to "Save", "#", class: "btn btn-primary form-save-link pull-right if-no-js-hide"
+        = link_to "Save", "#", class: "btn btn-primary form-save-link js-form-save-link pull-right if-no-js-hide", data: { updated_section: section.desc, action: "click->appraisal-form#stash" }
       .clear


### PR DESCRIPTION
## 📝 A short description of the changes

Cherry-picked from #2651 

Not exactly sure if it's related to the issue of part of the appraisals not being saved (looks like it may be partially) but this should make all textboxes with descriptions being save through the same JS as before we had one set being saved using Stimulus and the overall verdict via jQuery. When save all at once, overall verdict was not saved.

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1205737775276237/f

## :shipit: Deployment implications

None

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

