### PR TITLE
Error fixes

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -7,7 +7,7 @@ window.FormValidation =
     @validates = true
     $(".govuk-form-group--error").removeClass("govuk-form-group--error")
     $(".govuk-error-message").empty()
-    $(".steps-progress-bar .js-step-link").removeClass("step-errors")
+    $(".steps-progress-bar a.js-step-link").parent().removeClass("step-errors")
 
   clearErrors: (container) ->
     if container.closest(".question-financial").length > 0
@@ -190,7 +190,7 @@ window.FormValidation =
 
   addSubfieldError: (question, subquestion) ->
     questionRef = question.attr("data-question_ref")
-    input = $(subquestion).find('input,textarea,select').filter(':visible')
+    input = $(subquestion).find('input,textarea,select')
     if input.length
       label = @extractText(input.attr('id'))
       incompleteMessage = "Question #{questionRef} is incomplete. It is required and must be filled in."
@@ -954,6 +954,7 @@ window.FormValidation =
     stepContainer.find(".govuk-form-group--error").removeClass("govuk-form-group--error")
     stepContainer.find(".govuk-error-message").empty()
     $(".steps-progress-bar .js-step-link[data-step='" + currentStep + "']").removeClass("step-errors")
+    $("li, a", $(".steps-progress-bar .js-step-link[data-step='" + currentStep + "']")).removeClass("step-errors")
 
     for question in stepContainer.find(".question-block")
       question = $(question)


### PR DESCRIPTION
## 📝 A short description of the changes

* Corrects how 'step-errors' class is removed from side panel links to form sections, it was previously excluding links two-levels below elements with 'steps-progress-bar' class, so section C.1, C.2, C.3 links weren't targeted and the error icon persisted even after errors had been corrected

* Fixes missing errors for incomplete subfields on the initial render of the form. Previously, validation errors for hidden subfields were not displayed when navigating via the side panel links or the error summary links. These errors only became visible after navigating to another form section and then returning, this was because of `.filter(:visible)`, which excluded hidden elements from the validation process. 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/0/1207573828239723/f
* https://app.asana.com/0/1200504523179343/1207573828239725/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

