### PR TITLE
Bug fixes on award year filter for admin and assessor applications

### DIFF
--- a/app/assets/javascripts/admin/applications-filter.js.coffee
+++ b/app/assets/javascripts/admin/applications-filter.js.coffee
@@ -128,8 +128,14 @@ filterApplicationsDropdowns = () ->
     e.stopPropagation()
     # if other selected, show dropdown of years, otherwise get form answers for current year or all years
     if $(this).attr('id') == "other"
-      $(this).closest(".applications-filter").find(".other-years-dropdown").removeClass("hide")
+      dropdownWrapper = $(this).closest(".applications-filter").find(".other-years-dropdown")
+      dropdownWrapper.removeClass("hide")
+      dropdown = dropdownWrapper.find(".dropdown-toggle")
+      dropdown.focus().click()
     else
-      window.location = $(this).data('url')
+      search_query = $(this).closest(".new_search").find("#search_query").val()
+      url = new URL($(this).data('url'), document.baseURI)
+      url.searchParams.set('[search][query]', search_query)
+      window.location = url
 
 $(document).ready(ready)

--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -2002,6 +2002,7 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
 
 .award-year-radios {
   padding-left: 15px;
+  margin-top: pxToRem(20);
 }
 
 .award-year-container {

--- a/app/assets/stylesheets/admin/page-applications.scss
+++ b/app/assets/stylesheets/admin/page-applications.scss
@@ -33,6 +33,7 @@
   }
 
   .input__award-years {
+    min-height: pxToRem(33);
     display: inline-block;
 
     input {
@@ -46,6 +47,8 @@
     label {
       margin-right: pxToRem(20);
       font-weight: normal;
+      padding-bottom: pxToRem(1);
+      padding-top: pxToRem(4);
     }
 
     .dropdown {

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -518,7 +518,13 @@ class FormAnswerDecorator < ApplicationDecorator
   end
 
   def last_updated_by
-    latest_update && latest_update.subject.full_name
+    if latest_update
+      if latest_update.subject
+        latest_update.subject.full_name
+      else
+        "Deleted user"
+      end
+    end
   end
 
   private

--- a/app/views/shared/form_answers/_admin_award_year.html.slim
+++ b/app/views/shared/form_answers/_admin_award_year.html.slim
@@ -12,13 +12,13 @@ fieldset.award-year-z-index.applications-filter.award-year-radios
     input type="radio" id="all_years" name="year" value="all_years" data-url="#{url_for(params.permit(:controller, :action).merge(year: :all_years))}" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && !params[:year]))
     label for="all_years"
       | All years
-    input type="radio" id="other" name="year" value="other" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
+    input type="radio" id="other" name="year" value="#{selected_year}" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
     label for="other"
       | Other
 
     .dropdown.other-years-dropdown class="#{(current_year != selected_year && other_years.include?(params[:year].to_i) ? '' : 'hide')}"
       a.dropdown-toggle.btn.btn-block.btn-default href="#" data-toggle="dropdown" role="button" aria-expanded="false"
-        - current_year_text = params[:year].to_s == "all_years" || !params[:year] ? "All Years" : "#{selected_year - 1} - #{selected_year}"
+        - current_year_text = params[:year].to_s == "all_years" || !params[:year] || !other_years.include?(params[:year].to_i) ? "All Years" : "#{selected_year - 1} - #{selected_year}"
 
         = current_year_text
         span.caret-container

--- a/app/views/shared/form_answers/_admin_award_year.html.slim
+++ b/app/views/shared/form_answers/_admin_award_year.html.slim
@@ -6,10 +6,10 @@ fieldset.award-year-z-index.applications-filter.award-year-radios
   label.applications-filter__label
     ' Award year
   .input__award-years
-    input type="radio" id="current_year" name="year" value="#{current_year}" data-url="#{url_for(params.permit(:controller, :action).merge(year: current_year))}" checked=(current_year == params[:year].to_i || (namespace_name == :assessor && !params[:year]))
+    input type="radio" id="current_year" name="year" value="#{current_year}" data-url="#{url_for(params.permit(:controller, :action).merge(year: current_year, search: params[:search]))}" checked=(current_year == params[:year].to_i || (namespace_name == :assessor && !params[:year]))
     label for="current_year"
       | Current year
-    input type="radio" id="all_years" name="year" value="all_years" data-url="#{url_for(params.permit(:controller, :action).merge(year: :all_years))}" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && !params[:year]))
+    input type="radio" id="all_years" name="year" value="all_years" data-url="#{url_for(params.permit(:controller, :action).merge(year: :all_years, search: params[:search]))}" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && !params[:year]))
     label for="all_years"
       | All years
     input type="radio" id="other" name="year" value="#{selected_year}" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
@@ -25,8 +25,8 @@ fieldset.award-year-z-index.applications-filter.award-year-radios
           span.caret
       ul.dropdown-menu.dropdown-menu-right
         li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}"
-          = link_to "All Years", url_for(params.permit(:controller, :action).merge(year: :all_years))
+          = link_to "All Years", url_for(params.permit(:controller, :action).merge(year: :all_years, search: params[:search]))
 
         - AwardYear.admin_switch.each do |year, label|
           li class="#{'active' if label == current_year_text}"
-            = link_to label, url_for(params.permit(:controller, :action).merge(year: year))
+            = link_to label, url_for(params.permit(:controller, :action).merge(year: year, search: params[:search]))


### PR DESCRIPTION
## 📝 A short description of the changes

* Includes search params when setting the url on the radio buttons to persist search queries
* Sets the search query in the url even if not submitted - users are likely to use the filter by typing in a query and then switching the year.
* Bug fix on selected_year variable where it was being set to 'other' and causing label errors in the dropdown.
* Show text 'Deleted user' where a user in the 'Last Updated' column has been deleted - this was causing application crashes
* Accessibility fixes for focus and opening the dropdown menu when clicking on 'Other'
* General style fixes as per UI designs

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207701977274875/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="1077" alt="Screenshot 2024-07-03 at 11 45 07" src="https://github.com/bitzesty/qae/assets/65811538/a545b240-c121-4f72-a3b7-91219389b8f6">

