### PR TITLE
Make form to submit via `post` instead of `get`

### DIFF
--- a/app/controllers/content_only_controller.rb
+++ b/app/controllers/content_only_controller.rb
@@ -39,6 +39,16 @@ class ContentOnlyController < ApplicationController
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
   # rubocop:disable Rails/LexicallyScopedActionFilter
+  before_action :build_form,
+    only: [
+      :apply_innovation_award,
+      :apply_international_trade_award,
+      :apply_sustainable_development_award,
+      :apply_social_mobility_award,
+    ]
+  # rubocop:enable Rails/LexicallyScopedActionFilter
+
+  # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :restrict_access_if_admin_in_read_only_mode!, only: [:dashboard]
   before_action :clean_flash, only: [:sign_up_complete]
   before_action :check_trade_count_limit, only: :apply_international_trade_award
@@ -89,6 +99,10 @@ class ContentOnlyController < ApplicationController
     current_account.form_answers
                    .where(award_year: target_award_year)
                    .order("award_type")
+  end
+
+  def build_form
+    @form_answer = current_account.form_answers.build
   end
 
   def get_current_form

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -62,19 +62,19 @@ class FormController < ApplicationController
   end
 
   def new_innovation_form
-    build_new_form("innovation")
+    build_new_form("innovation", "innovation")
   end
 
   def new_international_trade_form
-    build_new_form("trade")
+    build_new_form("trade", "international_trade")
   end
 
   def new_sustainable_development_form
-    build_new_form("development")
+    build_new_form("development", "sustainable_development")
   end
 
   def new_social_mobility_form
-    build_new_form("mobility")
+    build_new_form("mobility", "social_mobility")
   end
 
   def edit_form
@@ -272,18 +272,20 @@ class FormController < ApplicationController
     result
   end
 
