### PR TITLE
Move feedback link so it shows for all forms

### DIFF
--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -30,16 +30,15 @@
       div[data-controller="inline-flash"]
         .document-list.space-y-2
           = render(partial: "admin/form_answers/docs/status", locals: { form_answer: @form_answer })
-          = render "admin/form_answers/docs/post_shortlisting_docs", resource: resource
 
         - if @form_answer.audit_certificate.blank? && Settings.after_shortlisting_stage?
           .sidebar-section.no-margin-bottom.space-y-3
             - if @form_answer.requires_vocf?
               #audit-certificate-form[data-controller="inline-flash"]
                 - audit_certificate = @form_answer.build_audit_certificate
-                = render "admin/audit_certificate/form", form_answer: @form_answer, audit_certificate: audit_certificate 
+                = render "admin/audit_certificate/form", form_answer: @form_answer, audit_certificate: audit_certificate
 
-    - elsif @form_answer.provided_estimates? 
+    - elsif @form_answer.provided_estimates?
       - figures_form = @form_answer.shortlisted_documents_wrapper || @form_answer.build_shortlisted_documents_wrapper
 
       = render(partial: "admin/figures_and_vat_returns/status", locals: { form_answer: @form_answer, figures_form: figures_form })
@@ -48,6 +47,8 @@
         = render(partial: "admin/figures_and_vat_returns/vat_returns", locals: { form_answer: @form_answer, figures_form: figures_form })
       #commercial-figures-section[data-controller="inline-flash"]
         = render(partial: "admin/figures_and_vat_returns/actual_figures", locals: { form_answer: @form_answer, figures_form: figures_form })
+
+    = render "admin/form_answers/docs/post_shortlisting_docs", resource: resource
 
   / TODO Only appears for EP but for now we need to think more on it
   /.sidebar-section

--- a/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
+++ b/app/views/admin/form_answers/docs/_post_shortlisting_docs.html.slim
@@ -33,7 +33,7 @@
 
     - if policy(resource).download_feedback_pdf?
       li
-        = link_to "View/print an application's feedbacks",
+        = link_to "View/print application feedback",
           download_pdf_admin_form_answer_feedbacks_path(resource.object, format: :pdf),
           target: admin_conditional_pdf_link_target(resource.object, "feedback")
 - else


### PR DESCRIPTION
## 📝 A short description of the changes

* Renders 'post_shortlisting_docs' partial outside of conditional statement so it shows for all award types. Policies exist within the partial to only show relevant documents
* Copy change on link text

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207025990859364

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="907" alt="Screenshot 2024-04-11 at 11 48 43" src="https://github.com/bitzesty/qae/assets/65811538/ac288acd-7b36-4ab6-a693-27d8dcb7caf9">
