### PR TITLE
Adds new govt support column for entries report

### DIFF
--- a/app/models/reports/all_entries.rb
+++ b/app/models/reports/all_entries.rb
@@ -92,6 +92,10 @@ class Reports::AllEntries
       method: :employees
     },
     {
+      label: "GovernmentSupport",
+      method: :government_support
+    },
+    {
       label: "CompanyRegNo",
       method: :business_reg_no
     },

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -239,4 +239,12 @@ class Reports::FormAnswer
   def po_sd_provided_actual_figures?
     %w[mobility development].include?(obj.award_type) && obj.document["product_estimated_figures"] == "no"
   end
+
+  def government_support
+    if obj.innovation?
+      obj.document["innovations_grant_funding"]
+    else
+      obj.document["received_grant"]
+    end.presence.to_s.humanize
+  end
 end

--- a/spec/models/reports/form_answer_spec.rb
+++ b/spec/models/reports/form_answer_spec.rb
@@ -99,4 +99,15 @@ describe Reports::FormAnswer do
       expect(Reports::FormAnswer.new(build(:form_answer)).send(:mso_grade_agreed)).to eq 'G,A'
     end
   end
+
+  describe '#government_support' do
+    it 'should return correct value' do
+      inn_form_answer = build(:form_answer, :innovation)
+      inn_form_answer.document = inn_form_answer.document.merge(
+        innovations_grant_funding: "yes",
+      )
+      expect(Reports::FormAnswer.new(build(:form_answer, :trade)).send(:government_support)).to eq "No"
+      expect(Reports::FormAnswer.new(inn_form_answer).send(:government_support)).to eq "Yes"
+    end
+  end
 end


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds a new column to the Entries report on the Admin dashboard that will 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207082081710120

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="311" alt="Screenshot 2024-04-16 at 15 27 34" src="https://github.com/bitzesty/qae/assets/65811538/1881281c-0912-431e-8bf1-be15903f575a">