-  def build_new_form(award_type)
-    form_answer = FormAnswer.create!(
-      user: current_user,
-      account: current_user.account,
-      award_type: award_type,
-      nickname: nickname,
-      document: {
-        company_name: current_user.company_name,
-      },
+  def build_new_form(award_type, partial_name)
+    @form_answer = current_user.account.form_answers.build(
+      permitted_params.merge(
+        award_type: award_type,
+        document: { company_name: current_user.company_name },
+        user: current_user,
+      ),
     )
 
-    redirect_to edit_form_url(form_answer)
+    if @form_answer.save
+      redirect_to edit_form_url(@form_answer)
+    else
+      render "content_only/apply_#{partial_name}_award", status: :unprocessable_entity
+    end
   end
 
   def set_form_answer
@@ -291,8 +293,8 @@ class FormController < ApplicationController
     @attachments = @form_answer.form_answer_attachments.index_by(&:id)
   end
 
-  def nickname
-    params[:nickname].presence
+  def permitted_params
+    params.fetch(:form_answer, {}).permit(:nickname)
   end
 
   def check_deadlines

--- a/app/views/content_only/_award_nickname.html.slim
+++ b/app/views/content_only/_award_nickname.html.slim
@@ -46,8 +46,25 @@
           ' up to this date.
 
   - if is_nickname_required
-    = render partial: "content_only/award_nickname_block", locals: { award_type: award_type }
+    = render partial: "content_only/award_nickname_block", locals: { award_type: award_type, f: f }
 
   p#get-started.get-started.group.govuk-body
     - title = is_nickname_required ? "Save and start eligibility questionnaire" : "Start eligibility questionnaire"
-    = submit_tag title, class: "govuk-button", rel: "external"
+    = f.submit title, class: "govuk-button"
+
+javascript:
+  setTimeout(() => {
+    const element = document.querySelector('.govuk-form-group--error')
+
+    if (element) {
+      const input = element.querySelector('[aria-invalid="true"]')
+      const scrollIntoViewOptions = { behavior: 'smooth', block: 'end', inline: 'nearest' }
+
+      if (input) {
+        input.focus()
+        input.scrollIntoView(scrollIntoViewOptions)
+      } else {
+        element.scrollIntoView(scrollIntoViewOptions)
+      }
+    }
+  }, '100')

--- a/app/views/content_only/_award_nickname_block.html.slim
+++ b/app/views/content_only/_award_nickname_block.html.slim
@@ -2,7 +2,7 @@ br
 
 .govuk-form-group
   h2.govuk-label-wrapper
-    = label_tag :nickname, "Please choose a reference for this application:", class: 'govuk-label govuk-label--l', for: 'award-nickname'
+    = label_tag :nickname, "Please choose a reference for this application:", class: "govuk-label govuk-label--l", for: "award-reference"
 
   - if local_assigns[:award_type] == "innovation"
     p.govuk-hint
@@ -15,4 +15,4 @@ br
     p.govuk-hint
       | Please create a reference. This will help you and your collaborators distinguish between different applications. Your reference will appear on the Applications page. Once chosen, it is permanent.
 
-  = text_field_tag :nickname, "", autocomplete: "off", required: true, aria: { required: true }, type: "text", class: "govuk-input govuk-!-width-two-thirds", id: 'award-nickname'
+  = f.input :nickname, required: true, label: false, input_html: { id: "award-reference", class: "govuk-input govuk-!-width-two-thirds", autocomplete: "off"}

--- a/app/views/content_only/apply_innovation_award.html.slim
+++ b/app/views/content_only/apply_innovation_award.html.slim
@@ -4,5 +4,5 @@ h1.govuk-heading-xl Innovation Award Application
 
 .article-related-positioning-container
   article.group role="article"
-    = form_tag new_innovation_form_path, method: :get do
-      = render "award_nickname", award_type: "innovation"
+    = simple_form_for @form_answer, url: new_innovation_form_path, html: { class: "qae-form" } do |f|
+      = render partial: "content_only/award_nickname", locals: { award_type: "innovation", f: f }

--- a/app/views/content_only/apply_international_trade_award.html.slim
+++ b/app/views/content_only/apply_international_trade_award.html.slim
@@ -3,5 +3,5 @@ h1.govuk-heading-xl International Trade Award Application
 .article-related-positioning-container
   .article-container
     article.group role="article"
-      = form_tag new_international_trade_form_path, method: :get do
-        = render "award_nickname", award_type: "trade"
+      = simple_form_for @form_answer, url: new_international_trade_form_path, html: { class: "qae-form" } do |f|
+        = render partial: "content_only/award_nickname", locals: { award_type: "trade", f: f }

--- a/app/views/content_only/apply_social_mobility_award.html.slim
+++ b/app/views/content_only/apply_social_mobility_award.html.slim
@@ -2,5 +2,5 @@ h1.govuk-heading-xl Promoting Opportunity Award (through social mobility) Applic
 
 .article-related-positioning-container
   article.group role="article"
-    = form_tag new_social_mobility_form_path, method: :get do
-      = render "award_nickname", award_type: "mobility"
+    = simple_form_for @form_answer, url: new_social_mobility_form_path, html: { class: "qae-form" } do |f|
+      = render partial: "content_only/award_nickname", locals: { award_type: "mobility", f: f }

--- a/app/views/content_only/apply_sustainable_development_award.html.slim
+++ b/app/views/content_only/apply_sustainable_development_award.html.slim
@@ -3,5 +3,5 @@ h1.govuk-heading-xl Sustainable Development Award Application
 .article-related-positioning-container
   .article-container
     article.group role="article"
-      = form_tag new_sustainable_development_form_path, method: :get do
-        = render "award_nickname", award_type: "development"
+      = simple_form_for @form_answer, url: new_sustainable_development_form_path, html: { class: "qae-form" } do |f|
+        = render partial: "content_only/award_nickname", locals: { award_type: "development", f: f }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,10 @@ en:
           attributes:
             position:
               blank: 'is empty - it is a required field and an option should be selected from the following list'
+        form_answer:
+          attributes:
+            nickname:
+              blank: Reference is required and must be filled in
 
   time:
     formats:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,10 +46,10 @@ Rails.application.routes.draw do
   get "/cookies" => "content_only#cookies", :as => "cookies"
   get "/accessibility-statement" => "content_only#accessibility_statement", :as => "accessibility_statement"
 
-  get "/new_innovation_form" => "form#new_innovation_form", :as => "new_innovation_form"
-  get "/new_international_trade_form" => "form#new_international_trade_form", :as => "new_international_trade_form"
-  get "/new_sustainable_development_form" => "form#new_sustainable_development_form", :as => "new_sustainable_development_form"
-  get "/new_social_mobility_form" => "form#new_social_mobility_form", :as => "new_social_mobility_form"
+  post "/new_innovation_form" => "form#new_innovation_form", :as => "new_innovation_form"
+  post "/new_international_trade_form" => "form#new_international_trade_form", :as => "new_international_trade_form"
+  post "/new_sustainable_development_form" => "form#new_sustainable_development_form", :as => "new_sustainable_development_form"
+  post "/new_social_mobility_form" => "form#new_social_mobility_form", :as => "new_social_mobility_form"
 
   get "/form/:id" => "form#edit_form", :as => "edit_form"
   post "/form/:id" => "form#save", :as => "save_form"

--- a/spec/acceptance/steps/application_form_creation_steps.rb
+++ b/spec/acceptance/steps/application_form_creation_steps.rb
@@ -31,7 +31,7 @@ end
 step "I create innovation form" do
   step "I go to dashboard"
   click_link "New application", href: "/apply_innovation_award"
-  fill_in "nickname", with: "Innovation"
+  fill_in "award-reference", with: "Innovation"
   click_button "Save and start eligibility questionnaire"
   click_link "Continue to eligibility questions"
   click_button "Continue" # eligibility step

--- a/spec/controllers/form_controller_spec.rb
+++ b/spec/controllers/form_controller_spec.rb
@@ -51,66 +51,74 @@ describe FormController do
 
   describe "#new_social_mobility_form" do
     it "allows to open mobility form" do
-      expect(get(:new_social_mobility_form, params: { nickname: "Promoting Opportunity" })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "mobility").last))
+      response = post(:new_social_mobility_form, params: { form_answer: { nickname: "Promoting Opportunity" } })
+
+      expect(response).not_to have_http_status(:unprocessable_entity)
+      expect(response).to redirect_to(edit_form_url(FormAnswer.where(award_type: "mobility").last))
     end
 
     it "does not allow to create an application without nickname/reference field filled" do
