### PR TITLE
move UK sales value after exports in financial summary for admins

### DIFF
--- a/app/form_pointers/form_financial_pointer.rb
+++ b/app/form_pointers/form_financial_pointer.rb
@@ -55,7 +55,12 @@ class FormFinancialPointer
 
       unless UK_SALES_EXCLUDED_FORM_TYPES.include?(form_answer.object.award_type.to_sym)
         uk_sales_data = UkSalesCalculator.new(fetched).data
-        fetched += [uk_sales_data] if uk_sales_data.present?
+
+        if index = fetched.index { |data| data[:exports].present? }
+          fetched.insert(index + 1, uk_sales_data) if uk_sales_data.present?
+        else
+          fetched += [uk_sales_data] if uk_sales_data.present?
+        end
       end
 
       fetched


### PR DESCRIPTION
## 📝 A short description of the changes

* just moving the row to a different place

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207057399563325

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="776" alt="image" src="https://github.com/bitzesty/qae/assets/332810/41cd8722-a840-4ae6-9cc2-eaa970262d84">

