### PR TITLE
Use `aria-label` attribute to identify form controls instead of `label`

### DIFF
--- a/app/views/admin/form_answers/financial_summary/_row.html.slim
+++ b/app/views/admin/form_answers/financial_summary/_row.html.slim
@@ -6,6 +6,4 @@ tr class=(row.keys.first == 'overseas_sales' ? 'exports' : row.keys.first)
       span.form-value class="#{'form-value-show' unless policy(resource).update_financials?}"
         = number_with_delimiter(field[:value])
       - if field[:name].present? && policy(resource).update_financials?
-        label.visuallyhidden.govuk-label for="financial_data_#{field[:name]}"
-          = "financial_data[#{field[:name]}]"
-        = text_field_tag "financial_data[#{field[:name]}]", field[:value], class: 'form-control'
+        = text_field_tag "financial_data[#{field[:name]}]", field[:value], class: 'form-control', "aria-label" => "financial_data[#{field[:name]}]"


### PR DESCRIPTION
## 📝 A short description of the changes

Label text was getting copied when user selected & copied financial table. The problem was in labels as they were visually hidden (to be used for screen readers). 

In the end using `aria-label` instead seems to be enough as that is also one of the ways to identify form controls according https://www.w3.org/WAI/tutorials/forms/labels/#using-aria-label.

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1205957528757705/f

## :shipit: Deployment implications

None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

