### PR TITLE
Patch for missing method error

### DIFF
--- a/app/controllers/form_award_eligibilities_controller.rb
+++ b/app/controllers/form_award_eligibilities_controller.rb
@@ -39,7 +39,7 @@ class FormAwardEligibilitiesController < ApplicationController
         @award_eligibility.force_validate_now = true
         @award_eligibility.valid?
 
-        step = @award_eligibility.errors.keys.first
+        step = @award_eligibility.errors.try(:keys).try(:first)
       end
 
       if step


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds guards for missing method when trying to call keys on eligibility errors. This error is shown when previous award winner is true but no year has been entered.
* https://appsignal.com/bit-zesty/sites/601bfb8714ad665fb298effe/exceptions/incidents/146

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/0/1207921559820514/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