-      expect { get(:new_social_mobility_form, params: { nickname: "" }) }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(post(:new_social_mobility_form, params: { form_answer: { nickname: "" } })).to have_http_status(:unprocessable_entity)
     end
   end
 
   describe "#new_innovation_form" do
     it "allows to open innovation form" do
-      expect(get(:new_innovation_form, params: { nickname: "Innovation" })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "innovation").last))
+      response = post(:new_innovation_form, params: { form_answer: { nickname: "Innovation" } })
+
+      expect(response).not_to have_http_status(:unprocessable_entity)
+      expect(response).to redirect_to(edit_form_url(FormAnswer.where(award_type: "innovation").last))
     end
 
     it "does not allow to create an application without nickname/reference field filled" do
-      expect { get(:new_innovation_form, params: { nickname: "" }) }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(post(:new_innovation_form, params: { form_answer: { nickname: "" } })).to have_http_status(:unprocessable_entity)
     end
   end
 
   context "individual deadlines" do
     describe "#new_international_trade_form" do
       it "allows to create an application if trade start deadline has past" do
-        expect(get(:new_international_trade_form)).to redirect_to(edit_form_url(FormAnswer.where(award_type: "trade").last))
+        expect(post(:new_international_trade_form)).to redirect_to(edit_form_url(FormAnswer.where(award_type: "trade").last))
       end
 
       it "does not allow to create an application if trade start deadline has not past" do
         Settings.current.deadlines.trade_submission_start.update_column(:trigger_at, Time.zone.now + 1.day)
-        expect(get(:new_international_trade_form)).to redirect_to(dashboard_url)
+        expect(post(:new_international_trade_form)).to redirect_to(dashboard_url)
       end
     end
 
     describe "#new_social_mobility_form" do
       it "allows to create an application if mobility deadline has past" do
