### PR TITLE
Progress halt accessibility tweaks

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -1044,6 +1044,15 @@ $(document).on 'change', '[data-question-haltable] .show-question input.govuk-in
       links.addClass('js-step-disabled')
       links.attr('inert', true)
 
+$(document).on 'keydown', '[data-question-haltable] .show-question input.govuk-input', (e) ->
+  if e.key == 'Tab' || e.keyCode == 9
+    e.preventDefault()
+
+    $(this).trigger('change')
+
+    setTimeout((() =>
+      focusNextElement()
+    ), 10)
 
 eachCons = (list, n, callback) ->
   return [] if n == 0
@@ -1055,3 +1064,15 @@ eachCons = (list, n, callback) ->
 
     callback.call(this, data)
     start += 1
+
+focusNextElement = ->
+  focussableElements = 'a:not([disabled]), button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([disabled])'
+  if document.activeElement and document.activeElement.form
+    focussable = Array::filter.call(document.activeElement.form.querySelectorAll(focussableElements), (element) ->
+      element.offsetWidth > 0 or element.offsetHeight > 0 or element == document.activeElement
+    )
+
+    index = focussable.indexOf(document.activeElement)
+    if index > -1
+      nextElement = focussable[index + 1] or focussable[0]
+      nextElement.focus()

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -1016,7 +1016,7 @@ $(document).on 'change', '[data-question-haltable] .show-question input.govuk-in
   if !(values.includes(null))
     pairs = values.reduce (result, value, index, array) ->
       [first, second] = array.slice(index, index + 2)
-      if first && second
+      if (first != undefined && second != undefined)
         result.push([first, second])
 
       result

--- a/app/views/qae_form/_question_halted_alert.html.slim
+++ b/app/views/qae_form/_question_halted_alert.html.slim
@@ -3,7 +3,7 @@
 - value = local_assigns.dig(:value) || question
 - visible = local_assigns.dig(:visible)
 
-div class=class_names("govuk-error-summary govuk-error-summary--question-halted", "hide" => !visible) role="alert" data-module="govuk-error-summary" data-target="haltable" data-halt-state="visible" data-halt-class-value="hide"
+div class=class_names("govuk-error-summary govuk-error-summary--question-halted", "hide" => !visible) role="alert" tabindex="-1" data-module="govuk-error-summary" data-target="haltable" data-halt-state="visible" data-halt-class-value="hide"
   div class="govuk-warning-text"
     span class="govuk-warning-text__icon" aria-hidden="true"
       | !

--- a/app/views/qae_form/_question_halted_alert.html.slim
+++ b/app/views/qae_form/_question_halted_alert.html.slim
@@ -3,7 +3,7 @@
 - value = local_assigns.dig(:value) || question
 - visible = local_assigns.dig(:visible)
 
-div class=class_names("govuk-error-summary govuk-error-summary--question-halted", "govuk-visually-hidden" => !visible) data-module="govuk-error-summary" data-target="haltable" data-halt-state="visible" data-halt-class-value="govuk-visually-hidden"
+div class=class_names("govuk-error-summary govuk-error-summary--question-halted", "hide" => !visible) data-module="govuk-error-summary" data-target="haltable" data-halt-state="visible" data-halt-class-value="hide"
   div class="govuk-warning-text"
     span class="govuk-warning-text__icon" aria-hidden="true"
       | !

--- a/app/views/qae_form/_question_halted_alert.html.slim
+++ b/app/views/qae_form/_question_halted_alert.html.slim
@@ -3,7 +3,7 @@
 - value = local_assigns.dig(:value) || question
 - visible = local_assigns.dig(:visible)
 
-div class=class_names("govuk-error-summary govuk-error-summary--question-halted", "hide" => !visible) data-module="govuk-error-summary" data-target="haltable" data-halt-state="visible" data-halt-class-value="hide"
+div class=class_names("govuk-error-summary govuk-error-summary--question-halted", "hide" => !visible) role="alert" data-module="govuk-error-summary" data-target="haltable" data-halt-state="visible" data-halt-class-value="hide"
   div class="govuk-warning-text"
     span class="govuk-warning-text__icon" aria-hidden="true"
       | !

--- a/spec/features/users/progress_halted_spec.rb
+++ b/spec/features/users/progress_halted_spec.rb
@@ -51,7 +51,7 @@ describe "Progress halt" do
         click_button "Save and continue"
 
         within("div[data-question-key=\"overseas_sales\"] > .govuk-form-group > .if-js-hide") do
-          expect(page).not_to have_selector(".govuk-error-summary.govuk-visually-hidden")
+          expect(page).not_to have_selector(".govuk-error-summary.hide")
           expect(page).to have_selector(".govuk-error-summary.govuk-error-summary--question-halted", count: 1)
           expect(page).to have_selector(".govuk-error-summary .govuk-error-summary__title", text: "You do not meet the eligibility criteria for this award.")
           expect(page).to have_selector(".govuk-error-summary .govuk-error-summary__body", text: "Your total overseas sales are showing dips during the period of your entry. Therefore, you do not meet eligibility for the award and cannot proceed.")


### PR DESCRIPTION
## 📝 A short description of the changes

Related to #2831 

 - added `role="alert"` to warning box and it now can receive focus as well
 - fixed focus on elements hiding/showing via JS (previously elements which were shown via JS didn't receive focus and were skipped and and vice versa)
 - fixed case when typing zeroes into the input was interpreted as `false` and therefore the warning was not triggered

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/0/1207135606763717/f

## :shipit: Deployment implications

None

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

