### PR TITLE
[temporary] return 404 for recommended application's feedback

### DIFF
--- a/app/controllers/users/form_answer_feedbacks_controller.rb
+++ b/app/controllers/users/form_answer_feedbacks_controller.rb
@@ -15,6 +15,9 @@ class Users::FormAnswerFeedbacksController < Users::BaseController
 
   before_action :require_application_to_have_a_feedback!
 
+  # temporarily restrict access for recommended applications
+  before_action :restrict_access_for_recommended_applications
+
   def show
     respond_to do |format|
       format.pdf do
@@ -47,6 +50,12 @@ class Users::FormAnswerFeedbacksController < Users::BaseController
       redirect_to dashboard_url,
                   notice: "There are no any feedback for this application!"
       return false
+    end
+  end
+
+  def restrict_access_for_recommended_applications
+    if form_answer.state == "recommended"
+      raise ActionController::RoutingError, "Not Found"
     end
   end
 end


### PR DESCRIPTION
## 📝 A short description of the changes

* make feedback download links to return 404

## 🔗 Link to the relevant story (or stories)

* [KAE0424] Prevent feedback links from working for applications with a Recommended status

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

