### PR TITLE
Reference field error - add full stop to the message & center element

### DIFF
--- a/app/views/account/collaborators/_form.html.slim
+++ b/app/views/account/collaborators/_form.html.slim
@@ -65,7 +65,7 @@ javascript:
 
     if (element) {
       const input = element.querySelector('[aria-invalid="true"]')
-      const scrollIntoViewOptions = { behavior: 'smooth', block: 'end', inline: 'nearest' }
+      const scrollIntoViewOptions = { behavior: 'smooth', block: 'center', inline: 'nearest' }
 
       if (input) {
         input.focus()

--- a/app/views/content_only/_award_nickname.html.slim
+++ b/app/views/content_only/_award_nickname.html.slim
@@ -58,7 +58,7 @@ javascript:
 
     if (element) {
       const input = element.querySelector('[aria-invalid="true"]')
-      const scrollIntoViewOptions = { behavior: 'smooth', block: 'end', inline: 'nearest' }
+      const scrollIntoViewOptions = { behavior: 'smooth', block: 'center', inline: 'nearest' }
 
       if (input) {
         input.focus()

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,7 +108,7 @@ en:
         form_answer:
           attributes:
             nickname:
-              blank: Reference is required and must be filled in
+              blank: Reference is required and must be filled in.
 
   time:
     formats:


### PR DESCRIPTION
## 📝 A short description of the changes

Updated scroll function to center the element vertically in case of error.
Added full stop to the error message. 

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179345/1207640920856089/f

## :shipit: Deployment implications

None

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

