### PR TITLE
Accessibility fixes on recent features added

### DIFF
--- a/app/assets/javascripts/admin/form_answers.js.coffee
+++ b/app/assets/javascripts/admin/form_answers.js.coffee
@@ -38,7 +38,6 @@ ready = ->
     $(".attachment-link", wrapper).prepend("<span class='btn-title'>Attach document</span>")
     $(".attachment-link", wrapper).prepend("<span class='glyphicon glyphicon-paperclip'></span>")
     $(".attachment-link", wrapper).prependTo("#new_commercial_figures_file")
-
     toggleCommercialFiguresButtonVisibility()
 
     wrapper = $("#audit-certificate-form")
@@ -50,68 +49,9 @@ ready = ->
 
   toggleCommercialFiguresButtonVisibility = ->
     if ($('.commercial-figures-file').length == 0)
-      $('#commercial-figures-attachment-form').removeClass('visuallyhidden')
+      $('#commercial-figures-attachment-form').removeClass('hide')
     else
-      $('#commercial-figures-attachment-form').addClass('visuallyhidden')
-
-  $(".edit-review-audit").on "click", (e) ->
-    $(".save-review-audit").show()
-
-  $(".section-applicant-status").on "click", "a", (e) ->
-    e.preventDefault()
-    state = $(this).data("state")
-    form = $("#new_form_answer_state_transition")
-    form.find("option[value='#{state}']").prop("selected", true)
-    $(".section-applicant-status .dropdown-toggle").html($(this).data("label"))
-    form.submit()
-
-  $("#new_form_answer_state_transition").on "ajax:success", (e, data, status, xhr) ->
-    $(".section-applicant-status .dropdown-menu").replaceWith(data)
-    if data == ""
-      stateToggle = $(".section-applicant-status .dropdown-toggle")
-      stateToggle.replaceWith("<p class='p-lg'>"+stateToggle.text()+"</p>")
-
-  $('.custom-select').each ->
-    field = $(this)[0]
-    if $(this).is(':disabled') or $(this).is('[readonly]')
-      return
-    accessibleAutocomplete.enhanceSelectElement
-      selectElement: field
-      showAllValues: true
-      dropdownArrow: ->
-        '<span class=\'autocomplete__arrow\'></span>'
-    return
-
-  $(".section-applicant-users form").on "ajax:success", (e, data, status, xhr) ->
-    panel = this.closest(".form-group")
-
-    removeExistingErrorMessages(panel)
-
-    $(this).closest(".form-group").removeClass("form-edit")
-    formValueBox = $(this).closest(".form-group").find(".edit-value")
-    selected = $(this).find("select :selected")
-
-
-    if (selected.val() == "")
-      formValueBox.html("<span class='p-empty'>Not assigned</span>")
-      message = "Assessor has been unassigned"
-    else
-      assessor = selected.text()
-      formValueBox.text(assessor)
-      message = "#{assessor} has been assigned"
-
-    panel.insertAdjacentHTML('afterbegin', buildBannerHtml(message, 'success'))
-
-  $(".section-applicant-users form").on "ajax:error", (e, data, status, xhr) ->
-    errors = data.responseJSON['errors']
-    panel = this.closest('.form-group')
-
-    removeExistingErrorMessages(panel)
-
-    Object.entries(errors).forEach ([key, values]) ->
-      field = panel.querySelector("[id$=#{key}]")
-      if field and shouldValidateField(field)
-        showErrorForInvalidField(field, values, '.form-group')
+      $('#commercial-figures-attachment-form').addClass('hide')
 
   $("#new_form_answer_attachment").on "fileuploadsubmit", (e, data) ->
     data.formData =
@@ -146,7 +86,7 @@ ready = ->
             moveAttachDocumentButton()
           else
             section = $(form).closest("#commercial-figures-section")
-            section.find(".document-list .p-empty").addClass("visuallyhidden")
+            section.find(".document-list .p-empty").addClass("hide")
             section.find(".document-list ul").append(result.text())
 
           window.fire(form, 'ajax:x:success', null)
@@ -173,8 +113,8 @@ ready = ->
 
     form.parents('.commercial-figures-file').remove()
     if $('.commercial-figures-file').length == 0
