### PR TITLE
Add whitespaces back to useful_information page

### DIFF
--- a/app/views/accounts/useful_information.html.slim
+++ b/app/views/accounts/useful_information.html.slim
@@ -99,8 +99,8 @@
 
       p.govuk-body
         | Also, please check the
-        = link_to('risk rating matrix', 'https://www.gov.uk/government/publications/sharing-hmrc-information-to-assist-the-kings-award-for-enterprise-committees-recommendations/memorandum-of-understanding-accessing-hmrc-information-to-assist-the-kings-award-for-enterprise-committees-to-make-recommendations-about-awards-to-u--4#annex-c--risk-rating-matrix', class: 'govuk-link', target: "_blank")
+        =< link_to('risk rating matrix', 'https://www.gov.uk/government/publications/sharing-hmrc-information-to-assist-the-kings-award-for-enterprise-committees-recommendations/memorandum-of-understanding-accessing-hmrc-information-to-assist-the-kings-award-for-enterprise-committees-to-make-recommendations-about-awards-to-u--4#annex-c--risk-rating-matrix', class: 'govuk-link', target: "_blank")
         |  in the HRMC's
-        = link_to('Memorandum of Understanding', 'https://www.gov.uk/government/publications/sharing-hmrc-information-to-assist-the-kings-award-for-enterprise-committees-recommendations/memorandum-of-understanding-accessing-hmrc-information-to-assist-the-kings-award-for-enterprise-committees-to-make-recommendations-about-awards-to-u--4', class: 'govuk-link', target: "_blank")
+        =< link_to('Memorandum of Understanding', 'https://www.gov.uk/government/publications/sharing-hmrc-information-to-assist-the-kings-award-for-enterprise-committees-recommendations/memorandum-of-understanding-accessing-hmrc-information-to-assist-the-kings-award-for-enterprise-committees-to-make-recommendations-about-awards-to-u--4', class: 'govuk-link', target: "_blank")
         |  (created to assist the King's Award for Enterprise Committee in making recommendations about awards to UK companies).
       p.govuk-body Further information can be found on the application form. Please be aware - firms have previously failed this part of the process for as little as a few hundred pounds so it really is worth checking with your finance team.


### PR DESCRIPTION
## 📝 A short description of the changes

* These spaces were removed in a previous PR

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207563441008162

## :shipit: Deployment implications

* 

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

