### PR TITLE
change the way we display the error for deactivated assessors

### DIFF
--- a/app/controllers/assessor/base_controller.rb
+++ b/app/controllers/assessor/base_controller.rb
@@ -4,6 +4,7 @@ class Assessor::BaseController < ApplicationController
   layout "application-assessor"
 
   before_action :authenticate_assessor!, :load_award_year_and_settings
+  before_action :check_suspension_status
   after_action :verify_authorized
 
   skip_before_action :authenticate_user!, raise: false
@@ -42,5 +43,12 @@ class Assessor::BaseController < ApplicationController
 
   def user_for_paper_trail
     "ASSESSOR:#{current_assessor.id}" if current_assessor.present?
+  end
+
+  def check_suspension_status
+    if current_assessor.suspended? && controller_name != "dashboard" && action_name != "suspended"
+      flash.clear # clearing any successfull login messages
+      redirect_to assessor_suspended_path
+    end
   end
 end

--- a/app/controllers/assessor/dashboard_controller.rb
+++ b/app/controllers/assessor/dashboard_controller.rb
@@ -2,4 +2,14 @@ class Assessor::DashboardController < Assessor::BaseController
   def index
     authorize :dashboard, :index?
   end
+
+  def suspended
+    authorize :dashboard, :index?
+
+    if current_assessor.suspended?
+      render :suspended, layout: "application_suspended"
+    else
+      redirect_to assessor_root_path
+    end
+  end
 end

--- a/app/models/assessor.rb
+++ b/app/models/assessor.rb
@@ -62,7 +62,7 @@ class Assessor < ApplicationRecord
   end
 
   def active_for_authentication?
-    super && !deleted? && !suspended?
+    super && !deleted?
   end
 
   def suspended?
@@ -75,10 +75,6 @@ class Assessor < ApplicationRecord
 
   def suspend!
     update_attribute(:suspended_at, Time.current)
-  end
-
-  def inactive_message
-    !suspended? ? super : :suspended
   end
 
   def self.roles

--- a/app/views/assessor/dashboard/suspended.html.slim
+++ b/app/views/assessor/dashboard/suspended.html.slim
@@ -1,0 +1,8 @@
+header.group.page-header.page-header-wider
+  h1.govuk-heading-l style="width: 60%"
+    | Your account has been temporarily deactivated
+
+.article-container.article-container-wider style="min-height: 18em;"
+  article.group role="article"
+    p.govuk-body
+      | As you have finished this round of assessments, your account has been temporarily deactivated for data security reasons. It will be re-activated when you need to do assessments.

--- a/app/views/layouts/application_suspended.html.slim
+++ b/app/views/layouts/application_suspended.html.slim
@@ -1,0 +1,92 @@
+title = content_for?(:title) ? "#{'Appraisal view of ' if admin_in_read_only_mode?}" + yield(:title)  + " - King's Awards for Enterprise" : "King's Awards for Enterprise"
+
+- content_for :head do
+  = stylesheet_link_tag "application.css"
+
+  - if Rails.env.test?
+    style
+      | * { -webkit-transition: none !important; transition: none !important; -webkit-animation: none !important; animation: none !important; }
+
+  = csrf_meta_tags
+
+  = yield :section_meta_tags
+
+  = yield :head
+
+
+- content_for :header_class do
+  - unless landing_page?
+    ' with-proposition
+
+
+- content_for :content do
+  = render "shared/offline_message"
+  = render "shared/dev_or_staging_banner"
+
+  #wrapper.guide.smart-answer.answer class="#{yield :page_wrapper_class}"
+    #QAE class="#{'layout-dev' if Rails.env.development?}"
+      .govuk-width-container role="region"
+        .govuk-phase-banner
+          p.govuk-phase-banner__content
+            strong.govuk-tag.govuk-phase-banner__content__tag
+              ' BETA
+            span.govuk-phase-banner__text
+              ' This is a new service
+              - if action_name != "feedback"
+                ' – your
+                = link_to "feedback", feedback_path, target: "_blank", class: 'govuk-link'
+                '  will help us to improve it.
+
+      .govuk-width-container
+        main#content.group class="govuk-main-wrapper app-main-class #{yield :page_content_class}"
+          = render "layouts/flash"
+
+          = yield
+
+- content_for :footer_support_links do
+  h2.govuk-visually-hidden Support links
+  ul.govuk-footer__inline-list
+    li.govuk-footer__inline-list-item
+      = link_to "Help", "https://www.gov.uk/help", class: 'govuk-footer__link'
+    li.govuk-footer__inline-list-item
+      = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
+    li.govuk-footer__inline-list-item
+      = link_to "Accessibility Statement", accessibility_statement_path, class: 'govuk-footer__link'
+    li.govuk-footer__inline-list-item
+      ' Built by
+      = link_to "The King's Awards Office", "http://blogs.bis.gov.uk/queensawards/", class: 'govuk-footer__link'
+
+- content_for :body_end do
+  - if should_enable_js?
+    = include_gon
+    = javascript_include_tag 'application'
+
+  - if Rails.env.test?
+    = javascript_tag("$.fx.off = true;")
+
+  - if ENV["GOOGLE_ANALYTICS_ID"].present?
+    / Google Analytics
+    script type="text/javascript"
+      | if (Cookies.get("gaconsent") === "accept" && !Cookies.get("gaoptout")) {
+      |   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      |   ga('create', '#{ENV["GOOGLE_ANALYTICS_ID"]}', 'auto');
+
+      |   ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
+      |   ga('govuk_shared.require', 'linker');
+      |   ga('govuk_shared.linker.set', 'anonymizeIp', true);
+      |   ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
+
+      - if current_user
+        | ga('set', 'userId', '#{current_user.id}');
+        | ga('set', 'dimension1', '#{current_user.id}');
+
+      |   ga('set', 'anonymizeIp', true);
+      |   ga('send', 'pageview');
+      |   ga('govuk_shared.send', 'pageview');
+      | }
+
+
+= render template: 'layouts/govuk_template'
+
+- if should_enable_js?
+  = javascript_tag "$(function() { #{yield(:javascript_code)} });" if content_for? :javascript_code

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,6 +173,8 @@ Rails.application.routes.draw do
       end
     end
 
+    get :suspended, to: "dashboard#suspended"
+
     resources :review_audit_certificates, only: [:create]
     resources :review_commercial_figures, only: [:create]
 

--- a/spec/features/assessor/log_in_spec.rb
+++ b/spec/features/assessor/log_in_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+include Warden::Test::Helpers
 
 describe "Log in" do
   let(:subject) { create(:assessor, :lead_for_all, password: "my98ssdkjv9823kds=2") }
@@ -19,6 +20,12 @@ describe "Log in" do
     fill_in "Password", with: "my98ssdkjv9823kds=2"
     click_button "Sign in"
     expect(page).not_to have_content "Applications"
-    expect(page).to have_content "Your account has been temporarily disabled."
+    expect(page).to have_content("Your account has been temporarily deactivated")
+  end
+
+  it "does not show the error if the assessor was activated and user navigates to the error url" do
+    login_as(subject, scope: :assessor)
+    visit assessor_suspended_path
+    expect(page).not_to have_content("Your account has been temporarily deactivated")
   end
 end


### PR DESCRIPTION
## 📝 A short description of the changes

* add new error page, handle all the redirects

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/home/1178339740118267/1206863095170340

## :shipit: Deployment implications

* 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="1007" alt="image" src="https://github.com/bitzesty/qae/assets/332810/4171abee-7002-40f5-98fb-d3efe2b2ef9c">
