### PR TITLE
Reference (nickname) field mandatory for Innovation & PO applications

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -44,6 +44,8 @@ class FormAnswer < ApplicationRecord
 
   BUSINESS_AWARD_TYPES = %w[trade innovation development mobility]
 
+  AWARD_TYPES_WITH_NICKNAME_REQUIRED = %w[innovation mobility]
+
   AWARD_TYPE_FULL_NAMES = {
     "trade" => "International Trade",
     "innovation" => "Innovation",
@@ -133,6 +135,7 @@ class FormAnswer < ApplicationRecord
     inclusion: {
       in: POSSIBLE_AWARDS,
     }
+  validates :nickname, presence: true, if: -> { award_type.in?(AWARD_TYPES_WITH_NICKNAME_REQUIRED) }
   validates :urn, uniqueness: { allow_blank: true } # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :sic_code, format: { with: SicCode::REGEX }, allow_blank: true
   validate :validate_answers

--- a/app/views/content_only/_award_nickname.html.slim
+++ b/app/views/content_only/_award_nickname.html.slim
@@ -1,3 +1,6 @@
+- is_nickname_required = award_type.in?(FormAnswer::AWARD_TYPES_WITH_NICKNAME_REQUIRED)
+- is_promotion = award_type == "promotion"
+
 .page-pre-eligibility
   h2.govuk-heading-l The Process
 
@@ -7,7 +10,7 @@
       ul.govuk-list.govuk-list--bullet
         li
           ' This is to ensure that your
-          - if award_type == "promotion"
+          - if is_promotion
             ' nominee
           - else
             ' organisation
@@ -25,7 +28,7 @@
     li
       p.govuk-body
         ' Submit your
-        - if award_type == "promotion"
+        - if is_promotion
           ' nomination
         - else
           ' application
@@ -36,15 +39,15 @@
           ' .
         li
           ' You can still edit submitted
-          - if award_type == "promotion"
+          - if is_promotion
             ' nominations
           - else
             ' applications
           ' up to this date.
 
-  - if award_type == "innovation"
+  - if is_nickname_required
     = render "content_only/award_nickname_block"
 
   p#get-started.get-started.group.govuk-body
-    - title = award_type == "innovation" ? "Save and start eligibility questionnaire" : "Start eligibility questionnaire"
+    - title = is_nickname_required ? "Save and start eligibility questionnaire" : "Start eligibility questionnaire"
     = submit_tag title, class: "govuk-button", rel: "external"

--- a/app/views/content_only/_award_nickname_block.html.slim
+++ b/app/views/content_only/_award_nickname_block.html.slim
@@ -2,11 +2,11 @@ br
 
 .govuk-form-group
   h2.govuk-label-wrapper
-    = label_tag :nickname, "Please choose a reference for this application (optional):", class: 'govuk-label govuk-label--l', for: 'award-nickname'
+    = label_tag :nickname, "Please choose a reference for this application:", class: 'govuk-label govuk-label--l', for: 'award-nickname'
 
   p.govuk-hint
     | If you have more than one innovation (and want them to be considered for an award), you will have to submit a separate application for each of them.
   p.govuk-hint
     | You can create a reference, for example, 'Fibre optic device' so that it helps you and your collaborators to distinguish between different innovation applications. It will appear on the Applications page. Once chosen, your reference is permanent.
 
-  = text_field_tag :nickname, "", autocomplete: "off", type: "text", class: "govuk-input govuk-!-width-two-thirds", id: 'award-nickname'
+  = text_field_tag :nickname, "", autocomplete: "off", required: true, type: "text", class: "govuk-input govuk-!-width-two-thirds", id: 'award-nickname'

--- a/app/views/content_only/apply_social_mobility_award.html.slim
+++ b/app/views/content_only/apply_social_mobility_award.html.slim
@@ -1,7 +1,6 @@
 h1.govuk-heading-xl Promoting Opportunity Award (through social mobility) Application
 
 .article-related-positioning-container
-  .article-container
-    article.group role="article"
-      = form_tag new_social_mobility_form_path, method: :get do
-        = render "award_nickname", award_type: "mobility"
+  article.group role="article"
+    = form_tag new_social_mobility_form_path, method: :get do
+      = render "award_nickname", award_type: "mobility"

--- a/spec/acceptance/steps/application_form_creation_steps.rb
+++ b/spec/acceptance/steps/application_form_creation_steps.rb
@@ -31,6 +31,7 @@ end
 step "I create innovation form" do
   step "I go to dashboard"
   click_link "New application", href: "/apply_innovation_award"
+  fill_in "nickname", with: "Innovation"
   click_button "Save and start eligibility questionnaire"
   click_link "Continue to eligibility questions"
   click_button "Continue" # eligibility step

--- a/spec/controllers/form_controller_spec.rb
+++ b/spec/controllers/form_controller_spec.rb
@@ -51,7 +51,21 @@ describe FormController do
 
   describe "#new_social_mobility_form" do
     it "allows to open mobility form" do
-      expect(get(:new_social_mobility_form)).to redirect_to(edit_form_url(FormAnswer.where(award_type: "mobility").last))
+      expect(get(:new_social_mobility_form, params: { nickname: "Promoting Opportunity" })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "mobility").last))
+    end
+
+    it "does not allow to create an application without nickname/reference field filled" do
+      expect { get(:new_social_mobility_form, params: { nickname: "" }) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe "#new_innovation_form" do
+    it "allows to open innovation form" do
+      expect(get(:new_innovation_form, params: { nickname: "Innovation" })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "innovation").last))
+    end
+
+    it "does not allow to create an application without nickname/reference field filled" do
+      expect { get(:new_innovation_form, params: { nickname: "" }) }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 
@@ -69,7 +83,7 @@ describe FormController do
 
     describe "#new_social_mobility_form" do
       it "allows to create an application if mobility deadline has past" do
