### PR TITLE
Sets from and to variables for error method in RecentFinancialYearQuestion

### DIFF
--- a/forms/qae_form_builder/trade_most_recent_financial_year_options_question.rb
+++ b/forms/qae_form_builder/trade_most_recent_financial_year_options_question.rb
@@ -6,6 +6,8 @@ class QaeFormBuilder
       date, range = question.get_changeable_date_range
 
       if date.present? && range.present? && !date.in?(range) && question.year_has_changed?
+        from = Settings.current_award_year_switch_date
+        to = Settings.current_submission_deadline
         result[question.key] = "You can only change the year if your dates in question D2 range between #{from.decorate.formatted_trigger_date} to #{to.decorate.formatted_trigger_date}."
       end
 

--- a/forms/qae_form_builder/trade_most_recent_financial_year_options_question.rb
+++ b/forms/qae_form_builder/trade_most_recent_financial_year_options_question.rb
@@ -1,18 +1,5 @@
 class QaeFormBuilder
   class TradeMostRecentFinancialYearOptionsQuestionValidator < OptionsQuestionValidator
-    def errors
-      result = {}
-
-      date, range = question.get_changeable_date_range
-
-      if date.present? && range.present? && !date.in?(range) && question.year_has_changed?
-        from = Settings.current_award_year_switch_date
-        to = Settings.current_submission_deadline
-        result[question.key] = "You can only change the year if your dates in question D2 range between #{from.decorate.formatted_trigger_date} to #{to.decorate.formatted_trigger_date}."
-      end
-
-      result
-    end
   end
 
   class TradeMostRecentFinancialYearOptionsQuestionBuilder < OptionsQuestionBuilder

--- a/spec/fixtures/form_answer_innovation.json
+++ b/spec/fixtures/form_answer_innovation.json
@@ -212,5 +212,6 @@
 "head_job_title": "test",
 "head_email": "test",
 "strong_esg_record": "on",
-"major_issues_overcome": "test"
+"major_issues_overcome": "test",
+"most_recent_financial_year": "2024"
 }

--- a/spec/fixtures/form_answer_trade.json
+++ b/spec/fixtures/form_answer_trade.json
@@ -178,5 +178,6 @@
 "head_job_title": "test",
 "head_email": "test",
 "strong_esg_record": "on",
-"major_issues_overcome": "test"
+"major_issues_overcome": "test",
+"most_recent_financial_year": "2024"
 }


### PR DESCRIPTION
## 📝 A short description of the changes

* The application crashes when there is an error in the dates used in the `TradeMostRecentFinancialYearOptionsQuestionValidator `as the from and to variables are not set. This PR assigns the variables using the same basis as `year_changeable?` method.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207563441008172/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
