### PR TITLE
Change award year switch to submit form on change

### DIFF
--- a/app/assets/javascripts/admin/applications-filter.js.coffee
+++ b/app/assets/javascripts/admin/applications-filter.js.coffee
@@ -133,7 +133,8 @@ filterApplicationsDropdowns = () ->
       dropdown = dropdownWrapper.find(".dropdown-toggle")
       dropdown.focus().click()
     else
-      search_query = $(this).closest(".new_search").find("#search_query").val()
+      search_query = $(this).closest("#new_search").find("#search_query").val()
+      console.log(search_query)
       url = new URL($(this).data('url'), document.baseURI)
       url.searchParams.set('[search][query]', search_query)
       window.location = url

--- a/app/assets/javascripts/admin/applications-filter.js.coffee
+++ b/app/assets/javascripts/admin/applications-filter.js.coffee
@@ -123,28 +123,27 @@ filterApplicationsDropdowns = () ->
                           .length
       $(this).closest(".applications-filter").find("label[data-value='select_all'] input").prop("checked", unselected is 0)
 
-  # On clicking the award year radio set search query to entered text
+  # On clicking the award year radios
   $(document).on "click", ".applications-filter .input__award-years input[type='radio']", (e) ->
     e.stopPropagation()
-    # if other selected, show dropdown of years, otherwise get form answers for current year or all years
+    # if other selected, show dropdown of years, otherwise submit form
     if $(this).attr('id') == "other"
       dropdownWrapper = $(this).closest(".applications-filter").find(".other-years-dropdown")
       dropdownWrapper.removeClass("hide")
       dropdown = dropdownWrapper.find(".dropdown-toggle")
       dropdown.focus().click()
     else
-      search_query = $(this).closest("#new_search").find("#search_query").val()
-      url = new URL($(this).data('url'), document.baseURI)
-      url.searchParams.set('[search][query]', search_query)
-      window.location = url
+      selected_year = $(this).val()
+      $(this).closest(".input__award-years").find("select option[value='#{selected_year}']").attr('selected', true).change()
+      $(this).closest('form').submit()
 
-  # On clicking the award year from the other year dropdown set search query to entered text
+  # On clicking the award year from the other year dropdown
   $(document).on "click", ".applications-filter .other-years-dropdown .dropdown-menu li", (e) ->
     e.stopPropagation()
     e.preventDefault()
-    search_query = $(this).closest("#new_search").find("#search_query").val()
-    url = new URL($(this).data('url'), document.baseURI)
-    url.searchParams.set('[search][query]', search_query)
-    window.location = url
+    # Set value of other radio button to selected year and submit
+    selected_year = $(this).attr('id')
+    $(this).closest(".input__award-years").find("select option[value='#{selected_year}']").attr('selected', true).change()
+    $(this).closest('form').submit()
 
 $(document).ready(ready)

--- a/app/assets/javascripts/admin/applications-filter.js.coffee
+++ b/app/assets/javascripts/admin/applications-filter.js.coffee
@@ -123,7 +123,7 @@ filterApplicationsDropdowns = () ->
                           .length
       $(this).closest(".applications-filter").find("label[data-value='select_all'] input").prop("checked", unselected is 0)
 
-  # On clicking the award year radio
+  # On clicking the award year radio set search query to entered text
   $(document).on "click", ".applications-filter .input__award-years input[type='radio']", (e) ->
     e.stopPropagation()
     # if other selected, show dropdown of years, otherwise get form answers for current year or all years
@@ -134,9 +134,17 @@ filterApplicationsDropdowns = () ->
       dropdown.focus().click()
     else
       search_query = $(this).closest("#new_search").find("#search_query").val()
-      console.log(search_query)
       url = new URL($(this).data('url'), document.baseURI)
       url.searchParams.set('[search][query]', search_query)
       window.location = url
+
+  # On clicking the award year from the other year dropdown set search query to entered text
+  $(document).on "click", ".applications-filter .other-years-dropdown .dropdown-menu li", (e) ->
+    e.stopPropagation()
+    e.preventDefault()
+    search_query = $(this).closest("#new_search").find("#search_query").val()
+    url = new URL($(this).data('url'), document.baseURI)
+    url.searchParams.set('[search][query]', search_query)
+    window.location = url
 
 $(document).ready(ready)

--- a/app/views/admin/form_answers/index.html.slim
+++ b/app/views/admin/form_answers/index.html.slim
@@ -9,7 +9,6 @@ h1.admin-page-heading
         = f.label :query, "Search", class: "search-input__label"
         = f.hint "By company name, reference number or category", class: "search-input__hint"
         .form-group.search-input
-          = text_field_tag :year, params[:year] || @award_year.year, class: "visuallyhidden", aria: { hidden: true }
           = f.input :query, label: false, input_html: { class: "form-control", type: "search", aria: { label: 'Search applications' }}
           = submit_tag :submit, class: 'search-submit'
 

--- a/app/views/assessor/form_answers/index.html.slim
+++ b/app/views/assessor/form_answers/index.html.slim
@@ -9,7 +9,6 @@ h1.admin-page-heading
         = f.label :query, "Search", class: "search-input__label"
         = f.hint "By company name, reference number or category", class: "search-input__hint"
         .form-group.search-input
-          = text_field_tag :year, params[:year] || @award_year.year, class: "visuallyhidden", aria: { hidden: true }, id: "award_year", tabindex: "-1"
           = text_field_tag :award_type, params[:award_type], class: "visuallyhidden", aria: { hidden: true }, tabindex: "-1"
           = f.input :query, label: false, input_html: { class: "form-control", type: "search", aria: {label: 'Search applications'} }
           = submit_tag :submit, class: 'search-submit'

