### PR TITLE
Converts title input to a dropdown in contact details

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   extend Enumerize
 
   POSSIBLE_ROLES = %w(account_admin regular)
+  POSSIBLE_TITLES = %w(Mr Mrs Miss Ms Mx Dr Professor Reverend Sir Baron Baroness Dame Lady Lord)
 
   devise :database_authenticatable, :registerable,
     :recoverable, :trackable, :validatable, :confirmable,

--- a/app/views/admin/form_answers/company_details/_organisation_head_form.html.slim
+++ b/app/views/admin/form_answers/company_details/_organisation_head_form.html.slim
@@ -29,9 +29,11 @@
               .row
                 .col-md-2
                   = f.input :head_of_business_title,
-                            as: :string,
+                            as: :select,
                             label: "Title",
-                            input_html: { class: "form-control" }
+                            input_html: { class: "form-control" },
+                            collection: User::POSSIBLE_TITLES,
+                            include_blank: false
                 .col-md-3
                   = f.input :head_of_business_first_name,
                             as: :string,

--- a/app/views/admin/press_summaries/_contact_details_for_press_enquiries_since_2020.html.slim
+++ b/app/views/admin/press_summaries/_contact_details_for_press_enquiries_since_2020.html.slim
@@ -17,9 +17,11 @@
     .row
       .col-md-2
         = f.input :title,
-                  as: :string,
+                  as: :select,
                   label: "Title",
-                  input_html: { class: 'form-control' }
+                  input_html: { class: 'form-control' },
+                  collection: User::POSSIBLE_TITLES,
+                  include_blank: false
     .row
       .col-md-8
         = f.input :name,

--- a/app/views/qae_form/_sub_fields_question.html.slim
+++ b/app/views/qae_form/_sub_fields_question.html.slim
@@ -35,7 +35,7 @@ div role="group" id="#{question.key}"
           id=question.input_name(suffix: sub_field_key)
           aria-describedby=(@form_answer.validator_errors && @form_answer.validator_errors[question.hash_key] ? "error_for_#{sub_field_key}" : nil )
         ]
-          option value='' disabled=true selected=(!User::POSSIBLE_TITLES.include?(question.input_value(suffix: sub_field_key)))
+          option value='' disabled=true selected=(User::POSSIBLE_TITLES.exclude?(question.input_value(suffix: sub_field_key)))
             | Select a title
           - User::POSSIBLE_TITLES.each do |option|
             option value="#{option}" selected=((question.input_value(suffix: sub_field_key)).to_s == option.to_s)

--- a/app/views/qae_form/_sub_fields_question.html.slim
+++ b/app/views/qae_form/_sub_fields_question.html.slim
@@ -28,13 +28,27 @@ div role="group" id="#{question.key}"
 
       - klass <<(QaeFormBuilder::SubFieldsQuestionDecorator::NO_VALIDATION_SUB_FIELDS.exclude?(sub_field_key) ? " required" : " not-required")
 
-      input.govuk-input.js-trigger-autosave[
-        class=klass
-        type="text"
-        id=question.input_name(suffix: sub_field_key)
-        value=question.input_value(suffix: sub_field_key)
-        name=question.input_name(suffix: sub_field_key)
-        autocomplete="off" *possible_read_only_ops
-        data-word-max=question.sub_fields_words_max
-        aria-describedby=(@form_answer.validator_errors && @form_answer.validator_errors[question.hash_key] ? "error_for_#{sub_field_key}" : nil )
-      ]
+      - if sub_field_key == :title
+        select.govuk-select.js-trigger-autosave[
+          class=klass
+          name=question.input_name(suffix: sub_field_key)
+          id=question.input_name(suffix: sub_field_key)
+          aria-describedby=(@form_answer.validator_errors && @form_answer.validator_errors[question.hash_key] ? "error_for_#{sub_field_key}" : nil )
+        ]
+          option value='' disabled=true selected=(!User::POSSIBLE_TITLES.include?(question.input_value(suffix: sub_field_key)))
+            | Select a title
+          - User::POSSIBLE_TITLES.each do |option|
+            option value="#{option}" selected=((question.input_value(suffix: sub_field_key)).to_s == option.to_s)
+              = option
+
+      - else
+        input.govuk-input.js-trigger-autosave[
+          class=klass
+          type="text"
+          id=question.input_name(suffix: sub_field_key)
+          value=question.input_value(suffix: sub_field_key)
+          name=question.input_name(suffix: sub_field_key)
+          autocomplete="off" *possible_read_only_ops
+          data-word-max=question.sub_fields_words_max
+          aria-describedby=(@form_answer.validator_errors && @form_answer.validator_errors[question.hash_key] ? "error_for_#{sub_field_key}" : nil )
+        ]


### PR DESCRIPTION
## 📝 A short description of the changes

* For head of business and press contact details KAO wish to force the user to select from an approved list of titles. We first add the list as a constant to the User model in case we wish to validate User titles in the future.
* We add a condition to the sub_fields_question view to render a select if the :title sub_field_key is present.
* We add a placeholder which will be selected if the title is not found in the list. The placeholder option is disabled to prevent users selecting.
* We changed the input field for admin head of organisation and press contact details to a select and include a blank option for when the title is missing.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207337151195641

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="985" alt="Screenshot 2024-05-22 at 09 09 31" src="https://github.com/bitzesty/qae/assets/65811538/e81335ce-5161-4945-8f91-ce71358f2138">
<img width="943" alt="Screenshot 2024-05-22 at 09 10 06" src="https://github.com/bitzesty/qae/assets/65811538/c6451824-a752-4181-8697-dd153e1cde17">
<img width="890" alt="Screenshot 2024-05-22 at 09 10 36" src="https://github.com/bitzesty/qae/assets/65811538/c11280bd-b079-44cd-83ec-b85d3a3fab86">