-      section.find(".document-list .p-empty").removeClass("visuallyhidden")
-      $('#commercial-figures-attachment-form').toggleClass('visuallyhidden', $('.commercial-figures-file').length != 0)
+      section.find(".document-list .p-empty").removeClass("hide")
+      $('#commercial-figures-attachment-form').toggleClass('hide', $('.commercial-figures-file').length != 0)
       initializeFileUpload()
 
     toggleCommercialFiguresButtonVisibility()
@@ -200,7 +140,7 @@ ready = ->
             initializeFileUpload()
           else
             section = $(form).closest("#vat-returns-section")
-            section.find(".document-list .p-empty").addClass("visuallyhidden")
+            section.find(".document-list .p-empty").addClass("hide")
             section.find(".document-list ul").append(result.text())
 
           window.fire(form, 'ajax:x:success', null)
@@ -226,7 +166,7 @@ ready = ->
 
     form.parents('.vat-returns-file').remove()
     if $('.vat-returns-file').length == 0
-      section.find(".document-list .p-empty").removeClass("visuallyhidden")
+      section.find(".document-list .p-empty").removeClass("hide")
       $('#shortlisted-documents-status').attr('data-status-reversible', 'false')
     else
       $('#shortlisted-documents-status').attr('data-status-reversible', 'true')
@@ -267,7 +207,7 @@ ready = ->
             initializeFileUpload()
           else
             sidebarSection = $(form).closest(".sidebar-section")
-            sidebarSection.find(".document-list .p-empty").addClass("visuallyhidden")
+            sidebarSection.find(".document-list .p-empty").addClass("hide")
             sidebarSection.find(".document-list ul").append(result.text())
             sidebarSection.removeClass("show-attachment-form")
             $("#form_answer_attachment_title").val(null)
@@ -331,8 +271,67 @@ ready = ->
       type: 'DELETE'
     window.fire(form[0], 'ajax:x:success', null)
     form.parents('.form_answer_attachment').remove()
-    if $('.form_answer_attachment').length == 0
-      sidebarSection.find(".document-list .p-empty").removeClass("visuallyhidden")
+    if sidebarSection.find('.form_answer_attachment').length == 0
+      sidebarSection.find(".document-list .p-empty").removeClass("hide")
+
+  $(".edit-review-audit").on "click", (e) ->
+    $(".save-review-audit").show()
+
+  $(".section-applicant-status").on "click", "a", (e) ->
+    e.preventDefault()
+    state = $(this).data("state")
+    form = $("#new_form_answer_state_transition")
+    form.find("option[value='#{state}']").prop("selected", true)
+    $(".section-applicant-status .dropdown-toggle").html($(this).data("label"))
+    form.submit()
+
+  $("#new_form_answer_state_transition").on "ajax:success", (e, data, status, xhr) ->
+    $(".section-applicant-status .dropdown-menu").replaceWith(data)
+    if data == ""
+      stateToggle = $(".section-applicant-status .dropdown-toggle")
+      stateToggle.replaceWith("<p class='p-lg'>"+stateToggle.text()+"</p>")
+
+  $('.custom-select').each ->
+    field = $(this)[0]
+    if $(this).is(':disabled') or $(this).is('[readonly]')
+      return
+    accessibleAutocomplete.enhanceSelectElement
+      selectElement: field
+      showAllValues: true
+      dropdownArrow: ->
+        '<span class=\'autocomplete__arrow\'></span>'
+    return
+
+  $(".section-applicant-users form").on "ajax:success", (e, data, status, xhr) ->
+    panel = this.closest(".form-group")
+
+    removeExistingErrorMessages(panel)
+
+    $(this).closest(".form-group").removeClass("form-edit")
+    formValueBox = $(this).closest(".form-group").find(".edit-value")
+    selected = $(this).find("select :selected")
+
+
+    if (selected.val() == "")
+      formValueBox.html("<span class='p-empty'>Not assigned</span>")
+      message = "Assessor has been unassigned"
+    else
+      assessor = selected.text()
+      formValueBox.text(assessor)
+      message = "#{assessor} has been assigned"
+
+    panel.insertAdjacentHTML('afterbegin', buildBannerHtml(message, 'success'))
+
+  $(".section-applicant-users form").on "ajax:error", (e, data, status, xhr) ->
+    errors = data.responseJSON['errors']
+    panel = this.closest('.form-group')
+
+    removeExistingErrorMessages(panel)
+
+    Object.entries(errors).forEach ([key, values]) ->
+      field = panel.querySelector("[id$=#{key}]")
+      if field and shouldValidateField(field)
+        showErrorForInvalidField(field, values, '.form-group')
 
   $(document).on 'click', '.form-edit-link', (e) ->
     e.preventDefault()

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -830,220 +830,7 @@ jQuery ->
   $(document).debounce "change", "textarea.js-trigger-autosave", triggerAutosave, debounceTime, raiseChangesFlag
   $(document).debounce "focusout", ".js-trigger-autosave", triggerAutosave, debounceTime, raiseChangesFlag
 
