### PR TITLE
Add missing class 'text-words-max' to textarea questions

### DIFF
--- a/forms/award_years/v2025/innovation/innovation_step1.rb
+++ b/forms/award_years/v2025/innovation/innovation_step1.rb
@@ -184,7 +184,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :major_issues_overcome, "Please explain any major issues that you have overcome in recent years and the remedial steps you have taken." do
           ref "A 2.2"
-          classes "sub-question"
+          classes "sub-question text-words-max"
           required
           context %(
             <p class="govuk-body">For example, what steps did you take following a major Health and Safety incident.</p>

--- a/forms/award_years/v2025/innovation/innovation_step2.rb
+++ b/forms/award_years/v2025/innovation/innovation_step2.rb
@@ -40,7 +40,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :invoicing_unit_relations, "Explain your relationship with the invoicing unit and the arrangements made." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "B 2.1"
           required
           conditional :principal_business, :no
@@ -347,7 +347,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :other_awards_desc, "List the awards you have won in the past." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "B 13.1"
           required
           context "<p>If you can't fit all of your awards below, then choose those you're most proud of.</p>"

--- a/forms/award_years/v2025/innovation/innovation_step3.rb
+++ b/forms/award_years/v2025/innovation/innovation_step3.rb
@@ -36,7 +36,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_desc_short, "Provide a one-line description of your innovative product, service, business model or process." do
           sub_section :innovation_background_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 1.2"
           required
           context %(
@@ -105,7 +105,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_hold_existing_patent_details, "Provide a link to your published patent document. If you do not have a patent, please explain the reasons why not." do
           sub_section :innovation_background_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 1.4.1"
           required
           context %(
@@ -133,7 +133,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_other_countries_it_was_developed, "Describe in what other countries and, if applicable, by what parties it was developed." do
           sub_section :innovation_background_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 1.5.1"
           required
           conditional :innovation_conceived_and_developed, :no
@@ -161,7 +161,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_contributors, "Please enter their names." do
           sub_section :innovation_background_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 1.6.1"
           required
           conditional :innovation_joint_contributors, :yes
@@ -184,7 +184,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_external_contributors, "Name any external organisations or individuals that contributed to your innovation and explain their contributions." do
           sub_section :innovation_background_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 1.7.1"
           required
           conditional :innovation_any_contributors, :yes
@@ -215,7 +215,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_contributors_why_organisations, "Explain why external organisations or individuals that contributed to your innovation are not all aware of this application." do
           sub_section :innovation_background_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 1.7.3"
           required
           conditional :innovation_any_contributors, :yes
@@ -234,7 +234,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_license_terms, "Briefly describe the licensing arrangement." do
           sub_section :innovation_background_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 1.8.1"
           required
           conditional :innovation_under_license, :yes
@@ -278,7 +278,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_context, "Describe the market conditions that led to the creation of your innovation and how you identified a gap in the market." do
           sub_section :innovation_timeline_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.3"
           required
           context %(
@@ -292,7 +292,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_desc_long, "Describe your innovation and why it is innovative." do
           sub_section :innovation_timeline_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.4"
           required
           context %(
@@ -343,7 +343,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_selection_details, "How did you select this innovation as the one to satisfy the gap in the market?" do
           sub_section :innovation_timeline_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.5"
           required
           context %(
@@ -357,7 +357,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_overcomes_issues, "Describe any challenges you encountered in developing your innovation and how you overcame them." do
           sub_section :innovation_timeline_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.6"
           required
           context %(
@@ -371,7 +371,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_strategies, "Explain the market opportunities and what strategies you used to penetrate the market." do
           sub_section :innovation_timeline_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.7"
           required
           context %(
@@ -385,7 +385,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_competitors, "Who offers products, services or business models that compete with yours?" do
           sub_section :innovation_timeline_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.8"
           required
           context %(
@@ -399,7 +399,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_protect_market_position_details, "How might you protect the market position you have created?" do
           sub_section :innovation_timeline_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.9"
           required
           context %(
@@ -413,7 +413,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_additional_comments, "Additional comments (optional)" do
           sub_section :innovation_timeline_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.10"
           context %(
             <p>
@@ -451,7 +451,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_befits_details_business, "How has the innovation added value to your business?" do
           sub_section :innovation_value_add_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 3.1"
           required
           context %(
@@ -506,7 +506,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_befits_details_customers, "Does the innovation benefit your customers, and if so, how?" do
           sub_section :innovation_value_add_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 3.2"
           required
           context %(
@@ -552,7 +552,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :beyond_your_immediate_customers, "Beyond your immediate customers, does the innovation benefit others, and if so, how and to whom?" do
           sub_section :innovation_value_add_header
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 3.3"
           required
           context %(

--- a/forms/award_years/v2025/innovation/innovation_step4.rb
+++ b/forms/award_years/v2025/innovation/innovation_step4.rb
@@ -55,7 +55,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :adjustments_explanation, "Explain adjustments to figures." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 2.2"
           required
           rows 2
@@ -72,7 +72,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :financial_year_date_changed_explaination, "Explain why your year-end date changed." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 2.3"
           required
           rows 1
@@ -203,7 +203,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :drops_in_turnover, "Explain any losses, drops in the total turnover, export sales, total net assets or reductions in net profit." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 4.6"
           required
           rows 3
@@ -219,7 +219,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :drops_explain_how_your_business_is_financially_viable, "Explain how your business is financially viable in terms of cash flow, cash generated, and investment received." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 4.7"
           required
           context %(
@@ -235,7 +235,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :investments_details, "Enter details of all your investments in the innovation. Include all investments made both during and before your entry period. Also, include the years in which they were made." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 4.8"
           required
           rows 3
@@ -248,7 +248,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :roi_details, "Please provide calculations on how you have recovered or will recover the investments outlined in question D4.8. How long did it take or will it take to recover the investments?" do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 4.9"
           required
           rows 3
@@ -372,7 +372,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :drops_in_sales, "Explain any drop in sales or the number of units sold (if applicable)." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 6.5"
           section :innovation_financials
           rows 2
@@ -400,7 +400,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :avg_unit_price_desc, "Explain your unit selling prices or contract values, highlighting any changes over the above periods (if applicable)." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 6.7"
           section :innovation_financials
           rows 2
@@ -425,7 +425,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :costs_change_desc, "Explain your direct unit or contract costs, highlighting any changes over the above periods (if applicable)." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 6.9"
           section :innovation_financials
           rows 2
@@ -439,6 +439,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :innovation_performance, "Describe how, when, and to what extent the innovation has improved the commercial performance of your business." do
           ref "D 7"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -476,6 +477,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :covid_impact_details, "Explain how your business has been responding to the economic uncertainty experienced nationally and globally in recent years." do
           ref "D 8"
+          classes "text-words-max"
           required
           context %(
             <ul>
@@ -506,7 +508,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :innovation_grant_funding_sources, "Provide details of dates, sources, types and, if relevant, amounts of the government support you received in relation to your innovation (at any time)." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 9.1"
           required
           context %(
@@ -518,7 +520,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :innovation_grant_funding_sources_in_application_period, "Provide details of dates, sources, types and, if relevant, amounts of the government support you received during the last five years." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 9.2"
           required
           context %(
@@ -551,7 +553,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :product_estimates_use, "Explain your use of estimates and how much of these are actual receipts or firm orders." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 10.2"
           required
           rows 2

--- a/forms/award_years/v2025/innovation/innovation_step5.rb
+++ b/forms/award_years/v2025/innovation/innovation_step5.rb
@@ -8,6 +8,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :impact_on_society, "The impact of your business operations on society." do
           ref "E 1"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -37,6 +38,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :impact_on_environment, "The environmental impact of your business operations." do
           ref "E 2"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -76,6 +78,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :employees_relations, "Relations with your workforce." do
           ref "E 3"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -111,6 +114,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :partners_relations, "Relations with customers and suppliers." do
           ref "E 4"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -140,6 +144,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :governance, "Additional environmental, social, and corporate governance (ESG) examples. (optional)" do
           ref "E 5"
+          classes "text-words-max"
           context %(
             <p>
               Feel free to provide any additional information about your ESG practices. If you have already covered your ESG practices in full in this section or section C of the form, just state so.

--- a/forms/award_years/v2025/international_trade/international_trade_step2.rb
+++ b/forms/award_years/v2025/international_trade/international_trade_step2.rb
@@ -35,7 +35,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :invoicing_unit_relations, "Explain your relationship with the invoicing unit, and the arrangements made." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "B 2.1"
           required
           conditional :principal_business, :no
@@ -250,7 +250,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :pareent_group_why_excluding_members, "Please explain why you are excluding any members of your group from this application." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "B 10.2"
           rows 5
           words_max 100
@@ -411,7 +411,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :other_awards_desc, "List the awards you have won in the past." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "B 17.1"
           required
           form_hint "If you can't fit all of your awards below, then choose those you're most proud of."

--- a/forms/award_years/v2025/international_trade/international_trade_step3.rb
+++ b/forms/award_years/v2025/international_trade/international_trade_step3.rb
@@ -7,7 +7,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :trade_business_as_a_whole, "Describe your business as a whole." do
-          classes "word-max-strict"
+          classes "word-max-strict text-words-max"
           sub_ref "C 1"
           required
           rows 5
@@ -15,7 +15,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :trade_brief_history, "Provide a brief history of your company, corporate targets and direction." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 1.1"
           required
           rows 5
@@ -23,7 +23,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :trade_overall_importance, "Explain the overall importance of exporting to your company." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           ref "C 2"
           required
           rows 5
@@ -31,7 +31,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :trade_description_short, "Provide a one-line description of your international trade." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 2.1"
           context %(
             <p>
@@ -97,7 +97,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :trade_plans_desc, "Describe your international trade strategy." do
           ref "C 3"
-          classes "word-max-strict"
+          classes "word-max-strict text-words-max"
           required
           context %(
             <p>
@@ -131,7 +131,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :actual_planned_performance_comparison, "Please explain how your actual performance compared to your planned performance as outlined in question C3." do
           sub_ref "C 3.1"
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           required
           rows 3
           words_max 250
@@ -147,7 +147,7 @@ class AwardYears::V2025::QaeForms
         textarea :markets_geo_spread, "Describe the geographical spread of your overseas markets." do
           required
           sub_ref "C 4.1"
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           context %(
             <p>
               Include evidence of how you segment and manage geographical regions to demonstrate your company's focus. Please supply market share information.
@@ -158,7 +158,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :top_overseas_sales, "What percentage of total overseas sales was made to each of your top 5 overseas markets (individual countries) during the final year of your entry?" do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 4.2"
           required
           rows 1
@@ -166,7 +166,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :identify_new_overseas, "Identify new overseas markets established during your period of entry and their contribution to total overseas sales." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 4.3"
           required
           rows 3
@@ -186,7 +186,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :operate_model_benefits, "Explain your franchise or other business models and the rationale for this. Describe the benefits this brings to the UK (or Channel Islands or Isle of Man)." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "C 5.1"
           required
           rows 3
@@ -195,7 +195,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :economic_uncertainty_response, "Explain how your business has been responding to the economic uncertainty experienced nationally and globally in recent years." do
           sub_ref "C 6"
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           required
           context %(
             <ul>

--- a/forms/award_years/v2025/international_trade/international_trade_step4.rb
+++ b/forms/award_years/v2025/international_trade/international_trade_step4.rb
@@ -83,7 +83,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :financial_figures_adjustment_explanation, "Explain adjustments to figures." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 3.2"
           required
           context %(
@@ -103,7 +103,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :financial_year_date_changed_explaination, "Explain why your year-end date changed." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 3.3"
           required
           rows 5
@@ -252,7 +252,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :drops_in_turnover, "If you have had any losses, drops in turnover, or reductions in net profit, please explain them." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 5.4"
           required
           context %(
@@ -268,7 +268,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :drops_explain_how_your_business_is_financially_viable, "Explain how your business is financially viable in terms of cash flow and cash generated." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 5.5"
           required
           rows 5
@@ -276,7 +276,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :investment_strategy_and_its_objectives, "Please describe your investment strategy and its objectives and, if applicable, the type and scale of investments you have received." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 5.6"
           required
           rows 5
@@ -299,7 +299,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :funding_details, "Provide details of dates, sources, types and, if relevant, amounts of the government support you received in relation to your export products or services (at any time)." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 6.1"
           required
           context %(
@@ -311,7 +311,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :funding_details_in_application_period, "Provide details of dates, sources, types and, if relevant, amounts of the government support you received during the last five years." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 6.2"
           required
           context %(
@@ -344,7 +344,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :explan_the_use_of_estimates, "Explain the use of estimates, and how much of these are actual receipts or firm orders." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 7.2"
           required
           conditional :are_any_of_the_figures_used_estimates, :yes

--- a/forms/award_years/v2025/international_trade/international_trade_step5.rb
+++ b/forms/award_years/v2025/international_trade/international_trade_step5.rb
@@ -8,6 +8,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :impact_on_society, "The impact of your business operations on society." do
           ref "E 1"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -40,6 +41,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :impact_on_environment, "The environmental impact of your business operations." do
           ref "E 2"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -80,6 +82,7 @@ class AwardYears::V2025::QaeForms
         textarea :employees_relations, "Relations with your workforce." do
           ref "E 3"
           required
+          classes "text-words-max"
           context %(
             <p>
               Examples of areas you may wish to describe:
@@ -114,6 +117,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :partners_relations, "Relations with customers and suppliers." do
           ref "E 4"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -146,6 +150,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :governance, "Additional environmental, social, and corporate governance (ESG) examples. (optional)" do
           ref "E 5"
+          classes "text-words-max"
           context %(
             <p>
               Feel free to provide any additional information about your ESG practices. If you have already covered your ESG practices in full in this section or section C of the form, just state so.

--- a/forms/award_years/v2025/social_mobility/social_mobility_step1.rb
+++ b/forms/award_years/v2025/social_mobility/social_mobility_step1.rb
@@ -184,7 +184,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :major_issues_overcome, "Please explain any major issues that you have overcome in recent years and the remedial steps you have taken." do
           ref "A 2.2"
-          classes "sub-question"
+          classes "sub-question text-words-max"
           required
           context %(
             <p class="govuk-body">For example, what steps did you take following a major Health and Safety incident.</p>

--- a/forms/award_years/v2025/social_mobility/social_mobility_step2.rb
+++ b/forms/award_years/v2025/social_mobility/social_mobility_step2.rb
@@ -35,7 +35,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :invoicing_unit_relations, "Explain your relationship with the invoicing unit and the arrangements made." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "B 2.1"
           required
           conditional :principal_business, :no
@@ -305,7 +305,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :part_of_joint_entry_names, "Please enter their names." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "B 12.1"
           required
           conditional :part_of_joint_entry, "yes"
@@ -330,7 +330,7 @@ class AwardYears::V2025::QaeForms
         textarea :external_specify_organisations_contributions, "Specify the organisations that have contributed, and state what, how and when they contributed." do
           sub_ref "B 13.1"
           required
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           words_max 100
           rows 1
           conditional :external_contribute_to_sustainable_product, "yes"
@@ -411,7 +411,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :other_awards_desc, "List the awards you have won in the past." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "B 15.1"
           required
           context %(

--- a/forms/award_years/v2025/social_mobility/social_mobility_step3.rb
+++ b/forms/award_years/v2025/social_mobility/social_mobility_step3.rb
@@ -378,7 +378,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :initiative_activities_other_specify, "Please list other activity types" do
           required
-          classes "sub-question js-conditional-question-checkbox"
+          classes "sub-question js-conditional-question-checkbox text-words-max"
           sub_ref "C 2.1"
           conditional :initiative_activities, "other_activity_types"
           words_max 50
@@ -390,7 +390,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :initiative_desc_short, "Provide a one-line description of your initiative." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 3.1"
           required
           context %(
@@ -406,14 +406,14 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :initiative_desc_medium, "Briefly describe the initiative, its aims, what it provides and how it promotes opportunity through social mobility." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 3.2"
           required
           words_max 300
         end
 
         textarea :initiative_motivations, "Outline the factors or issues that motivated your organisation to provide the initiative." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 3.3"
           required
           context %(
@@ -431,7 +431,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :initiative_exemplary_evidence, "Describe what makes your initiative exemplary." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 3.4"
           required
           context %(
@@ -449,7 +449,7 @@ class AwardYears::V2025::QaeForms
         textarea :initiative_evidence_exemplary, "Provide evidence of what makes your initiative exemplary." do
           sub_ref "C 3.5"
           required
-          classes "sub-question"
+          classes "sub-question text-words-max"
           words_max 200
           context %(
             <p>To support your answer in C3.4, provide <strong>third-party evidence</strong> of what makes your initiative exemplary compared to other similar initiatives and how you are going 'above and beyond' compared to your sector. For example, provide links to independent evaluation reports, details of awards won, client feedback ratings and how that compares with other similar organisations.</p>
@@ -457,7 +457,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :initiative_day_to_day_running, "Who is responsible for and who runs the initiative day-to-day?" do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 3.6"
           required
           words_max 200
@@ -467,7 +467,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :goals_targets_monitor, "Describe what goals or targets you set and how you monitor them in the context of your initiative." do
-          classes "question"
+          classes "question text-words-max"
           ref "C 4"
           required
           words_max 500
@@ -492,7 +492,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :goals_targets_compare, "Describe how the goals or targets you set compare to the outcomes." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 4.1"
           required
           words_max 200
@@ -502,7 +502,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :addressing_shortfalls, "Explain any shortfalls and if you do anything to address them." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 4.2"
           required
           words_max 200
@@ -663,6 +663,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :disadvantaged_group_not_in_list, "If you are putting forward a group that is not on this list, please provide details and explain why you believe the group you support should be considered disadvantaged." do
           sub_ref "C 5.4.1"
+          classes "text-words-max"
           context %(
             <p><em>
               Answer this question if you provided numbers for 'Other disadvantaged group' in question C5.4.
@@ -719,7 +720,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :disadvantaged_groups_impact_employment_explained, "If, in question C5.5, jobs retained for more than a year are significantly lower than those secured during the support or within a year of support ending, please explain why." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 5.5.1"
           required
           words_max 150
@@ -820,7 +821,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :disadvantaged_groups_numbers_explained, "Explain how you collected the impact numbers." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 5.8"
           required
           context %(
@@ -830,7 +831,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :initiative_qualitative_impact, "Provide qualitative evidence on the impact that your initiative has achieved for your participants." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 5.9"
           required
           context %(
@@ -857,7 +858,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :initiative_feedback, "Describe what feedback, if any, you sought on how your initiative could be improved. What, if any, of the suggested improvements have you implemented?" do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 5.10"
           required
           context %(
@@ -882,7 +883,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :initiative_impact_sharing, "Explain if and how you share and celebrate the evidence of the initiative’s impact across the organisation." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 6.1"
           required
           context %(
@@ -892,21 +893,21 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :initiative_member_engagement, "Explain if and how you engage the organisation’s members or workforce in the design and implementation of your initiative." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 6.2"
           required
           words_max 200
         end
 
         textarea :initiative_long_term_plans, "What are your long-term plans for ensuring your organisation continues to promote opportunities through social mobility beyond what you already do?" do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 6.3"
           required
           words_max 200
         end
 
         textarea :initiative_organisation_benefits, "Are there any other benefits of the initiative to your organisation that you haven't yet outlined in the previous responses?" do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "C 6.4"
           required
           context %(
@@ -925,6 +926,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :initiative_community_society_impact, "Impact on community and society." do
           sub_ref "C 7"
+          classes "text-words-max"
           required
           context %(
             <p>What is the impact of your initiative on the local community and at a regional and national level, and how is this exemplary?</p>
@@ -935,6 +937,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :initiative_investments, "Investments in the initiative" do
           sub_ref "C 8"
+          classes "text-words-max"
           required
           question_sub_title %{
             List all investments and reinvestments (capital and operating costs) in your promoting opportunity through social mobility initiative. Include the years in which they were made.

--- a/forms/award_years/v2025/social_mobility/social_mobility_step4.rb
+++ b/forms/award_years/v2025/social_mobility/social_mobility_step4.rb
@@ -8,6 +8,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :drops_explain_how_your_business_is_financially_viable, "Explain how your organisation is financially viable." do
           sub_ref "D 1"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -77,7 +78,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :financial_adjustments_explanation, "Explain adjustments to figures." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 2.4"
           required
           context %(
@@ -91,7 +92,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :financial_year_date_changed_explaination, "Explain why your year-end date changed." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 2.5"
           required
           rows 2
@@ -168,7 +169,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :drops_in_turnover, "If you have had any losses, drops in turnover (or income), or reductions in net profit, please explain them." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 4.4"
           required
           context %(
@@ -190,6 +191,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :covid_impact_details, "Explain how your business has been responding to the economic uncertainty experienced nationally and globally in recent years." do
           ref "D 5"
+          classes "text-words-max"
           required
           context %(
             <ul>
@@ -219,7 +221,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :funding_details, "Provide details of dates, sources, types and, if relevant, amounts of the government support." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 6.1"
           required
           context %(
@@ -252,7 +254,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :product_estimates_use, "Explain the use of estimates and how much of these are actual receipts or firm orders." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 7.2"
           required
           rows 5

--- a/forms/award_years/v2025/social_mobility/social_mobility_step5.rb
+++ b/forms/award_years/v2025/social_mobility/social_mobility_step5.rb
@@ -8,6 +8,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :impact_on_society, "The impact of your business operations on society." do
           ref "E 1"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -37,6 +38,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :impact_on_environment, "The environmental impact of your business operations." do
           ref "E 2"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -76,6 +78,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :employees_relations, "Relations with your workforce." do
           ref "E 3"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -111,6 +114,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :partners_relations, "Relations with customers and suppliers." do
           ref "E 4"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -140,6 +144,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :governance, "Additional environmental, social, and corporate governance (ESG) examples. (optional)" do
           ref "E 5"
+          classes "text-words-max"
           required
           context %(
             <p>

--- a/forms/award_years/v2025/sustainable_development/sustainable_development_step1.rb
+++ b/forms/award_years/v2025/sustainable_development/sustainable_development_step1.rb
@@ -184,7 +184,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :major_issues_overcome, "Please explain any major issues that you have overcome in recent years and the remedial steps you have taken." do
           ref "A 2.2"
-          classes "sub-question"
+          classes "sub-question text-words-max"
           required
           context %(
             <p class="govuk-body">For example, what steps did you take following a major Health and Safety incident.</p>

--- a/forms/award_years/v2025/sustainable_development/sustainable_development_step2.rb
+++ b/forms/award_years/v2025/sustainable_development/sustainable_development_step2.rb
@@ -35,7 +35,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :invoicing_unit_relations, "Explain your relationship with the invoicing unit and the arrangements made." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "B 2.1"
           required
           conditional :principal_business, :no
@@ -205,7 +205,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :social_media_links, "Links to social media accounts, for example, LinkedIn, Twitter, Instagram (optional)." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "B 8.1"
           context %(
             <p>Please note, when evaluating your application, the assessors may check your organisation's online presence.</p>
@@ -305,7 +305,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :part_of_joint_entry_names, "Please enter their names." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "B 12.1"
           required
           conditional :part_of_joint_entry, "yes"
@@ -330,7 +330,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :external_contributors, "Specify the organisations that have contributed, and state what, how and when they contributed." do
           sub_ref "B 13.1"
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           required
           conditional :external_contribute_to_sustainable_product, "yes"
           words_max 100
@@ -412,7 +412,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :other_awards_desc, "List the awards you have won in the past." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "B 15.1"
           required
           context %(

--- a/forms/award_years/v2025/sustainable_development/sustainable_development_step3.rb
+++ b/forms/award_years/v2025/sustainable_development/sustainable_development_step3.rb
@@ -11,7 +11,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :one_line_description_of_interventions, "Provide a one-line description of your sustainable development interventions." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           ref "C 1.1"
           required
           context %(
@@ -37,7 +37,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :briefly_describe_your_interventions, "Briefly describe your sustainable development interventions." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           ref "C 1.2"
           required
           context %(
@@ -57,7 +57,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :briefly_describe_your_core_business, "A brief summary of your organisation." do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 2.1"
           context %(
             <p>
@@ -70,7 +70,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :describe_previous_situation_before_sustainability, "What was the situation before your organisation adopted a sustainability purpose, objectives and interventions?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 2.2"
           required
           rows 2
@@ -78,7 +78,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :why_these_particular_interventions, "Why did you choose these particular interventions, and how do they align with the core aims and values of your organisation?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 2.3"
           required
           rows 3
@@ -86,7 +86,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :how_have_you_embedded_sustainability_objectives, "How have you embedded sustainability objectives or purpose in your organisation?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 2.4"
           required
           rows 2
@@ -94,7 +94,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :explain_how_the_business_operates_sustainably, "If your application is focused on particular sustainable development interventions, explain how your whole business also operates sustainably, especially in terms of climate change." do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 2.5"
           required
           context %{
@@ -146,7 +146,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :how_sustainability_interventions_benefit_business_strategy, "How do sustainability interventions benefit the overall business strategy?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 2.6"
           required
           rows 2
@@ -154,7 +154,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :explain_your_strategy_in_developing_sustainably, "Explain your strategy in developing sustainably for the future." do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 2.7"
           required
           context %(
@@ -176,7 +176,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :describe_the_driving_force_of_your_organisation, "Who is ultimately responsible for the organisation's sustainability interventions and their success?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 3.1"
           required
           rows 2
@@ -184,7 +184,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :who_is_responsible_for_day_to_day_management, "Who is responsible for the day-to-day management, and the main areas of sustainability, in your organisation?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 3.2"
           required
           context %(
@@ -195,7 +195,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :describe_the_senior_decision_makers_commitment_to_sustainability, "What is the senior decision maker's commitment to the future sustainable growth of the organisation?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 3.3"
           required
           rows 2
@@ -203,7 +203,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :how_does_your_organisation_inspire_others, "How does your organisation inspire other organisations to be more sustainable?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 3.4"
           required
           context %(
@@ -216,7 +216,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :how_do_you_collaborate_with_partners, "How do you collaborate with partners and others to develop best practice?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 3.5"
           required
           rows 2
@@ -224,7 +224,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :describe_your_organisation_diversity, "How does your organisation attract, recruit, promote and retain a diverse workforce?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 3.6"
           required
           context %(
@@ -237,7 +237,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :describe_how_employee_relations_improved_their_motivation, "How do you ensure workforce motivation, well-being and satisfaction?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 3.7"
           required
           rows 2
@@ -254,7 +254,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :culture_and_values_regarding_sustainability, "How is sustainability embedded in your organisation's culture and values?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 4.1"
           required
           rows 2
@@ -262,7 +262,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :how_do_you_increase_positive_perception_of_sustainability, "How do you increase positive perceptions of your organisation's sustainability among stakeholders, such as your workforce, supply chain, customers, communities, and media?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 4.2"
           context %(
             <p>
@@ -281,7 +281,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :what_are_your_long_term_plans_for_sustainability, "What are your long-term plans for ensuring your organisation provides the leadership, innovation or interventions to enable greater sustainable development?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 4.3"
           required
           rows 2
@@ -302,7 +302,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :describe_your_interventions_using_un, "Which UN SDGs are your efforts targeted towards?" do
           required
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           sub_ref "C 5.1"
           context %(
             <p>
@@ -314,7 +314,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :aims_of_the_interventions, "The aims of the interventions." do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 5.2"
           required
           context %(
@@ -327,7 +327,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :proportion_of_interventions_compared_to_organisation_size, "The proportion of these interventions compared to your whole organisation's size." do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 5.3"
           required
           context %(
@@ -340,7 +340,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :evidence_of_exemplary_interventions, "Provide evidence of what makes your interventions exemplary." do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 5.4"
           required
           context %(
@@ -385,7 +385,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :how_do_you_measure_the_success_of_interventions, "How do you measure the success of your sustainability intervention?" do
           ref "C 6.1"
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           required
           context %(
             <p>For example, are key performance indicators (KPIs) or targets used? If so, how are they set and monitored? Are the KPIs or targets being met, and what happens if they are not?</p>
@@ -396,14 +396,14 @@ class AwardYears::V2025::QaeForms
 
         textarea :what_qualitive_measures_were_used_to_measure_success, "State what qualitative measures were used to evaluate the success of your sustainable business objectives to your organisation, customers, workforce or others in meeting objectives for performance." do
           ref "C 6.2"
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           required
           rows 3
           words_max 300
         end
 
         textarea :impact_of_your_sustainable_development, "The impact of your sustainable objectives." do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 6.3"
           required
           context %(
@@ -416,7 +416,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :how_does_the_scale_of_intervention_compare_to_others, "How does the scale of your interventions compare with other organisations in your sector?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 6.4"
           required
           context %(
@@ -432,7 +432,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :what_longer_term_outcomes_do_you_expect, "What longer-term outcomes do you expect as a result of your sustainable development efforts?" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 6.5"
           required
           rows 2
@@ -440,7 +440,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :which_accreditations_have_been_achieved, "If your organisation has achieved recognised standards or accreditations, please list them." do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 6.6"
           required
           context %(
@@ -453,7 +453,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :governance, "Additional information about your Environmental, Social, and Corporate Governance (ESG). (optional)" do
-          classes "word-max-strict sub-question"
+          classes "word-max-strict sub-question text-words-max"
           ref "C 6.7"
           context %(
             <p>

--- a/forms/award_years/v2025/sustainable_development/sustainable_development_step4.rb
+++ b/forms/award_years/v2025/sustainable_development/sustainable_development_step4.rb
@@ -8,6 +8,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :explain_why_your_organisation_is_financially_viable, "Explain how your organisation is financially viable." do
           ref "D 1"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -77,7 +78,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :financial_adjustments_explanation, "Explain adjustments to figures." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 2.4"
           context %(
             <p>
@@ -91,7 +92,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :financial_year_date_changed_explaination, "Explain why your year-end date changed." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 2.5"
           required
           rows 2
@@ -185,7 +186,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :drops_in_turnover, "If you have had any losses, drops in turnover (or income), or reductions in net profit, please explain them." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 4.6"
           required
           rows 5
@@ -206,6 +207,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :investments_details, "Please enter details of all investments and reinvestments (capital and operating costs) in your sustainable development actions or interventions. If none, please state so." do
           ref "D 5"
+          classes "text-words-max"
           required
           context %(
             <p>
@@ -218,6 +220,7 @@ class AwardYears::V2025::QaeForms
 
         textarea :covid_impact_details, "Explain how your business has been responding to the economic uncertainty experienced nationally and globally in recent years." do
           ref "D 6"
+          classes "text-words-max"
           required
           context %(
             <ul>
@@ -247,7 +250,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :funding_details, "Provide details of dates, sources, types and, if relevant, amounts of the government support." do
-          classes "sub-question word-max-strict"
+          classes "sub-question word-max-strict text-words-max"
           sub_ref "D 7.1"
           required
           context %(
@@ -281,7 +284,7 @@ class AwardYears::V2025::QaeForms
         end
 
         textarea :product_estimates_use, "Explain the use of estimates and how much of these are actual receipts or firm orders." do
-          classes "sub-question"
+          classes "sub-question text-words-max"
           sub_ref "D 8.2"
           required
           rows 5


### PR DESCRIPTION
## 📝 A short description of the changes

* Add missing class 'text-words-max' to textarea questions to trigger correct validation, extension of PR #2998 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207256055276973/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

