### PR TITLE
Changes to the collaborator form when collaborator already linked to another account

### DIFF
--- a/app/interactors/add_collaborator.rb
+++ b/app/interactors/add_collaborator.rb
@@ -30,10 +30,13 @@ class AddCollaborator
       user = User.find_by email: email
 
       if user.present?
+        @invalid = true
+
         if user.account_id == account.id
           @errors = ["This user already added to collaborators!"]
         elsif user.account.present?
-          @errors = ["User already associated with another account!"]
+          user = User.new(params)
+          user.errors.add(:email, "User already associated with another account")
         end
 
         user.role = params[:role]
@@ -57,6 +60,6 @@ class AddCollaborator
   end
 
   def valid?
-    @errors.blank?
+    @errors.blank? && !@invalid
   end
 end

--- a/app/interactors/add_collaborator.rb
+++ b/app/interactors/add_collaborator.rb
@@ -11,7 +11,6 @@ class AddCollaborator
   def initialize(current_user, account, params)
     @current_user = current_user
     @account = account
-    @readonly = false
     @params = params
     @email = params[:email]
     @collaborator = find_or_build_collaborator
@@ -35,7 +34,6 @@ class AddCollaborator
           @errors = ["This user already added to collaborators!"]
         elsif user.account.present?
           @errors = ["User already associated with another account!"]
-          @readonly = true
         end
 
         user.role = params[:role]
@@ -60,9 +58,5 @@ class AddCollaborator
 
   def valid?
     @errors.blank?
-  end
-
-  def readonly?
-    !!@readonly
   end
 end

--- a/app/views/account/collaborators/_form.html.slim
+++ b/app/views/account/collaborators/_form.html.slim
@@ -54,7 +54,7 @@
 
     p.govuk-button-group
       - if f.object.persisted?
-        = f.submit "Save collaborator details", class: "govuk-button", disabled: add_collaborator_interactor.readonly?
+        = f.submit "Save collaborator details", class: "govuk-button"
       - else
         = f.submit "Add the collaborator", class: "govuk-button"
       = link_to "Cancel", account_collaborators_path, class: "govuk-button govuk-button--secondary"

--- a/spec/features/account/collaborators_spec.rb
+++ b/spec/features/account/collaborators_spec.rb
@@ -140,7 +140,38 @@ So that they can collaborate form answers
                 }
               end
 
-              expect_to_see "User already associated with another account!"
+              within(".collaborator_email") do
+                expect_to_see "User already associated with another account"
+              end
+            end
+
+            it "can add collaborator after changing the email" do
+              within("#new_collaborator") do
+                fill_in "Email", with: user_associated_with_another_account.email
+                choose("Admin and collaborator")
+
+                expect {
+                  click_on "Add the collaborator"
+                }.to_not change {
+                  account.reload.users.count
+                }
+              end
+
+              within(".collaborator_email") do
+                expect_to_see "User already associated with another account"
+              end
+
+              within("#new_collaborator") do
+                fill_in "Email", with: "valid@example.test"
+
+                expect {
+                  click_on "Add the collaborator"
+                }.to change {
+                  account.reload.users.count
+                }
+              end
+
+              expect_to_see "valid@example.test successfully added to Collaborators!"
             end
           end
 

--- a/spec/interactors/add_collaborator_spec.rb
+++ b/spec/interactors/add_collaborator_spec.rb
@@ -68,7 +68,7 @@ describe "Interactors::AddCollaborator" do
         .and not_change { MailDeliveryWorker.jobs.size }
 
       expect(account.reload.users.count).to be_eql 1
-      expect(add_collaborator_interactor.errors).to be_eql ["User already associated with another account!"]
+      expect(add_collaborator_interactor.collaborator.errors[:email]).to be_eql ["User already associated with another account"]
     end
   end
 


### PR DESCRIPTION
## 📝 A short description of the changes

If user is associated with another account, we now display error within email input but allows user to re-submit the form after changing the email.

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1207287023679691/f

## :shipit: Deployment implications

None 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

