### PR TITLE
Reject blank & null vallues when generating PDF styles

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/custom_questions/textarea.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/textarea.rb
@@ -241,7 +241,7 @@ module QaePdfForms::CustomQuestions::Textarea
       style_options = style_options[0].split(";").map(&:strip)
     end
 
-    style_options = Array.wrap(style_options)
+    style_options = Array.wrap(style_options).reject(&:blank?)
     styles = { inline_format: true, color: FormPdf::DEFAULT_ANSWER_COLOR }
 
     if style_options.present?


### PR DESCRIPTION
## 📝 A short description of the changes

Reject `blank` & `nil` values from being picked by PDF generator. 

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1207645684540462/f
AppSignal error here: https://appsignal.com/bit-zesty/sites/601bfb8714ad665fb298effe/exceptions/incidents/3606/samples/601bfb8714ad665fb298effe-664236946902935182917192454001

## :shipit: Deployment implications

Done 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

