### PR TITLE
only moderated assessment unlock should reset application status

### DIFF
--- a/app/controllers/concerns/assessment_submission_mixin.rb
+++ b/app/controllers/concerns/assessment_submission_mixin.rb
@@ -17,7 +17,7 @@ module AssessmentSubmissionMixin
   def unlock
     authorize resource, :can_unlock?
     resource.update_column(:locked_at, nil)
-    form_answer.state_machine.perform_simple_transition(:assessment_in_progress)
+    form_answer.state_machine.perform_simple_transition(:assessment_in_progress) if resource.moderated?
     log_event
 
     render_flash_message_for(resource, message: flash_message)

--- a/spec/controllers/admin/assessment_submissions_controller_spec.rb
+++ b/spec/controllers/admin/assessment_submissions_controller_spec.rb
@@ -3,7 +3,7 @@ include Warden::Test::Helpers
 
 RSpec.describe Admin::AssessmentSubmissionsController do
   let!(:admin) {create(:admin, superadmin: true)}
-  let!(:assessor_assignment) {create(:assessor_assignment)}
+  let!(:assessor_assignment) { create(:assessor_assignment) }
 
   before do
     sign_in admin
@@ -21,11 +21,67 @@ RSpec.describe Admin::AssessmentSubmissionsController do
     end
   end
 
-  describe "PATCH unlonk" do
-    it "should unlock a resource" do
-      patch :unlock, params: { id: assessor_assignment.id, assessment_id: assessor_assignment.id }
-      expect(response).to redirect_to [:admin, assessor_assignment.form_answer]
-      expect(assessor_assignment.reload.locked_at).to be_nil
+  describe "PATCH unlock" do
+    let(:form_answer) { assessor_assignment.form_answer }
+
+    context "primary assessment" do
+      let!(:assessor_assignment) { create(:assessor_assignment, position: "primary", locked_at: Time.now) }
+
+      before do
+        form_answer.update_column(:state, "recommended")
+      end
+
+      it "should unlock a resource" do
+        patch :unlock, params: { id: assessor_assignment.id, assessment_id: assessor_assignment.id }
+        expect(response).to redirect_to [:admin, assessor_assignment.form_answer]
+        expect(form_answer.reload.state).to eq("recommended")
+        expect(assessor_assignment.reload.locked_at).to be_nil
+      end
+    end
+
+    context "secondary assessment" do
+      let!(:assessor_assignment) { create(:assessor_assignment, :submitted, :locked, position: "secondary") }
+
+      before do
+        assessor_assignment.form_answer.update_column(:state, "recommended")
+      end
+
+      it "should unlock a resource" do
+        patch :unlock, params: { id: assessor_assignment.id, assessment_id: assessor_assignment.id }
+        expect(response).to redirect_to [:admin, assessor_assignment.form_answer]
+        expect(form_answer.reload.state).to eq("recommended")
+        expect(assessor_assignment.reload.locked_at).to be_nil
+      end
+    end
+
+    context "moderated assessment" do
+      let!(:assessor_assignment) { create(:assessor_assignment, :submitted, :locked, position: "moderated") }
+
+      before do
+        assessor_assignment.form_answer.update_column(:state, "recommended")
+      end
+
+      it "should unlock a resource" do
+        patch :unlock, params: { id: assessor_assignment.id, assessment_id: assessor_assignment.id }
+        expect(response).to redirect_to [:admin, assessor_assignment.form_answer]
+        expect(form_answer.reload.state).to eq("assessment_in_progress")
+        expect(assessor_assignment.reload.locked_at).to be_nil
+      end
+    end
+
+    context "case summary" do
+      let!(:assessor_assignment) { create(:assessor_assignment, :submitted, :locked, position: "case_summary") }
+
+      before do
+        assessor_assignment.form_answer.update_column(:state, "recommended")
+      end
+
+      it "should unlock a resource" do
+        patch :unlock, params: { id: assessor_assignment.id, assessment_id: assessor_assignment.id }
+        expect(response).to redirect_to [:admin, assessor_assignment.form_answer]
+        expect(form_answer.reload.state).to eq("recommended")
+        expect(assessor_assignment.reload.locked_at).to be_nil
+      end
     end
   end
 end

--- a/spec/factories/assessor_assignments_factory.rb
+++ b/spec/factories/assessor_assignments_factory.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
     trait :submitted do
       submitted_at { DateTime.now - 1.minute }
     end
+
+    trait :locked do
+      locked_at { DateTime.now - 1.minute }
+    end
   end
 
   factory :assessor_assignment_moderated, class: AssessorAssignment do


### PR DESCRIPTION
## 📝 A short description of the changes

* prevent primary, secondary and case summary assessments from changing the application status

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1206003080195662/f

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