--- a/app/views/shared/form_answers/_admin_award_year.html.slim
+++ b/app/views/shared/form_answers/_admin_award_year.html.slim
@@ -1,32 +1,42 @@
 - current_year = AwardYear.current.year
 - selected_year = params[:year] ? params[:year].to_i : current_year
-- other_years = AwardYear.admin_switch.keys
+- other_years = AwardYear.admin_switch.keys.select{ |year| year <= current_year }
 
 fieldset.award-year-z-index.applications-filter.award-year-radios
   label.applications-filter__label
     ' Award year
   .input__award-years
-    input type="radio" id="current_year" name="year" value="#{current_year}" data-url="#{url_for(params.permit(:controller, :action).merge(year: current_year, search: params[:search]))}" checked=(current_year == params[:year].to_i || (namespace_name == :assessor && !params[:year]))
-    label for="current_year"
-      | Current year
-    input type="radio" id="all_years" name="year" value="all_years" data-url="#{url_for(params.permit(:controller, :action).merge(year: :all_years, search: params[:search]))}" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && !params[:year]))
-    label for="all_years"
-      | All years
-    input type="radio" id="other" name="year" value="#{selected_year}" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
-    label for="other"
-      | Other
+    .if-no-js-hide
+      input type="radio" id="current_year" name="award_year" value="#{current_year}" checked=(current_year == params[:year].to_i || (namespace_name == :assessor && other_years.exclude?(params[:year].to_i)))
+      label for="current_year"
+        | Current year
+      input type="radio" id="all_years" name="award_year" value="all_years" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && other_years.exclude?(params[:year].to_i)))
+      label for="all_years"
+        | All years
+      input type="radio" id="other" name="award_year" value="#{selected_year}" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
+      label for="other"
+        | Other
 
-    .dropdown.other-years-dropdown class="#{(current_year != selected_year && other_years.include?(params[:year].to_i) ? '' : 'hide')}"
-      a.dropdown-toggle.btn.btn-block.btn-default href="#" data-toggle="dropdown" role="button" aria-expanded="false"
-        - current_year_text = params[:year].to_s == "all_years" || !params[:year] || !other_years.include?(params[:year].to_i) ? "All Years" : "#{selected_year - 1} - #{selected_year}"
+      .dropdown.other-years-dropdown class="#{(current_year != selected_year && other_years.include?(params[:year].to_i) ? '' : 'hide')}"
+        a.dropdown-toggle.btn.btn-block.btn-default href="#" data-toggle="dropdown" role="button" aria-expanded="false"
+          - current_year_text = params[:year].to_s == "all_years" || !params[:year] || !other_years.include?(params[:year].to_i) ? "All Years" : "#{selected_year - 1} - #{selected_year}"
 
-        = current_year_text
-        span.caret-container
-          span.caret
-      ul.dropdown-menu.dropdown-menu-right
-        li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}" data-url="#{url_for(params.permit(:controller, :action).merge(year: :all_years, search: params[:search]))}"
-          = link_to "All Years", "#"
+          = current_year_text
+          span.caret-container
+            span.caret
+        ul.dropdown-menu.dropdown-menu-right
+          li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}" id="all_years"
+            = link_to "All Years", "#"
 
-        - AwardYear.admin_switch.each do |year, label|
-          li class="#{'active' if label == current_year_text}" data-url="#{url_for(params.permit(:controller, :action).merge(year: year, search: params[:search]))}"
-            = link_to label, "#"
+          - AwardYear.admin_switch.each do |year, label|
+            - if year <= current_year
+              li class="#{'active' if label == current_year_text}" id="#{year}"
+                = link_to label, "#"
+
+    select name="year" id="award_year" class="form-control if-js-hide"
+      option value="all_years" selected=(params[:year].to_s == 'all_years' || (namespace_name == :admin && other_years.exclude?(params[:year].to_i)))
+        | All years
+      - AwardYear.admin_switch.each do |year, label|
+        - if year <= current_year
+          option value="#{year}" selected=(year == selected_year)
+            = label

--- a/app/views/shared/form_answers/_admin_award_year.html.slim
+++ b/app/views/shared/form_answers/_admin_award_year.html.slim
@@ -24,9 +24,9 @@ fieldset.award-year-z-index.applications-filter.award-year-radios
         span.caret-container
           span.caret
       ul.dropdown-menu.dropdown-menu-right
-        li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}"
-          = link_to "All Years", url_for(params.permit(:controller, :action).merge(year: :all_years, search: params[:search]))
+        li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}" data-url="#{url_for(params.permit(:controller, :action).merge(year: :all_years, search: params[:search]))}"
+          = link_to "All Years", "#"
 
         - AwardYear.admin_switch.each do |year, label|
-          li class="#{'active' if label == current_year_text}"
-            = link_to label, url_for(params.permit(:controller, :action).merge(year: year, search: params[:search]))
+          li class="#{'active' if label == current_year_text}" data-url="#{url_for(params.permit(:controller, :action).merge(year: year, search: params[:search]))}"
+            = link_to label, "#"


### PR DESCRIPTION
## 📝 A short description of the changes

* Change selector for the search query as admin and assessor have different classes but the ID 'new_search' is present in both.
* Use javascript to set the select option and submit the form when switching the award year.
* Remove hidden year tags which caused params to be set twice.
* Removes award years after the current year.
* Adds support for no js

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207701977274882/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

