### PR TITLE
add ability to suspend assessors (no ui yet)

### DIFF
--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -58,8 +58,16 @@ class Assessor < ApplicationRecord
   end
 
   def active_for_authentication?
-    super && !deleted?
+    super && !deleted? && !suspended?
   end
+
+  def suspended?
+    suspended_at.present?
+  end
+
+  def inactive_message
+    !suspended? ? super : :suspended
+ end
 
   def self.roles
     [["Not Assigned", nil], ["Lead Assessor", "lead"], ["Assessor", "regular"]]

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -11,6 +11,7 @@ en:
       inactive: "Your account is not activated yet."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."
+      suspended: "Your account has been temporarily disabled. As you have finished this round of assessments, your account has been temporarily deactivated for data security reasons. It will be re-activated when you need to do assessments."
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."

--- a/db/migrate/20240314105208_add_suspended_at_to_assessors.rb
+++ b/db/migrate/20240314105208_add_suspended_at_to_assessors.rb
@@ -1,0 +1,5 @@
+class AddSuspendedAtToAssessors < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assessors, :suspended_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,13 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
 -- Name: citext; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -399,7 +406,8 @@ CREATE TABLE public.assessors (
     mobility_role character varying,
     deleted boolean DEFAULT false,
     autosave_token character varying,
-    unique_session_id character varying
+    unique_session_id character varying,
+    suspended_at timestamp(6) without time zone
 );
 
 
@@ -4312,6 +4320,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220906085443'),
 ('20220906085454'),
 ('20220927093210'),
-('20231025022311');
+('20231025022311'),
+('20240314105208');
 
 

--- a/spec/features/assessor/log_in_spec.rb
+++ b/spec/features/assessor/log_in_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe "Log in" do
+  let(:subject) { create(:assessor, :lead_for_all, password: "my98ssdkjv9823kds=2") }
+
+  it "logs in" do
+    visit "/assessors/sign_in"
+    fill_in "Email", with: subject.email
+    fill_in "Password", with: "my98ssdkjv9823kds=2"
+    click_button "Sign in"
+    expect(page).to have_content "Applications"
+  end
+
+  it "can't log in if suspended" do
+    subject.update!(suspended_at: Time.zone.now)
+
+    visit "/assessors/sign_in"
+    fill_in "Email", with: subject.email
+    fill_in "Password", with: "my98ssdkjv9823kds=2"
+    click_button "Sign in"
+    expect(page).not_to have_content "Applications"
+    expect(page).to have_content "Your account has been temporarily disabled."
+  end
+end


### PR DESCRIPTION
## 📝 A short description of the changes

* add column to allow us to suspend assessors

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1206833235918005/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="1039" alt="image" src="https://github.com/bitzesty/qae/assets/332810/814d39c5-7dd8-4ef0-a140-effce4082a64">

