### PR TITLE
Ensure all non-breaking spaces and any other types of whitespace are replaced with regular spaces before performing .split on textarea wordcount

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -140,7 +140,8 @@ window.FormValidation =
   validateWordLimit: (question) ->
     textarea = question.find("textarea")
     wordLimit = textarea.attr("data-word-max")
-    normalizedContent = textarea.val().replace(/&nbsp;/g, ' ').replace(/\n/g, ' ');
+    textareaValue = textarea.val() || '';
+    normalizedContent = textareaValue.replace(/(&nbsp;|\n|\s)+/g, ' ').trim();
     wordCount = normalizedContent.split(" ").length
     if wordCount > wordLimit
       @logThis(question, "validateWordLimit", "Word limit exceeded")


### PR DESCRIPTION
## 📝 A short description of the changes

*  Ensure all non-breaking spaces and any other types of whitespace are replaced with regular spaces before performing .split on textarea wordcount

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207796563026166/f

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

