### PR TITLE
Removes conditional for latest year end question

### DIFF
--- a/forms/award_years/v2025/innovation/innovation_step4.rb
+++ b/forms/award_years/v2025/innovation/innovation_step4.rb
@@ -26,8 +26,6 @@ class AwardYears::V2025::QaeForms
               Answer this question if your dates in question D1 range between #{Settings.current_award_year_switch_date.decorate.formatted_trigger_date} to #{Settings.current_submission_deadline.decorate.formatted_trigger_date}.
             </p>
           )
-
-          conditional :financial_year_date, :day_month_range, range: AwardYear.fy_date_range_threshold(minmax: true), disable_pdf_conditional_hints: true, data: { value: AwardYear.fy_date_range_threshold(minmax: true, format: true), type: :range }
         end
 
         options :financial_year_date_changed, "Did your year-end date change during your <span class='js-entry-period-subtext'>five</span> most recent financial years that you will be providing figures for?" do

--- a/forms/award_years/v2025/international_trade/international_trade_step4.rb
+++ b/forms/award_years/v2025/international_trade/international_trade_step4.rb
@@ -59,15 +59,12 @@ class AwardYears::V2025::QaeForms
           option (AwardYear.current.year - 2).to_s, (AwardYear.current.year - 2).to_s
           option (AwardYear.current.year - 1).to_s, (AwardYear.current.year - 1).to_s
           default_option (AwardYear.current.year - 1).to_s
-
           classes "js-most-recent-financial-year"
           context %(
             <p>
               Answer this question if your dates in question D2 range between #{Settings.current_award_year_switch_date.decorate.formatted_trigger_date} to #{Settings.current_submission_deadline.decorate.formatted_trigger_date}.
             </p>
           )
-
-          conditional :financial_year_date, :day_month_range, range: AwardYear.fy_date_range_threshold(minmax: true), data: { value: AwardYear.fy_date_range_threshold(minmax: true, format: true), type: :range }
         end
 
         options :financial_year_date_changed, "Did your year-end date change during your <span class='js-entry-period-subtext'>three or six</span>-year entry period that you will be providing figures for?" do


### PR DESCRIPTION
## 📝 A short description of the changes

* Removes conditional to always show the question to change the year end for Innovation and International Trade

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207364210379390

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="799" alt="Screenshot 2024-05-23 at 10 43 18" src="https://github.com/bitzesty/qae/assets/65811538/5788bfd1-b8cc-4004-87bb-bd93e0af7b92">
