### PR TITLE
add draft id to application pdfs

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/draw_elements.rb
@@ -89,7 +89,7 @@ module QaePdfForms::General::DrawElements
     render_logo
     move_down 8.mm
     indent 32.mm do
-      render_urn if form_answer.urn.present? && pdf_blank_mode.blank?
+      render_urn if pdf_blank_mode.blank?
       render_award_information
       render_company_name unless pdf_blank_mode.present?
     end
@@ -172,7 +172,8 @@ module QaePdfForms::General::DrawElements
   end
 
   def render_urn
-    text form_answer.urn,
+    identification = form_answer.urn.presence || "Draft ID: #{form_answer.id}"
+    text identification,
       header_text_properties
   end
 


### PR DESCRIPTION
## 📝 A short description of the changes

* for applications without urn have the draft id displayed on pdf for the internal reference 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207307549494921/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="1072" alt="image" src="https://github.com/bitzesty/qae/assets/332810/e5f1161d-db32-4604-81f4-325c0aec7a14">
