### PR TITLE
Adds url validation to website questions

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -785,6 +785,21 @@ window.FormValidation =
       @appendMessage(question, "Select a maximum of " + selection_limit)
       @addErrorClass(question)
 
+  validateWebsiteUrl: (question) ->
+    questionRef = question.attr("data-question_ref")
+    url = question.find("input[type='website_url']").val()
+    urlRegex = /(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?/i;
+
+    if !url
+      @appendMessage(question, "Question #{questionRef} is incomplete. It is required and must be filled in. Use the format as shown in the description.")
+      @addErrorClass(question)
+    else
+      if !url[/\Ahttp:\/\//] || !url[/\Ahttps:\/\//]
+        url = "http://#{url}"
+      if !urlRegex.test(url) || url.includes("<script")
+        @logThis(question, "validateWebsiteUrl", "Not a valid URL")
+        @addErrorMessage(question, "The website address is in an incorrect format. Use the format as shown in the description.")
+        @addErrorClass(question)
 
   # It's for easy debug of validation errors
   # As it really tricky to find out the validation which blocks form
@@ -903,6 +918,9 @@ window.FormValidation =
 
     if question.hasClass("sub-fields-word-max")
       @validateSubfieldWordLimit(question)
+
+    if question.find("input[type='website_url']")
+      @validateWebsiteUrl(question)
 
   validate: ->
     @clearAllErrors()

--- a/forms/award_years/v2025/innovation/innovation_step2.rb
+++ b/forms/award_years/v2025/innovation/innovation_step2.rb
@@ -197,6 +197,7 @@ class AwardYears::V2025::QaeForms
         end
 
         text :website_url, "Website address." do
+          type "website_url"
           classes "text-words-max"
           required
           ref "B 8"

--- a/forms/award_years/v2025/international_trade/international_trade_step2.rb
+++ b/forms/award_years/v2025/international_trade/international_trade_step2.rb
@@ -193,6 +193,7 @@ class AwardYears::V2025::QaeForms
         end
 
         text :website_url, "Website address." do
+          type "website_url"
           classes "text-words-max"
           required
           ref "B 8"

--- a/forms/award_years/v2025/social_mobility/social_mobility_step2.rb
+++ b/forms/award_years/v2025/social_mobility/social_mobility_step2.rb
@@ -190,6 +190,7 @@ class AwardYears::V2025::QaeForms
         end
 
         text :website_url, "Website address." do
+          type "website_url"
           classes "text-words-max"
           required
           ref "B 8"

--- a/forms/award_years/v2025/sustainable_development/sustainable_development_step2.rb
+++ b/forms/award_years/v2025/sustainable_development/sustainable_development_step2.rb
@@ -195,6 +195,7 @@ class AwardYears::V2025::QaeForms
         end
 
         text :website_url, "Website address." do
+          type "website_url"
           classes "text-words-max"
           required
           ref "B 8"

--- a/forms/qae_form_builder/question.rb
+++ b/forms/qae_form_builder/question.rb
@@ -55,6 +55,15 @@ class QaeFormBuilder
         limit
       end
     end
+
+    def valid_url?(url)
+      return false if url.include?("<script")
+      unless url[/\Ahttp:\/\//] || url[/\Ahttps:\/\//]
+        url = "http://#{url}"
+      end
+      url_regexp = /\A(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix
+      url =~ url_regexp ? true : false
+    end
   end
 
   class QuestionDecorator < QaeDecorator

--- a/forms/qae_form_builder/text_question.rb
+++ b/forms/qae_form_builder/text_question.rb
@@ -15,6 +15,11 @@ class QaeFormBuilder
         result[question.hash_key] << " Exceeded #{limit} word limit."
       end
 
+      if question.type == "website_url" && question.input_value && !valid_url?(question.input_value)
+        result[question.hash_key] ||= ""
+        result[question.hash_key] << " The website address is in an incorrect format. Use the format as shown in the description."
+      end
+
       result
     end
   end


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds validation of urls entered in website questions. We do not need to check a response status, just the formatting of the link. We are using regex to match a pattern. In order to allow both `http://www.` and `www.` we add a scheme if it is missing.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1206657020467771

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="651" alt="Screenshot 2024-04-18 at 09 22 43" src="https://github.com/bitzesty/qae/assets/65811538/b3476dfd-dd66-40b2-9d58-d6abfa2332a5">

