### PR TITLE
Updates error message for 15 word limit questions

### DIFF
--- a/forms/qae_form_builder/textarea_question.rb
+++ b/forms/qae_form_builder/textarea_question.rb
@@ -11,7 +11,11 @@ class QaeFormBuilder
 
       if limit && limit_with_buffer(limit) && length && length > (limit_with_buffer(limit) - 1)
         result[question.hash_key] ||= ""
-        result[question.hash_key] << " Question #{question.ref} has a word limit of #{limit}. Your answer has to be #{limit_with_buffer(limit) - 1} words or less (as we allow 10% leeway)."
+        if limit_with_buffer(limit) > 15
+          result[question.hash_key] << " Question #{question.ref} has a word limit of #{limit}. Your answer has to be #{limit_with_buffer(limit) - 1} words or less (as we allow 10% leeway)."
+        else
+          result[question.hash_key] << " Question #{question.ref} has a word limit of #{limit}. Your answer has to be #{limit_with_buffer(limit) - 1} word or less."
+        end
       end
 
       result


### PR DESCRIPTION
Signed-off-by: Louis Kirkham <louis.kirkham@bitzesty.com>

## 📝 A short description of the changes

* Changes validation to exclude 10% leeway when 15 words or less
* Adds a different error for when the word limit is 15 or less
* Replaces non-breaking whitespace unicode. This change had been missed when updating the word count check.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207904458299115/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="937" alt="Screenshot 2024-07-29 at 13 30 30" src="https://github.com/user-attachments/assets/7d80cb08-e149-4a07-9ee8-fe406034e141">