-  updateUploadListVisiblity = (list, button, max) ->
-    list_elements = list.find("li")
-    count = list_elements.length
-    wrapper = button.closest('div.js-upload-wrapper')
-
-    if count > 0
-      list.removeClass("visuallyhidden")
-
-    if !max || count < max
-      button.each ->
-        $(this).removeClass("visuallyhidden")
-
-    else
-      button.each ->
-        $(this).addClass("visuallyhidden")
-
-  reindexUploadListInputs = (list) ->
-    idx = 0
-    list.find("li").each (i, li) ->
-      process_input = (j, input_el) ->
-        name = $(input_el).attr("name")
-        match = /([^\[]+)\[([^\]]+)\]\[([0-9]*)\](.*)/.exec name
-        if match
-          $(input_el).attr("name", "#{match[1]}[#{match[2]}][#{idx}]#{match[4]}")
-
-      $(li).find("input").each process_input
-      $(li).find("textarea").each process_input
-      idx++
-
-  appendRemoveLinkForWebsiteLink = (div) ->
-    remove_link = $("<a>").addClass("remove-link govuk-button govuk-button--warning remove-website").prop("href", "#").text("Remove")
-    div.append(remove_link)
-
-  appendRemoveLinkForAttachment = (div, wrapper, data) ->
-    attachment_id = data.result['id']
-    form_answer_id = data.result['form_answer_id']
-    list_namespace = wrapper.attr("data-list-namespace")
-    destroy_url = "/form/form_answers/" + form_answer_id + "/" + list_namespace + "/" + attachment_id
-
-    remove_link = $("<a>").addClass("remove-link govuk-button govuk-button--warning")
-                          .prop("href", destroy_url)
-                          .attr("data-method", "delete")
-                          .attr("data-remote", "true")
-                          .text("Remove")
-    div.append(remove_link)
-
   govuk_buttons = $( ".website-document-btns" )
