### PR TITLE
Use 10% buffer on text area word limits

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -138,14 +138,20 @@ window.FormValidation =
         return question.find("input[type='checkbox']").filter(":checked").length
 
   validateWordLimit: (question) ->
+    questionRef = question.attr("data-question_ref")
     textarea = question.find("textarea")
     wordLimit = textarea.attr("data-word-max")
+    maxWordLimit = Math.round(wordLimit * 1.1)
     textareaValue = textarea.val() || '';
-    normalizedContent = textareaValue.replace(/(&nbsp;|\n|\s)+/g, ' ').trim();
-    wordCount = normalizedContent.split(" ").length
-    if wordCount > wordLimit
+    # change newlines to space, remove leading and trailing spaces, remove multiple spaces
+    normalizedContent = textareaValue
+      .replace(/\n/g,' ')
+      .replace(/(^\s*)|(\s*$)/gi,'')
+      .replace(/[ ]{2,}/gi,' ')
+    wordCount = normalizedContent.split(" ").length;
+    if wordCount > maxWordLimit
       @logThis(question, "validateWordLimit", "Word limit exceeded")
-      @addErrorMessage(question, "Exceeded #{wordLimit} word limit.")
+      @addErrorMessage(question, "Question #{questionRef} has a word limit of #{wordLimit}. Your answer has to be #{maxWordLimit} words or less (as we allow 10% leeway).")
 
   validateSubfieldWordLimit: (question) ->
     wordLimit = $(question.context).attr("data-word-max")

--- a/forms/qae_form_builder/textarea_question.rb
+++ b/forms/qae_form_builder/textarea_question.rb
@@ -9,9 +9,9 @@ class QaeFormBuilder
 
       limit = question.delegate_obj.words_max
 
-      if limit && limit_with_buffer(limit) && length && length > limit_with_buffer(limit)
+      if limit && limit_with_buffer(limit) && length && length > (limit_with_buffer(limit) - 1)
         result[question.hash_key] ||= ""
-        result[question.hash_key] << " Exceeded #{limit} words limit."
+        result[question.hash_key] << " Question #{question.ref} has a word limit of #{limit}. Your answer has to be #{limit_with_buffer(limit) - 1} words or less (as we allow 10% leeway)."
       end
 
       result


### PR DESCRIPTION
Signed-off-by: Louis Kirkham <louis.kirkham@bitzesty.com>

## 📝 A short description of the changes

* Add 10% leeway when showing error for textarea word limits
* Change word count calculation to exclude trailing spaces 
* Update error message on backend and frontend validations 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207873161652607/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="752" alt="Screenshot 2024-07-25 at 11 06 04" src="https://github.com/user-attachments/assets/ad736b9c-df72-4719-b3e6-8e90ba6d122a">

