### PR TITLE
Add Clarity tracking code to assessor UI

### DIFF
--- a/app/views/layouts/application-assessor.html.slim
+++ b/app/views/layouts/application-assessor.html.slim
@@ -34,6 +34,7 @@ html.no-js
       style
         | * { -webkit-transition: none !important; transition: none !important; -webkit-animation: none !important; animation: none !important; }
 
+    = render "shared/clarity_tracker"
   body#assessor-layout data-autosave-token="#{current_assessor.try(:autosave_token)}" class="assessor-layout #{controller_name}-page #{action_name}-page #{controller_name}-#{action_name}-page #{yield :page_class} #{'layout-dev' if Rails.env.development?}"
     #site-wrapper
       #site-wrapper-margin

--- a/app/views/shared/_clarity_tracker.html.erb
+++ b/app/views/shared/_clarity_tracker.html.erb
@@ -1,0 +1,14 @@
+<% if ENV.has_key?("CLARITY_PROJECT_KEY") %>
+  <script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "<%= ENV["CLARITY_PROJECT_KEY"] %>");
+
+    <% if current_user.present? %>
+      window.clarity("identify", "<%= current_user.email %>");
+      window.clarity("set", "controller", "<%= controller_name %>");
+    <% end %>
+  </script>
+<% end %>


### PR DESCRIPTION
## 📝 A short description of the changes

Added tracking code needed to track sessions via Clarity. ENV variable w/ project ID needs to be set.

---
Clarity cannot track content of form fields (https://github.com/microsoft/clarity/issues/309) so we need to find some workarounds:

1. Maybe using `contenteditable` attribute on HTML element other than input/textarea and then syncing the changes into hidden input element may be a way to go. There may be however lot of JS tied to these inputs (character counter etc.)

```
<blockquote contenteditable="true">
  <p>Editable content.</p>
</blockquote>
<input type="text" hidden />
```

2. Using something like a widget to sync content typed in by user from any input. Can only be visible when the input field is focused and should display all content which is typed/pasted into the input. Should allow us to see the content for debugging.

![CleanShot 2023-11-07 at 23 51 41@2x](https://github.com/bitzesty/qae/assets/13330910/e187c1ca-7909-4350-9955-911639c9e9f0)

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179345/1205820879057437/f

## :shipit: Deployment implications

Set `CLARITY_PROJECT_KEY` ENV variable if you wish to enable tracking via Clarity.

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

