### PR TITLE
FIX: Fix fetching product data for trade applications post 2023

### DIFF
--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -300,7 +300,15 @@ module Reports::DataPickers::FormDocumentPicker
         doc("application_category") == "initiative" ? doc("initiative_desc_short") : doc("organisation_desc_short")
       end
     else
-      doc("trade_goods_briefly")
+      if obj.award_year.year <= 2023
+        doc("trade_goods_briefly")
+      else
+        if doc("trade_goods_and_services_explanations").present?
+          doc("trade_goods_and_services_explanations").map{ |h| h.dig("desc_short") }
+                                                      .reject(&:blank?)
+                                                      .join(", ")
+        end
+      end
     end
 
     ActionView::Base.full_sanitizer.sanitize(service)


### PR DESCRIPTION
## 📝 A short description of the changes

The key for fetching product/service description for trade applications submitted post 2023 has changed. This change corrects the key for those new applications.

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1205812233901852/f

## :shipit: Deployment implications

None.

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

