### PR TITLE
Adds bullet point to the process page

### DIFF
--- a/app/views/content_only/_award_nickname.html.slim
+++ b/app/views/content_only/_award_nickname.html.slim
@@ -20,6 +20,7 @@
         li The form can be completed over a number of days.
         li You can save and return to the form at any point.
         li You will be given more detailed instructions after the eligibility questionnaire.
+        li Collaborators can work on the form simultaneously if they are on different sections.
 
     li
       p.govuk-body
@@ -47,4 +48,3 @@
   p#get-started.get-started.group.govuk-body
     - title = award_type == "innovation" ? "Save and start eligibility questionnaire" : "Start eligibility questionnaire"
     = submit_tag title, class: "govuk-button", rel: "external"
-


### PR DESCRIPTION
## 📝 A short description of the changes

* Add bullet point: ‘Collaborators can work on the form simultaneously if they are on different sections.’ to the page that appears before the eligibility

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207125165410107

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="553" alt="Screenshot 2024-04-22 at 17 04 31" src="https://github.com/bitzesty/qae/assets/65811538/14ca9aac-7c4c-49d5-96b1-c5e5221e3259">
