### PR TITLE
Set latest financial year after year end input

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -80,7 +80,7 @@ getLatestFinancialYearParts = () ->
   if (parseInt(fy_month, 10) == 9 && parseInt(fy_day, 10) >= 7) || parseInt(fy_month, 10) > 9
     fy_year = parseInt(fy_year, 10) - 1
 
-  if $(".js-most-recent-financial-year input:checked").val() && $(".js-most-recent-financial-year .js-conditional-question").hasClass("show-question")
+  if $(".js-most-recent-financial-year input:checked").val()
     fy_year = parseInt($(".js-most-recent-financial-year input:checked").val())
 
   return [fy_day, fy_month, fy_year]
@@ -328,7 +328,7 @@ jQuery ->
 
     # overriding financial year with the selected radio button value
     # also check if the question is visible
-    if $(".js-most-recent-financial-year input:checked").val() && $(".js-most-recent-financial-year .js-conditional-question").hasClass("show-question")
+    if $(".js-most-recent-financial-year input:checked").val()
       fy_year = parseInt($(".js-most-recent-financial-year input:checked").val())
 
     # Updates the latest changed financial year input
@@ -350,7 +350,22 @@ jQuery ->
     # We should change the last year date regardless if it's present or not
     fy_latest_changed_input.find("input.js-fy-year").val(fy_year)
 
-    updateYearEnd()
+    # If the latest financial year is not set, we set it
+    if $('input:radio[name="form\\[most_recent_financial_year\\]"]:checked').size() == 0
+    # If day and month entered are valid, we set the latest financial year
+      fy_date = new Date(fy_year + "-" + fy_month + "-" + fy_day)
+      if fy_date instanceof Date && !isNaN(fy_date.getTime())
+        setDefaultRecentFinancialYear()
+        updateYearEnd()
+
+  # Update the recent financial year end
+  setDefaultRecentFinancialYear = () ->
+    [fy_day, fy_month, fy_year] = getLatestFinancialYearParts()
+    $(".js-most-recent-financial-year-options input").each ->
+      if $(this).val() == fy_year.toString()
+        $(this).prop("checked", true)
+      else
+        $(this).prop("checked", false)
 
   # Update the financial year labels
   updateYearEnd = () ->

--- a/app/views/qae_form/_trade_most_recent_financial_year_options_question.html.slim
+++ b/app/views/qae_form/_trade_most_recent_financial_year_options_question.html.slim
@@ -5,7 +5,7 @@
   .govuk-radios
     - for answer in question.options do
       .govuk-radios__item
-        input.js-trigger-autosave.govuk-radios__input type="radio" id="#{question.input_name}_#{answer.value.to_s.parameterize}" name=question.input_name value=answer.value checked=(answer.value.to_s == (question.input_value || '').to_s || (question.input_value.blank? && question.default_option.to_s == answer.value.to_s)) aria-describedby="#{question.input_name}_#{answer.value.to_s.parameterize}_hint" *possible_read_only_ops
+        input.js-trigger-autosave.govuk-radios__input type="radio" id="#{question.input_name}_#{answer.value.to_s.parameterize}" name=question.input_name value=answer.value checked=(answer.value.to_s == (question.input_value || '').to_s) aria-describedby="#{question.input_name}_#{answer.value.to_s.parameterize}_hint" *possible_read_only_ops
         label.govuk-label.govuk-radios__label for="#{question.input_name}_#{answer.value.to_s.parameterize}"
           = answer.text.html_safe
         span.question-context id="#{question.input_name}_#{answer.value.to_s.parameterize}_hint"

--- a/forms/award_years/v2025/innovation/innovation_step4.rb
+++ b/forms/award_years/v2025/innovation/innovation_step4.rb
@@ -18,14 +18,7 @@ class AwardYears::V2025::QaeForms
           required
           option (AwardYear.current.year - 2).to_s, (AwardYear.current.year - 2).to_s
           option (AwardYear.current.year - 1).to_s, (AwardYear.current.year - 1).to_s
-          default_option (AwardYear.current.year - 1).to_s
-
           classes "js-most-recent-financial-year fs-trackable fs-two-trackable"
-          context %(
-            <p>
-              Answer this question if your dates in question D1 range between #{Settings.current_award_year_switch_date.decorate.formatted_trigger_date} to #{Settings.current_submission_deadline.decorate.formatted_trigger_date}.
-            </p>
-          )
         end
 
         options :financial_year_date_changed, "Did your year-end date change during your <span class='js-entry-period-subtext'>five</span> most recent financial years that you will be providing figures for?" do

--- a/forms/award_years/v2025/international_trade/international_trade_step4.rb
+++ b/forms/award_years/v2025/international_trade/international_trade_step4.rb
@@ -58,13 +58,7 @@ class AwardYears::V2025::QaeForms
           required
           option (AwardYear.current.year - 2).to_s, (AwardYear.current.year - 2).to_s
           option (AwardYear.current.year - 1).to_s, (AwardYear.current.year - 1).to_s
-          default_option (AwardYear.current.year - 1).to_s
           classes "js-most-recent-financial-year"
-          context %(
-            <p>
-              Answer this question if your dates in question D2 range between #{Settings.current_award_year_switch_date.decorate.formatted_trigger_date} to #{Settings.current_submission_deadline.decorate.formatted_trigger_date}.
-            </p>
-          )
         end
 
         options :financial_year_date_changed, "Did your year-end date change during your <span class='js-entry-period-subtext'>three or six</span>-year entry period that you will be providing figures for?" do


### PR DESCRIPTION
## 📝 A short description of the changes

* Removes check to see if the question is visible - the condition has been removed so this question will always be visible and will not have the `show-question` class
* Removes the default value for the radio buttons for the latest financial year. This is set when the user enters a valid date in the year end question and is not overwritten if the user changes the financial year end date. The year ends for future questions are then set if the year end has been set. The user can still update these dates by changing the input for the latest financial year question.
* Removes help copy as this question will always be visible.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207364210379410/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="815" alt="Screenshot 2024-05-24 at 09 50 23" src="https://github.com/bitzesty/qae/assets/65811538/da45413f-7007-4e92-9533-3aead8cd1430">