-
-  $('.js-file-upload').each (idx, el) ->
-    form = $(el).closest('form')
-    attachments_url = form.data 'attachments-url'
-    $el = $(el)
-
-    wrapper = $el.closest('div.js-upload-wrapper')
-    button = wrapper.find(".js-button-add")
-    list = wrapper.find('.js-uploaded-list')
-
-    max = wrapper.data('max-attachments')
-    name = wrapper.data('name')
-    form_name = wrapper.data('form-name')
-    needs_description = !!wrapper.data('description')
-    has_filename = !!wrapper.data('filename')
-    is_link = !!$el.data('add-link')
-
-    govuk_button = $(el).closest('.govuk-button')
-
-    #  Searching for inputs only excludes 'Add website address' button
-    if $(el).is("input")
-      $el.on "focus", ->
-        button.addClass("onfocus")
-        govuk_button.removeClass('govuk-button govuk-button--secondary')
-        govuk_button.addClass('upload-focus')
-
-      $el.on "blur", ->
-        button.removeClass("onfocus")
-        govuk_button.addClass('govuk-button govuk-button--secondary')
-        govuk_button.removeClass('upload-focus')
-
-    progress_all = (e, data) ->
-      # TODO
-
-    upload_started = (e, data) ->
-      # Show `Uploading...`
-      govuk_button.addClass("visuallyhidden")
-      new_el = $("<li class='js-uploading'>")
-      div = $("<div>")
-      uid = '_' + Math.random().toString(36).substr(2, 9);
-      label = $("<label class='govuk-label' for='#{uid}'>").text("Uploading...")
-      div.append(label)
-      new_el.append(div)
-      list.append(new_el)
-      list.removeClass("visuallyhidden")
-      wrapper.removeClass("govuk-form-group--error")
-      wrapper.find(".govuk-error-message").empty()
-
-    success_or_error = (e, data) ->
-      errors = data.result.errors
-
-      if errors
-        failed(errors.toString())
-      else
-        upload_done(e, data)
-
-    failed = (error_message) ->
-      if error_message
-        wrapper.addClass("govuk-form-group--error")
-        wrapper.find(".govuk-error-message").html(error_message)
-
-      # Remove `Uploading...`
-      list.find(".js-uploading").remove()
-      list.removeClass("visuallyhidden")
-      govuk_button.removeClass("visuallyhidden")
-
-    upload_done = (e, data, link) ->
-      # Remove `Uploading...`
-      list.find(".js-uploading").remove()
-      list.addClass("visuallyhidden")
-      wrapper.removeClass("govuk-form-group--error")
-      wrapper.find(".govuk-error-message").empty()
-
-      # Show new upload
-      new_el = $("<li>")
-
-      if link
-        div = $("<div>")
-        uid = '_' + Math.random().toString(36).substr(2, 9);
-        label = $("<label class='govuk-label' for='#{uid}'>").text('Website address')
-        input = $("<input class=\"govuk-input js-trigger-autosave\" type=\"text\" id='#{uid}'>").prop('name', "#{form_name}[#{name}][][link]")
-        label.append("<br/>")
-        label.append(input)
-        appendRemoveLinkForWebsiteLink(div)
-        updateUploadListVisiblity(list, govuk_buttons, max)
-        div.append(label)
-        new_el.append(div)
-      else
-        new_el.addClass("js-file-uploaded")
-
-        if has_filename
-          filename = wrapper.data('filename')
-        else
-          if data.result['original_filename']
-            filename = data.result['original_filename']
-          else
-            filename = "File uploaded"
-        div = $("<div><p class='govuk-body'>#{filename}</p></div>")
-
-        hidden_input = $("<input type='hidden' name='#{form_name}[#{name}][][file]' value='#{data.result['id']}' />")
-
-        div.append(hidden_input)
-        new_el.append(div)
-        appendRemoveLinkForAttachment(div, wrapper, data)
-
-      if needs_description
-        desc_div = $("<div>")
-        unique_name = "#{form_name}[#{name}][][description]"
-        label = ($("<label class='govuk-label'>").text("Description").attr("for", unique_name))
-        label.append($("<textarea class='govuk-textarea js-char-count js-trigger-autosave' rows='2' maxlength='600' data-word-max='100'>")
-             .attr("name", unique_name)
-             .attr("id", unique_name))
-        desc_div.append(label)
-        new_el.append(desc_div)
-
-      list.append(new_el)
-      new_el.find("textarea").val("")
-      new_el.find('.js-char-count').charcount()
-      list.removeClass('visuallyhidden')
-      updateUploadListVisiblity(list, govuk_button, max)
-      updateUploadListVisiblity(list, govuk_buttons, max)
-      reindexUploadListInputs(list)
-      new_el.find('input,textarea,select').filter(':visible').first().focus()
-
-    updateUploadListVisiblity(list, govuk_buttons, max)
-
-    if is_link
-      $el.click (e) ->
-        e.preventDefault()
-        if !$(this).hasClass("read-only")
-          upload_done(null, null, true)
-        false
-    else
-      $el.fileupload(
-        url: attachments_url + ".json"
-        forceIframeTransport: true
-        dataType: 'json'
-        formData: [
-          {
-            name: "authenticity_token",
-            value: $("meta[name='csrf-token']").attr("content")
-          },
-          {
-            name: "question_key",
-            value: $el.data("question-key")
-          }
-        ]
-        progressall: progress_all
-        send: upload_started
-        always: success_or_error
-      )
-
-  $(document).on "click", ".js-upload-wrapper .remove-link", (e) ->
-    e.preventDefault()
-
-    if !$(this).hasClass("read-only")
-      li = $(this).closest 'li'
-      list = li.closest(".js-uploaded-list")
-      wrapper = list.closest(".js-upload-wrapper")
-      button = wrapper.find(".button-add")
-      max = wrapper.data('max-attachments')
-
-      li.remove()
-      updateUploadListVisiblity(list, button, max)
-      reindexUploadListInputs(list)
-      triggerAutosave()
-      false
 
   # Show current holder info when they are a current holder on basic eligibility current holder question
   if $(".eligibility_current_holder").length > 0
@@ -1464,3 +1251,216 @@ jQuery ->
   #
   # Init WYSYWYG editor for QAE Form textareas - end
   #
