### PR TITLE
Stop CSRF protection when extending Devise session

### DIFF
--- a/app/controllers/concerns/session_status_check_mixin.rb
+++ b/app/controllers/concerns/session_status_check_mixin.rb
@@ -6,7 +6,7 @@ module SessionStatusCheckMixin
   JUDGE_NAMESPACE = "judges".freeze
 
   included do
-    protect_from_forgery with: :exception
+    protect_from_forgery with: :exception, except: [:extend]
 
     prepend_before_action :skip_timeout, only: [:show]
   end


### PR DESCRIPTION
## 📝 A short description of the changes

Fix of `Can't verify CSRF token authenticity.` issue.

AppSignal error here: https://appsignal.com/bit-zesty/sites/601bfb8714ad665fb298effe/exceptions/incidents/2591/samples/timestamp/2023-10-26T14:28:07Z

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1205813972169129/f

## :shipit: Deployment implications

None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