-        expect(get(:new_social_mobility_form, params: { nickname: "Promoting Opportunity" })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "mobility").last))
+        expect(post(:new_social_mobility_form, params: { form_answer: { nickname: "Promoting Opportunity" } })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "mobility").last))
       end
 
       it "does not allow to create an application if mobility start deadline has not past" do
         Settings.current.deadlines.mobility_submission_start.update_column(:trigger_at, Time.zone.now + 1.day)
-        expect(get(:new_social_mobility_form)).to redirect_to(dashboard_url)
+        expect(post(:new_social_mobility_form)).to redirect_to(dashboard_url)
       end
     end
 
     describe "#new_sustainable_development_form" do
       it "allows to create an application if trade development deadline has past" do
-        expect(get(:new_sustainable_development_form)).to redirect_to(edit_form_url(FormAnswer.where(award_type: "development").last))
+        expect(post(:new_sustainable_development_form)).to redirect_to(edit_form_url(FormAnswer.where(award_type: "development").last))
       end
 
       it "does not allow to create an application if development start deadline has not past" do
         Settings.current.deadlines.development_submission_start.update_column(:trigger_at, Time.zone.now + 1.day)
-        expect(get(:new_sustainable_development_form)).to redirect_to(dashboard_url)
+        expect(post(:new_sustainable_development_form)).to redirect_to(dashboard_url)
       end
     end
 
     describe "#new_innovation_form" do
       it "allows to create an application if innovation start deadline has past" do
-        expect(get(:new_innovation_form, params: { nickname: "Innovation" })).to redirect_to(edit_form_url(FormAnswer.where(award_type: "innovation").last))
+        response = post(:new_innovation_form, params: { form_answer: { nickname: "Innovation" } })
+
+        expect(response).to redirect_to(edit_form_url(FormAnswer.where(award_type: "innovation").last))
       end
 
       it "does not allow to create an application if innovation start deadline has not past" do
         Settings.current.deadlines.innovation_submission_start.update_column(:trigger_at, Time.zone.now + 1.day)
-        expect(get(:new_innovation_form)).to redirect_to(dashboard_url)
+        expect(post(:new_innovation_form)).to redirect_to(dashboard_url)
       end
     end
   end

--- a/spec/features/users/eligibility_form_fulfillment_spec.rb
+++ b/spec/features/users/eligibility_form_fulfillment_spec.rb
@@ -16,7 +16,7 @@ describe "Eligibility forms" do
     it "process the eligibility form", js: true do
       visit dashboard_path
       new_application("International Trade Award")
-      # fill_in("nickname", with: "trade nick")
+      # fill_in("award-reference", with: "trade nick")
       click_button("Start eligibility questionnaire")
       click_link("Continue to eligibility questions")
 
@@ -43,7 +43,7 @@ describe "Eligibility forms" do
     it "process the eligibility form" do
       visit dashboard_path
       new_application("Innovation Award")
-      fill_in("nickname", with: "innovation nick")
+      fill_in("award-reference", with: "innovation nick")
       click_button("Save and start eligibility questionnaire")
       click_link("Continue to eligibility questions")
       form_choice(["Yes", "Yes", /Business/, /Product/, "Yes", "No", "Yes", "Yes", "Yes", "Yes"])
@@ -63,7 +63,7 @@ describe "Eligibility forms" do
     it "process the eligibility form" do
       visit dashboard_path
       new_application("Sustainable Development Award")
-      # fill_in "nickname", with: "development nick"
+      # fill_in("award-reference", with: "development nick")
       click_button "Start eligibility questionnaire"
       click_link("Continue to eligibility questions")
       form_choice([


### PR DESCRIPTION
## 📝 A short description of the changes

When creating new application, originally the form was submitted via `get` method. In terms of validation we were relying on HTML5 built-in validations however the styles did not match the rest of the app. This changes that and form is now submitted via `post` method (error styles match rest of the application).

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179345/1207640920856071/f

## :shipit: Deployment implications

None 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

