### PR TITLE
Adds time for reception information on winner mailers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -38,6 +38,7 @@ class ApplicationMailer < Mail::Notify::Mailer
     @reception_deadline = deadlines.where(kind: "buckingham_palace_reception_attendee_information_due_by").first
     @reception_deadline_time = formatted_deadline_time(@reception_deadline)
     @reception_date = deadlines.where(kind: "buckingham_palace_attendees_invite").first
+    @reception_start_time = formatted_deadline_time(@reception_date)
   end
 
   def deadlines

--- a/app/renderers/mail_renderer.rb
+++ b/app/renderers/mail_renderer.rb
@@ -210,6 +210,10 @@ class MailRenderer
       "%-d %B %Y"
     )
 
+    assigns[:reception_start_time] = deadline_time(
+      "buckingham_palace_attendees_invite"
+    )
+
     render(assigns, "account_mailers/business_apps_winners_mailer/preview/notify")
   end
 
@@ -253,6 +257,10 @@ class MailRenderer
     assigns[:reception_date] = deadline_str(
       "buckingham_palace_attendees_invite",
       "%-d %B %Y"
+    )
+
+    assigns[:reception_start_time] = deadline_time(
+      "buckingham_palace_attendees_invite"
     )
 
     render(assigns, "users/winners_head_of_organisation_mailer/preview/notify")

--- a/app/views/account_mailers/business_apps_winners_mailer/notify.text.erb
+++ b/app/views/account_mailers/business_apps_winners_mailer/notify.text.erb
@@ -48,7 +48,7 @@ On your online account, you will also have access to The King's Awards Recipient
 
 By accepting the Award, you agree to the terms set out in The King's Awards Recipients Manual.
 
-#4. Reception at Windsor Castle on <%= @reception_date.try :strftime, "%-d %B %Y" %>
+#4. Reception at Windsor Castle on <%= @reception_date.try :strftime, "%-d %B %Y" %> at <%= "#{@reception_start_time}" %>
 
 Please note the date and venue. One representative from each successful organisation will be invited to attend a Reception at Windsor Castle hosted by His Majesty The King. Please note that, unfortunately, this number cannot be increased. We will contact you in due course, asking you to nominate one representative to attend the event.
 

--- a/app/views/account_mailers/business_apps_winners_mailer/preview/notify.html.slim
+++ b/app/views/account_mailers/business_apps_winners_mailer/preview/notify.html.slim
@@ -108,7 +108,9 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   strong
     | 4. Reception at Windsor Castle on
-    =< @reception_date
+    =<> @reception_date
+    | at
+    =< @reception_start_time
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Please note the date and venue. One representative from each successful organisation will be invited to attend a Reception at Windsor Castle hosted by His Majesty The King. Please note that, unfortunately, this number cannot be increased. We will contact you in due course, asking you to nominate one representative to attend the event.

--- a/app/views/users/winners_head_of_organisation_mailer/notify.text.erb
+++ b/app/views/users/winners_head_of_organisation_mailer/notify.text.erb
@@ -48,7 +48,7 @@ A link to The King's Awards Emblems and Recipients Manual is located on your acc
 * the terms of using your Award and displaying the Royal Emblem, which you agree to by accepting the Award;
 * the presentation by His Majesty's Lord-Lieutenant, the Grant of Appointment and Trophy.
 
-#4. Reception at Windsor Castle on <%= @reception_date.try :strftime, "%-d %B %Y" %>
+#4. Reception at Windsor Castle on <%= @reception_date.try :strftime, "%-d %B %Y" %> at <%= "#{@reception_start_time}" %>
 
 This year, one employed representative from each successful organisation will be invited to attend a Reception at Windsor Castle hosted by His Majesty The King. Unfortunately, this number cannot be increased.
 

--- a/app/views/users/winners_head_of_organisation_mailer/preview/notify.html.slim
+++ b/app/views/users/winners_head_of_organisation_mailer/preview/notify.html.slim
@@ -102,7 +102,9 @@ div style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   strong
    | 4. Reception at Windsor Castle on
-   =< @reception_date
+   =<> @reception_date
+   | at
+   =< @reception_start_time
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | This year, one employed representative from each successful organisation will be invited to attend a Reception at Windsor Castle hosted by His Majesty The King. Unfortunately, this number cannot be increased.


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds a start time for the reception information on the winners mailers

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1206880003047877/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="990" alt="Screenshot 2024-03-19 at 16 50 38" src="https://github.com/bitzesty/qae/assets/65811538/42799fac-c07e-4a69-8f03-17c8843793f4">

