### PR TITLE
Downgrades ckeditor and disables version check

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -1249,6 +1249,7 @@ jQuery ->
         height: 200
         wordcount:
           maxWordCount: $(this).data('word-max')
+        versionCheck: false
 
       CKEDITOR.on 'instanceCreated', (event) ->
         editor = event.editor

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -1,3 +1,3 @@
 Ckeditor.setup do |config|
-  config.cdn_url = "//cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.js"
+  config.cdn_url = "//cdn.ckeditor.com/4.22.1/full/ckeditor.js"
 end


### PR DESCRIPTION
## 📝 A short description of the changes

* CKeditor version 5 is not loading so this PR downgrades back to the latest working version. This version shows a warning notification so we are disabling this warning so it does not show for users until we apply the major upgrade to v5

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207706056016995

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