-        expect(get(:new_social_mobility_form)).to redirect_to(edit_form_url(FormAnswer.where(award_type: "mobility").last))
+        expect(get(:new_social_mobility_form, params: { nickname: "Promoting Opportunity" })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "mobility").last))
       end
 
       it "does not allow to create an application if mobility start deadline has not past" do
@@ -91,7 +105,7 @@ describe FormController do
 
     describe "#new_innovation_form" do
       it "allows to create an application if innovation start deadline has past" do
-        expect(get(:new_innovation_form)).to redirect_to(edit_form_url(FormAnswer.where(award_type: "innovation").last))
+        expect(get(:new_innovation_form, params: { nickname: "Innovation" })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "innovation").last))
       end
 
       it "does not allow to create an application if innovation start deadline has not past" do

--- a/spec/factories/form_answer_factory.rb
+++ b/spec/factories/form_answer_factory.rb
@@ -51,6 +51,7 @@ FactoryBot.define do
 
     trait :innovation do
       award_type { "innovation" }
+      nickname { "Innovation" }
       document do
         FormAnswer::DocumentParser.parse_json_document(
           JSON.parse(
@@ -73,6 +74,7 @@ FactoryBot.define do
 
     trait :mobility do
       award_type { "mobility" }
+      nickname { "Promoting Opportunity" }
       document do
         FormAnswer::DocumentParser.parse_json_document(
           JSON.parse(

--- a/spec/features/users/eligibility_form_fulfillment_spec.rb
+++ b/spec/features/users/eligibility_form_fulfillment_spec.rb
@@ -43,7 +43,7 @@ describe "Eligibility forms" do
     it "process the eligibility form" do
       visit dashboard_path
       new_application("Innovation Award")
-      # fill_in("nickname", with: "innovation nick")
+      fill_in("nickname", with: "innovation nick")
       click_button("Save and start eligibility questionnaire")
       click_link("Continue to eligibility questions")
       form_choice(["Yes", "Yes", /Business/, /Product/, "Yes", "No", "Yes", "Yes", "Yes", "Yes"])


### PR DESCRIPTION
## 📝 A short description of the changes

Made reference (`nickname`) field mandatory for Innovation & PO applications. Adding `required` to the input should be enough for now along with backend validation and should work OK also without JS. 

Added also rake task to backfill reference (`nickname`) for applications where its missing.

To run the task use command `bundle exec rake form_answers:populate_nickname`

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179345/1207631171095194/f 

## :shipit: Deployment implications

None

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
![CleanShot 2024-06-21 at 17 35 21](https://github.com/bitzesty/qae/assets/13330910/589b65a3-6634-4ec1-a199-670e48985a42)