+
+  appendRemoveLinkForWebsiteLink = (div) ->
+    remove_link = $("<a>").addClass("remove-link govuk-button govuk-button--warning remove-website").prop("href", "#").text("Remove")
+    div.append(remove_link)
+
+  appendRemoveLinkForAttachment = (div, wrapper, data) ->
+    attachment_id = data.result['id']
+    form_answer_id = data.result['form_answer_id']
+    list_namespace = wrapper.attr("data-list-namespace")
+    destroy_url = "/form/form_answers/" + form_answer_id + "/" + list_namespace + "/" + attachment_id
+
+    remove_link = $("<a>").addClass("remove-link govuk-button govuk-button--warning")
+                          .prop("href", destroy_url)
+                          .attr("data-method", "delete")
+                          .attr("data-remote", "true")
+                          .text("Remove")
+    div.append(remove_link)
+
+  updateUploadListVisiblity = (list, button, max) ->
+    list_elements = list.find("li")
+    count = list_elements.length
+    wrapper = button.closest('div.js-upload-wrapper')
+
+    if count > 0
+      list.removeClass("hide")
+
+    if !max || count < max
+      button.each ->
+        $(this).removeClass("hide")
+
+    else
+      button.each ->
+        $(this).addClass("hide")
+
+  reindexUploadListInputs = (list) ->
+    idx = 0
+    list.find("li").each (i, li) ->
+      process_input = (j, input_el) ->
+        name = $(input_el).attr("name")
+        match = /([^\[]+)\[([^\]]+)\]\[([0-9]*)\](.*)/.exec name
+        if match
+          $(input_el).attr("name", "#{match[1]}[#{match[2]}][#{idx}]#{match[4]}")
+
+      $(li).find("input").each process_input
+      $(li).find("textarea").each process_input
+      idx++
+
+  $('.js-file-upload').each (idx, el) ->
+    form = $(el).closest('form')
+    attachments_url = form.data 'attachments-url'
+    $el = $(el)
+
+    wrapper = $el.closest('div.js-upload-wrapper')
+    button = wrapper.find(".js-button-add")
+    list = wrapper.find('.js-uploaded-list')
+
+    max = wrapper.data('max-attachments')
+    name = wrapper.data('name')
+    form_name = wrapper.data('form-name')
+    needs_description = !!wrapper.data('description')
+    has_filename = !!wrapper.data('filename')
+    is_link = !!$el.data('add-link')
+
+    govuk_button = $(el).closest('.govuk-button')
+
+    #  Searching for inputs only excludes 'Add website address' button
+    if $(el).is("input")
+      $el.on "focus", ->
+        button.addClass("onfocus")
+        govuk_button.removeClass('govuk-button govuk-button--secondary')
+        govuk_button.addClass('upload-focus')
+
+      $el.on "blur", ->
+        button.removeClass("onfocus")
+        govuk_button.addClass('govuk-button govuk-button--secondary')
+        govuk_button.removeClass('upload-focus')
+
+    progress_all = (e, data) ->
+      # TODO
+
+    upload_started = (e, data) ->
+      # Show `Uploading...`
+      govuk_button.addClass("hide")
+      new_el = $("<li class='js-uploading'>")
+      div = $("<div>")
+      uid = '_' + Math.random().toString(36).substr(2, 9);
+      label = $("<label class='govuk-label' for='#{uid}'>").text("Uploading...")
+      div.append(label)
+      new_el.append(div)
+      list.append(new_el)
+      list.removeClass("hide")
+      wrapper.removeClass("govuk-form-group--error")
+      wrapper.find(".govuk-error-message").empty()
+
+    success_or_error = (e, data) ->
+      errors = data.result.errors
+
+      if errors
+        failed(errors.toString())
+      else
+        upload_done(e, data)
+
+    failed = (error_message) ->
+      if error_message
+        wrapper.addClass("govuk-form-group--error")
+        wrapper.find(".govuk-error-message").html(error_message)
+
+      # Remove `Uploading...`
+      list.find(".js-uploading").remove()
+      list.removeClass("hide")
+      govuk_button.removeClass("hide")
+
+    upload_done = (e, data, link) ->
+      # Remove `Uploading...`
+      list.find(".js-uploading").remove()
+      list.addClass("hide")
+      wrapper.removeClass("govuk-form-group--error")
+      wrapper.find(".govuk-error-message").empty()
+
+      # Show new upload
+      new_el = $("<li>")
+
+      if link
+        div = $("<div>")
+        uid = '_' + Math.random().toString(36).substr(2, 9);
+        label = $("<label class='govuk-label' for='#{uid}'>").text('Website address')
+        input = $("<input class=\"govuk-input js-trigger-autosave\" type=\"text\" id='#{uid}'>").prop('name', "#{form_name}[#{name}][][link]")
+        label.append("<br/>")
+        label.append(input)
+        appendRemoveLinkForWebsiteLink(div)
+        updateUploadListVisiblity(list, govuk_buttons, max)
+        div.append(label)
+        new_el.append(div)
+      else
+        new_el.addClass("js-file-uploaded")
+
+        if has_filename
+          filename = wrapper.data('filename')
+        else
+          if data.result['original_filename']
+            filename = data.result['original_filename']
+          else
+            filename = "File uploaded"
+        div = $("<div><p class='govuk-body'>#{filename}</p></div>")
+
+        hidden_input = $("<input type='hidden' name='#{form_name}[#{name}][][file]' value='#{data.result['id']}' />")
+
+        div.append(hidden_input)
+        new_el.append(div)
+        appendRemoveLinkForAttachment(div, wrapper, data)
+
+      if needs_description
+        desc_div = $("<div>")
+        unique_name = "#{form_name}[#{name}][][description]"
+        label = ($("<label class='govuk-label'>").text("Description").attr("for", unique_name))
+        label.append($("<textarea class='govuk-textarea js-char-count js-trigger-autosave' rows='2' maxlength='600' data-word-max='100'>")
+             .attr("name", unique_name)
+             .attr("id", unique_name))
+        desc_div.append(label)
+        new_el.append(desc_div)
+
+      list.append(new_el)
+      new_el.find("textarea").val("")
+      new_el.find('.js-char-count').charcount()
+      list.removeClass('hide')
+      updateUploadListVisiblity(list, govuk_button, max)
+      reindexUploadListInputs(list)
+      new_el.find('input,textarea,select').filter(':visible').first().focus()
+
+    updateUploadListVisiblity(list, govuk_buttons, max)
+
+    if is_link
+      $el.click (e) ->
+        e.preventDefault()
+        if !$(this).hasClass("read-only")
+          upload_done(null, null, true)
+        false
+    else
+      $el.fileupload(
+        url: attachments_url + ".json"
+        forceIframeTransport: true
+        dataType: 'json'
+        formData: [
+          {
+            name: "authenticity_token",
+            value: $("meta[name='csrf-token']").attr("content")
+          },
+          {
+            name: "question_key",
+            value: $el.data("question-key")
+          }
+        ]
+        progressall: progress_all
+        send: upload_started
+        always: success_or_error
+      )
+
+  $(document).on "click", ".js-upload-wrapper .remove-link", (e) ->
+    e.preventDefault()
+
+    if !$(this).hasClass("read-only")
+      li = $(this).closest 'li'
+      list = li.closest(".js-uploaded-list")
+      wrapper = list.closest(".js-upload-wrapper")
+      button = wrapper.find(".button-add")
+      max = wrapper.data('max-attachments')
+
+      li.remove()
+      updateUploadListVisiblity(list, button, max)
+      reindexUploadListInputs(list)
+      triggerAutosave()
+      false
+

