### PR TITLE
New destroy collaborator action for admins

### DIFF
--- a/app/controllers/account/collaborators_controller.rb
+++ b/app/controllers/account/collaborators_controller.rb
@@ -71,11 +71,7 @@ class Account::CollaboratorsController < Account::BaseController
   def destroy
     form_id = params[:form_id].presence
 
-    collaborator.account_id = Account.create(owner: collaborator).id
-    collaborator.role = "account_admin"
-    collaborator.save!
-    collaborator.form_answers
-                .update_all(user_id: account.owner_id)
+    CollaboratorRemovalService.new(collaborator, account).reassign_form_answers
 
     redirect_to account_collaborators_path(form_id: form_id),
       notice: "#{collaborator.email} successfully removed from Collaborators!"

--- a/app/controllers/admin/collaborator_deletion_controller.rb
+++ b/app/controllers/admin/collaborator_deletion_controller.rb
@@ -1,0 +1,13 @@
+class Admin::CollaboratorDeletionController < Admin::BaseController
+  def destroy
+    form_id = params[:form_id].presence
+    collaborator = User.find(params[:id])
+    account = collaborator.account
+
+    authorize :collaborator, :destroy?
+
+    CollaboratorRemovalService.new(collaborator, account).reassign_form_answers
+
+    redirect_to edit_admin_user_path(account.owner), notice: "#{collaborator.email} successfully removed from Collaborators!"
+  end
+end

--- a/app/policies/collaborator_policy.rb
+++ b/app/policies/collaborator_policy.rb
@@ -1,0 +1,5 @@
+class CollaboratorPolicy < ApplicationPolicy
+  def destroy?
+    admin?
+  end
+end

--- a/app/services/collaborator_removal_service.rb
+++ b/app/services/collaborator_removal_service.rb
@@ -1,4 +1,6 @@
 class CollaboratorRemovalService
+  attr_reader :collaborator, :account
+
   def initialize(collaborator, account)
     @collaborator = collaborator
     @account = account
@@ -6,10 +8,10 @@ class CollaboratorRemovalService
 
   def reassign_form_answers
     User.transaction do
-      @collaborator.account_id = Account.create(owner: @collaborator).id
-      @collaborator.role = "account_admin"
-      @collaborator.save!
-      @collaborator.form_answers.update_all(user_id: @account.owner_id)
+      collaborator.account_id = Account.create(owner: collaborator).id
+      collaborator.role = "account_admin"
+      collaborator.save!
+      collaborator.form_answers.update_all(user_id: account.owner_id)
     end
   end
 end

--- a/app/services/collaborator_removal_service.rb
+++ b/app/services/collaborator_removal_service.rb
@@ -1,0 +1,15 @@
+class CollaboratorRemovalService
+  def initialize(collaborator, account)
+    @collaborator = collaborator
+    @account = account
+  end
+
+  def reassign_form_answers
+    User.transaction do
+      @collaborator.account_id = Account.create(owner: @collaborator).id
+      @collaborator.role = "account_admin"
+      @collaborator.save!
+      @collaborator.form_answers.update_all(user_id: @account.owner_id)
+    end
+  end
+end

--- a/app/views/admin/collaborators/_item.html.slim
+++ b/app/views/admin/collaborators/_item.html.slim
@@ -1,11 +1,11 @@
 li.list-group-item id=dom_id(collaborator)
   .pull-right
     - if params.has_key? :form_id
-      = link_to "Remove", account_collaborator_path(collaborator, form_id: params[:form_id]),
+      = link_to "Remove", admin_collaborator_deletion_path(collaborator, form_id: params[:form_id]),
                           method: :delete,
                           class: "remove-link text-danger"
     - else
-      = link_to "Remove", account_collaborator_path(collaborator),
+      = link_to "Remove", admin_collaborator_deletion_path(collaborator),
                           method: :delete,
                           class: "remove-link text-danger"
   p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,6 +260,9 @@ Rails.application.routes.draw do
         post :scan_via_debounce_api
       end
     end
+
+    resources :collaborator_deletion, only: [:destroy]
+
     resources :assessors do
       member do
         get :confirm_activate


### PR DESCRIPTION
## 📝 A short description of the changes

* Previously, admins were encountering an authorisation error when trying to delete collaborators
* This creates a new controller for admins deleting collaborators
* Some logic is shared with previous destroy method so this has been moved to a service 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207254172513031/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

