### PR TITLE
Adding a lock to AssessmentSubmissionService

### DIFF
--- a/app/services/assessment_submission_service.rb
+++ b/app/services/assessment_submission_service.rb
@@ -10,6 +10,10 @@ class AssessmentSubmissionService
 
   def perform
     resource.transaction do
+      if resource.changed?
+        Rails.logger.info "Changes before save: #{resource.changes}"
+        resource.save 
+      end
       resource.lock!
       resource.submission_action = true
 


### PR DESCRIPTION
## 📝 A short description of the changes

A race condition could potentially occur in the perform method of the AssessmentSubmissionService class. This method involves several operations that read from and write to the database, and if these operations are not properly synchronized, it could lead to inconsistent data.

1. Two or more requests to submit the same assessment could be processed at the same time. This could happen if a user accidentally double-clicks the submit button, or if multiple users are working on the same assessment.

2. The first request reads the current state of the assessment from the database.

3. The second request also reads the current state of the assessment from the database. Because this happens before the first request has had a chance to update the database, the second request gets the old state of the assessment.

4. The first request updates the assessment and writes the new state to the database.

5. The second request updates the assessment based on the old state it read earlier, and writes this outdated state to the database. This overwrites the update made by the first request.


