### PR TITLE
Pass allow_other_host

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -51,13 +51,13 @@ class Admin::BaseController < ApplicationController
                   type: "application/pdf",
                   disposition: 'attachment'
       else
-        redirect_to pdf_hard_copy.file.url
+        redirect_to pdf_hard_copy.file.url, allow_other_host: true
       end
     else
       send_data pdf_data.render,
                 filename: "application_#{mode.pluralize}_#{form_answer.decorate.pdf_filename}",
                 type: "application/pdf",
-                disposition: 'attachment'              
+                disposition: 'attachment'
     end
   end
 end

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -33,7 +33,9 @@
 
     - if policy(resource).download_feedback_pdf?
       li
-        = link_to "View/print an application's feedbacks", download_pdf_admin_form_answer_feedbacks_path(resource.object, format: :pdf), target: admin_conditional_pdf_link_target(resource.object, "feedback")
+        = link_to "View/print an application's feedbacks",
+          download_pdf_admin_form_answer_feedbacks_path(resource.object, format: :pdf),
+          target: admin_conditional_pdf_link_target(resource.object, "feedback")
 - else
   p.p-empty
     ' No documents have been attached.


### PR DESCRIPTION
## 📝 A short description of the changes

* When downloading the pdf on production admins face the error 'unsafe redirect'. This commit passes `allow_other_host: true` to the link
* https://appsignal.com/bit-zesty/sites/601bfb8714ad665fb298effe/exceptions/incidents/2720

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/0/1206942547747339/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
