### PR TITLE
Disable form if user is associated with another account

### DIFF
--- a/app/interactors/add_collaborator.rb
+++ b/app/interactors/add_collaborator.rb
@@ -11,6 +11,7 @@ class AddCollaborator
   def initialize(current_user, account, params)
     @current_user = current_user
     @account = account
+    @readonly = false
     @params = params
     @email = params[:email]
     @collaborator = find_or_build_collaborator
@@ -34,6 +35,7 @@ class AddCollaborator
           @errors = ["This user already added to collaborators!"]
         elsif user.account.present?
           @errors = ["User already associated with another account!"]
+          @readonly = true
         end
 
         user.role = params[:role]
@@ -58,5 +60,9 @@ class AddCollaborator
 
   def valid?
     @errors.blank?
+  end
+
+  def readonly?
+    !!@readonly
   end
 end

--- a/app/views/account/collaborators/_form.html.slim
+++ b/app/views/account/collaborators/_form.html.slim
@@ -54,7 +54,7 @@
 
     p.govuk-button-group
       - if f.object.persisted?
-        = f.submit "Save collaborator details", class: "govuk-button"
+        = f.submit "Save collaborator details", class: "govuk-button", disabled: add_collaborator_interactor.readonly?
       - else
         = f.submit "Add the collaborator", class: "govuk-button"
       = link_to "Cancel", account_collaborators_path, class: "govuk-button govuk-button--secondary"


### PR DESCRIPTION
## 📝 A short description of the changes

If user is associated with another account, submit button should be disabled when error is shown. Currently it [resulted in an error](https://appsignal.com/bit-zesty/sites/601bfb8714ad665fb298effe/exceptions/incidents/3/samples/601bfb8714ad665fb298effe-432144119111663885217187067801) as when user tries to submit the form, the collaborator is not found. 

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1207287023679691/f

## :shipit: Deployment implications

None 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

