### PR TITLE
Clears manual dates when latest yr end changes

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -367,6 +367,20 @@ jQuery ->
       else
         $(this).prop("checked", false)
 
+  clearManuallyEnteredYearEnds = () ->
+    console.log("clearManuallyEnteredYearEnds")
+    $(".js-financial-conditional > .by-years-wrapper").each ->
+      $(this).find(".js-year-end").each ->
+        fy_input = $(".js-financial-year-changed-dates .js-year-end[data-year=#{$(this).attr("data-year")}]").closest(".js-fy-entries").find(".govuk-date-input")
+        fy_day = fy_input.find(".js-fy-day").val("")
+        fy_month = fy_input.find(".js-fy-month").val("")
+        fy_year = fy_input.find(".js-fy-year").val("")
+
+  # Clear manually entered year ends when the most recent financial year is changed
+  $(".js-most-recent-financial-year-options input").each ->
+    $(this).change ->
+      clearManuallyEnteredYearEnds()
+
   # Update the financial year labels
   updateYearEnd = () ->
     base = $(".js-financial-conditional .js-year-end")
@@ -1478,4 +1492,3 @@ jQuery ->
       reindexUploadListInputs(list)
       triggerAutosave()
       false
-

--- a/forms/award_years/v2025/innovation/innovation_step4.rb
+++ b/forms/award_years/v2025/innovation/innovation_step4.rb
@@ -45,9 +45,6 @@ class AwardYears::V2025::QaeForms
             <p>
               We recommend that you answer question B5 before proceeding with this and further questions, as this will automatically adjust the number of years you need to provide the figures for.
             </p>
-            <p>
-              For the purpose of this application, your most recent financial year-end is your last financial year ending before the #{Settings.current_submission_deadline.decorate.formatted_trigger_date("with_year")} - the application submission deadline.
-            </p>
           )
 
           by_year_condition :started_trading, ->(v) { Utils::Date.within_range?(v, AwardYear.start_trading_between(2, 3)) }, 2, data: { value: AwardYear.start_trading_between(2, 3, minmax: true, format: true), type: :range, identifier: "2 to 3" }

--- a/forms/award_years/v2025/international_trade/international_trade_step4.rb
+++ b/forms/award_years/v2025/international_trade/international_trade_step4.rb
@@ -75,15 +75,7 @@ class AwardYears::V2025::QaeForms
           required
           type :date
           label ->(y) { "Financial year #{y}" }
-
-          context %(
-            <p>
-              For the purpose of this application, your most recent financial year-end is your last financial year ending before the #{Settings.current.deadlines.where(kind: "submission_end").first.decorate.formatted_trigger_date("with_year")} - the application submission deadline.
-            </p>
-          )
-
           additional_pdf_context I18n.t("pdf_texts.trade.years_question_additional_context")
-
           by_year_condition :trade_commercial_success, "3 to 5", 3
           by_year_condition :trade_commercial_success, "6 plus", 6
           conditional :trade_commercial_success, :true

--- a/forms/qae_form_builder/about_section_question.rb
+++ b/forms/qae_form_builder/about_section_question.rb
@@ -246,7 +246,6 @@ class QaeFormBuilder
         :header => "Periods the figures are required for",
         :context => [
           "We ask you to provide figures for your five most recent financial years. If you started trading within the last five years, you only need to provide figures for the years you have been trading. However, to meet minimum eligibility requirements, you must be able to provide figures for at least your two most recent financial years, covering the full 24 months.",
-          "For the purpose of this application, your most recent financial year is your last financial year ending before the #{Settings.current.deadlines.where(kind: "submission_end").first.decorate.formatted_trigger_date("with_year")} - the application submission deadline.",
         ],
       )
     end
@@ -256,7 +255,6 @@ class QaeFormBuilder
         :header => "Periods the figures are required for",
         :context => [
           "Depending on which award you are applying for, you must be able to provide financial figures for your three most recent financial years, covering exactly 36 consecutive months; or if you are applying for a 6-year award (see question D1), you must provide figures for the last six financial years, covering exactly 72 consecutive months.",
-          "For the purpose of this application, your most recent financial year is your last financial year ending before the #{Settings.current.deadlines.where(kind: "submission_end").first.decorate.formatted_trigger_date("with_year")} - the application submission deadline.",
           "If you have changed your year-end during the period of your application, see D2.3 for an explanation of how this must be dealt with.",
         ],
       )


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds listener on latest year end question to clear manually entered dates if the user has selected that their year end has changed.
* Removes help copy

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207397751341385

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
