### PR TITLE
Fix JS validation for word count in textarea

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -138,8 +138,10 @@ window.FormValidation =
         return question.find("input[type='checkbox']").filter(":checked").length
 
   validateWordLimit: (question) ->
-    wordLimit = $(question.context).attr("data-word-max")
-    wordCount = $(question.context).val().split(" ").length
+    textarea = question.find("textarea")
+    wordLimit = textarea.attr("data-word-max")
+    normalizedContent = textarea.val().replace(/&nbsp;/g, ' ').replace(/\n/g, ' ');
+    wordCount = normalizedContent.split(" ").length
     if wordCount > wordLimit
       @logThis(question, "validateWordLimit", "Word limit exceeded")
       @addErrorMessage(question, "Exceeded #{wordLimit} word limit.")


### PR DESCRIPTION
## 📝 A short description of the changes

* When text is pasted into textareas, spaces are converted to non-breaking spaces (&nbsp;) and line breaks to (\n), previous code was counting words by spaces and ignoring these.
* Also, step validation was not working on these questions, this PR changes use of .context to .find('textarea') instead, which correctly identifies the textarea element in both `validate` and `validateStep` functions

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207796563026166/f#:~:text=%5BKAEIMP0724%5D%20Update%20validations%20on%20text%20fields%20with%20word%20counts/limits

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

