### PR TITLE
Remove `SubCategory` field from CSV exports

### DIFF
--- a/app/models/reports/all_entries.rb
+++ b/app/models/reports/all_entries.rb
@@ -68,10 +68,6 @@ class Reports::AllEntries
       method: :agree_sharing_of_details_with_lieutenancies?
     },
     {
-      label: "SubCategory",
-      method: :sub_category
-    },
-    {
       label: "Innovation Type",
       method: :innovation_type
     },

--- a/app/models/reports/cases_status_report.rb
+++ b/app/models/reports/cases_status_report.rb
@@ -93,10 +93,6 @@ class Reports::CasesStatusReport
     {
       label: "KAOPermission",
       method: :qao_permission
-    },
-    {
-      label: "SubCategory",
-      method: :sub_category
     }
   ]
 

--- a/spec/features/admin/form_answers/generation_of_csv_reports_spec.rb
+++ b/spec/features/admin/form_answers/generation_of_csv_reports_spec.rb
@@ -33,7 +33,6 @@ describe "Admin generates the CSV reports" do
     it "produces proper output" do
       expect(output.size).to eq(2)
       expect(output[1][9]).to eq("No")
-      expect(output[1][-1]).to eq("Outstanding growth in the last 3 years")
     end
   end
 


### PR DESCRIPTION
## 📝 A short description of the changes

Removal of `SubCategory` field from CSV exports

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1205641320590997/f

## :shipit: Deployment implications

None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

