### PR TITLE
Add default value for proportion on matrix question C5.1

### DIFF
--- a/forms/qae_form_builder/matrix_question.rb
+++ b/forms/qae_form_builder/matrix_question.rb
@@ -101,6 +101,7 @@ class QaeFormBuilder
       else
         disadvantaged = answers["#{question_key}_#{x_heading}_total_disadvantaged"].to_f
       end
+      disadvantaged ||= 0
       total = answers["#{question_key}_#{x_heading}_calculated_total"].to_f
       proportion = (disadvantaged.to_f / total * 100).round(2)
       answers["#{question_key}_#{x_heading}_calculated_proportion"] = proportion


### PR DESCRIPTION
## 📝 A short description of the changes

* Add default value for proportion on matrix question C5.1 otherwise error appears that input is blank

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207391396707926

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

