### PR TITLE
Fix 422 status when deleting admin comments

### DIFF
--- a/app/assets/javascripts/admin/comments.js.coffee
+++ b/app/assets/javascripts/admin/comments.js.coffee
@@ -36,6 +36,7 @@ ready = ->
     e.preventDefault()
     $.ajax
       url: $(this).attr('action')
+      headers: 'Content-Type': 'application/json'
       type: 'DELETE'
       success: () =>
         numberWrapper = $(@).closest(".panel").find(".panel-heading .comments-number")


### PR DESCRIPTION
## 📝 A short description of the changes

* When admins are attempting to delete comments on production there is a 422 status error.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1206408878957787/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="1792" alt="Screenshot 2024-01-24 at 13 32 34" src="https://github.com/bitzesty/qae/assets/65811538/c2d0e427-ce5a-40b4-a94f-9e826a1b155f">
