### PR TITLE
Remove 'Role' filter from Users table, make it a static heading

### DIFF
--- a/app/search/user_search.rb
+++ b/app/search/user_search.rb
@@ -1,10 +1,5 @@
 class UserSearch < Search
-  DEFAULT_SEARCH = {
-    sort: "full_name",
-    search_filter: {
-      role: User.role.values,
-    },
-  }
+  DEFAULT_SEARCH = { sort: "full_name" }
 
   include FullNameSort
 end

--- a/app/views/admin/users/_list.html.slim
+++ b/app/views/admin/users/_list.html.slim
@@ -9,32 +9,8 @@
             = sort_link f, 'Email', @search, :email
           th.sortable
             = sort_link f, 'Company', @search, :company_name
-          th.filter
-            - role_names = { "account_admin" => "Admin and collaborator", "regular" => "Collaborator only" }
-            = f.simple_fields_for [:filters, @search.filters] do |f|
-              - role_collection = User.role.options.map{ |role| [role_names[role[1]], role[1]] }
-              = f.input :role, collection: role_collection, label: false, input_html: {multiple: true, class: 'if-js-hide', aria: { label: "Search applications" } }
-              = f.submit "Filter", class: "if-js-hide"
-              label.if-js-hide Ctrl + left click for multi select
-            .dropdown.if-no-js-hide
-              button.btn.btn-default.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="true"
-                ' Role:
-                span.text-filter
-                  ' All
-                span.caret
-              ul.dropdown-menu role="menu"
-                li.checkbox role="menuitem"
-                  label data-value="select_all"
-                    input type="checkbox"
-                    span.label-contents
-                      em Select all
-                li.divider
-                - User.role.options.each do |role|
-                  li.checkbox role="menuitem"
-                    label data-value=role[1]
-                      input type="checkbox"
-                      span.label-contents
-                        = role_names[role[1]]
+          th
+            ' Role
           th.sortable
             = sort_link f, 'Signed in on', @search, :last_sign_in_at
           th.sortable


### PR DESCRIPTION
## 📝 A short description of the changes

* Removes 'Role' filter from Users table and makes it a static heading

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207256055276973/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