--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -1152,5 +1152,5 @@ fieldset.account-contact-preferences-other-ops {
 
 .cke_wordcount span {
   font-size: 1.1875rem !important;
-  color: $grey-1 !important;
+  color: $grey-dark !important;
 }

--- a/app/assets/stylesheets/styleguide/_palette.scss
+++ b/app/assets/stylesheets/styleguide/_palette.scss
@@ -51,6 +51,7 @@ $light-blue-25: #d5e8f3;
 
 // Standard palette, greys
 $black: #0b0c0c;
+$grey-dark: #555;
 $grey-1: #6f777b;
 $grey-2: #bfc1c3;
 $grey-3: #dee0e2;

--- a/app/views/admin/figures_and_vat_returns/_actual_figures.html.slim
+++ b/app/views/admin/figures_and_vat_returns/_actual_figures.html.slim
@@ -3,8 +3,8 @@ label
 
 div[data-controller="inline-flash"]
   .document-list.space-y-3
-    p.p-empty class="#{'visuallyhidden' if figures_form.commercial_figures_file.present?}"
-      ' No document has been attached.
+    p.p-empty class="#{'hide' if figures_form.commercial_figures_file.present?}"
+      ' No variance explanation document has been attached.
     ul.list-unstyled.list-actions
       - if figures_form.commercial_figures_file.present?
         = render(partial: "admin/figures_and_vat_returns/file", collection: Array.wrap(figures_form.commercial_figures_file), as: :attachment)

--- a/app/views/admin/figures_and_vat_returns/_vat_returns.html.slim
+++ b/app/views/admin/figures_and_vat_returns/_vat_returns.html.slim
@@ -3,8 +3,8 @@ label
 
 div[data-controller="inline-flash"]
   .document-list.space-y-3
-    p.p-empty class="#{'visuallyhidden' if figures_form.vat_returns_files.any?}"
-      ' No documents have been attached.
+    p.p-empty class="#{'hide' if figures_form.vat_returns_files.any?}"
+      ' No financial documents have been attached.
     ul.list-unstyled.list-actions
       - if figures_form.vat_returns_files.any?
         = render(partial: "admin/figures_and_vat_returns/file", collection: figures_form.vat_returns_files, as: :attachment)

--- a/app/views/admin/form_answer_attachments/_form.html.slim
+++ b/app/views/admin/form_answer_attachments/_form.html.slim
@@ -14,7 +14,7 @@
           span[aria-hidden="true"] &times;
 
     .attachment-link.if-js-hide
-      = form.label :file, "Attach document", class: "visuallyhidden"
+      = form.label :file, "Attach document", class: "hide"
       = form.file_field :file
 
     .form-group

--- a/app/views/admin/form_answers/_section_documents.html.slim
+++ b/app/views/admin/form_answers/_section_documents.html.slim
@@ -61,8 +61,8 @@
       ' Other Docs
     div[data-controller="inline-flash"]
       .document-list
-        p.p-empty class="#{'visuallyhidden' if @form_answer.form_answer_attachments.uploaded_not_by_user.any?}"
-          ' No documents have been attached.
+        p.p-empty class="#{'hide' if @form_answer.form_answer_attachments.uploaded_not_by_user.any?}"
+          ' No other documents have been attached.
         - if @form_answer.form_answer_attachments.uploaded_not_by_user.any?
           ul.list-unstyled.list-actions
             = render(partial: "admin/form_answer_attachments/form_answer_attachment", collection: @form_answer.form_answer_attachments.uploaded_not_by_user.visible_for(current_subject))

--- a/app/views/qae_form/financial_summary/_development.html.slim
+++ b/app/views/qae_form/financial_summary/_development.html.slim
@@ -10,7 +10,7 @@ table.govuk-table.user-financial-summary-table.table-data
   thead
     tr.govuk-table__row.year-header data-type="fs-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Financial data entered
       th.govuk-table__header
         span.year
         span.legend
@@ -79,7 +79,7 @@ table.govuk-table.user-financial-summary-table.table-growth
   thead
     tr.govuk-table__row.year-header data-type="fs-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Total annual percentages
       th.govuk-table__header
         span.year
         span.legend
@@ -109,6 +109,14 @@ span.question-context.question-debug.govuk-hint
   | The table below displays the financial data calculated from the figures you have entered in question D4.1.
 
 table.govuk-table.user-financial-summary-table.table-summary class="govuk-!-width-two-thirds"
+  thead
+    tr.govuk-table__row.year-header data-type="fs-changed-dates"
+        th.govuk-table__header
+          span.visuallyhidden Overall turnover growth
+        th.govuk-table__header
+          span.year
+          span.legend
+            | Amount
   tbody
     tr.govuk-table__row
       td.govuk-table__cell.js-label-absolute-cell

--- a/app/views/qae_form/financial_summary/_innovation_part_1.html.slim
+++ b/app/views/qae_form/financial_summary/_innovation_part_1.html.slim
@@ -10,7 +10,7 @@ table.govuk-table.user-financial-summary-table.table-data
   thead
     tr.govuk-table__row.year-header data-type="fs-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Financial data entered
       th.govuk-table__header
         span.year
         span.legend
@@ -107,7 +107,7 @@ table.govuk-table.user-financial-summary-table.table-growth
   thead
     tr.govuk-table__row.year-header data-type="fs-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Tunover annual percentages
       th.govuk-table__header
         span.year
         span.legend
@@ -149,6 +149,14 @@ span.question-context.question-debug.govuk-hint
   | The table below displays the financial data calculated from the figures you have entered in question D4.1.
 
 table.govuk-table.user-financial-summary-table.table-summary class="govuk-!-width-two-thirds"
+  thead
+    tr.govuk-table__row.year-header data-type="fs-changed-dates"
+        th.govuk-table__header
+          span.visuallyhidden Overall turnover growth
+        th.govuk-table__header
+          span.year
+          span.legend
+            | Amount
   tbody
     tr.govuk-table__row
       td.govuk-table__cell.js-label-absolute-cell

--- a/app/views/qae_form/financial_summary/_innovation_part_2.html.slim
+++ b/app/views/qae_form/financial_summary/_innovation_part_2.html.slim
@@ -10,7 +10,7 @@ table.govuk-table.user-financial-summary-table.table-two-data
   thead
     tr.govuk-table__row.year-header data-type="fs-two-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Financial data entered
       th.govuk-table__header
         span.year
         span.legend

--- a/app/views/qae_form/financial_summary/_mobility.html.slim
+++ b/app/views/qae_form/financial_summary/_mobility.html.slim
@@ -10,7 +10,7 @@ table.govuk-table.user-financial-summary-table.table-data
   thead
     tr.govuk-table__row.year-header data-type="fs-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Financial data entered
       th.govuk-table__header
         span.year
         span.legend
@@ -61,7 +61,7 @@ table.govuk-table.user-financial-summary-table.table-growth
   thead
     tr.govuk-table__row.year-header data-type="fs-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Turnover annual percentages
       th.govuk-table__header
         span.year
         span.legend
@@ -91,6 +91,14 @@ span.question-context.question-debug.govuk-hint
   | The table below displays the financial data calculated from the figures you have entered in question D4.1.
 
 table.govuk-table.user-financial-summary-table.table-summary class="govuk-!-width-two-thirds"
+  thead
+    tr.govuk-table__row.year-header data-type="fs-changed-dates"
+        th.govuk-table__header
+          span.visuallyhidden Overall turnover growth
+        th.govuk-table__header
+          span.year
+          span.legend
+            | Amount
   tbody
     tr.govuk-table__row
       td.govuk-table__cell.js-label-absolute-cell

--- a/app/views/qae_form/financial_summary/_trade.html.slim
+++ b/app/views/qae_form/financial_summary/_trade.html.slim
@@ -10,7 +10,7 @@ table.govuk-table.user-financial-summary-table.table-data
   thead
     tr.govuk-table__row.year-header data-type="fs-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Financial data entered
       th.govuk-table__header
         span.year
         span.legend
@@ -92,7 +92,7 @@ table.govuk-table.user-financial-summary-table.table-growth
   thead
     tr.govuk-table__row.year-header data-type="fs-changed-dates"
       th.govuk-table__header
-        span.visuallyhidden Financial data type
+        span.visuallyhidden Overseas sales annual percentages
       th.govuk-table__header
         span.year
         span.legend
@@ -155,6 +155,14 @@ span.question-context.question-debug.govuk-hint
   | The table below displays the financial data calculated from the figures you have entered in question D5.1.
 
 table.govuk-table.user-financial-summary-table.table-summary class="govuk-!-width-two-thirds"
+  thead
+    tr.govuk-table__row.year-header data-type="fs-changed-dates"
+        th.govuk-table__header
+          span.visuallyhidden Overall overseas sales growth
+        th.govuk-table__header
+          span.year
+          span.legend
+            | Amount
   tbody
     tr.govuk-table__row
       td.govuk-table__cell.js-label-absolute-cell

--- a/spec/features/admin/form_answers/attachments_management_spec.rb
+++ b/spec/features/admin/form_answers/attachments_management_spec.rb
@@ -37,7 +37,7 @@ describe "Form answer attachments management", %q{
 
     it "destroys the attachment" do
       click_button "Remove"
-      expect(page).to have_content("No documents")
+      expect(page).to have_content("No other documents")
     end
   end
 


### PR DESCRIPTION
## 📝 A short description of the changes

* Where the `visuallyhidden` class was used for the text 'No documents attached', this was read by screen readers even when documents had been attached. These have been replaced with `hide` class which has `display: none` style.
* Improved messages to be more specific to the sidebar section
* Added a column header to the Overall Turnover Growth table. Also changed table headers to match the table headings.
* Changed word count text to a darker grey to fix contrast issue against grey background   

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207135606763709

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="803" alt="Screenshot 2024-05-24 at 11 24 42" src="https://github.com/bitzesty/qae/assets/65811538/755dd298-d35e-4095-8155-c382eb9348c9">
