### PR TITLE
Remove error icon from disabled navigation links 

### DIFF
--- a/app/assets/stylesheets/frontend/views/award_form.scss
+++ b/app/assets/stylesheets/frontend/views/award_form.scss
@@ -37,6 +37,10 @@
     }
   }
 
+  &.js-step-disabled a {
+    background: none !important;
+  }
+
   &.step-current a {
     cursor: default;
     color: $black;


### PR DESCRIPTION
## 📝 A short description of the changes

Related to #2831. Fixed displaying of disabled nav links when some error was present.

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/0/1207170220217476/f

## :shipit: Deployment implications

None. 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
Before:
<img src="https://github.com/bitzesty/qae/assets/13330910/525b6a5e-67fc-4c2c-8351-c95346aeddaf" width="240">
After:
<img src="https://github.com/bitzesty/qae/assets/13330910/03fd2362-19a7-49f9-b66c-b4fa35bb56fa" width="240">
