### PR TITLE
Use all years for admin search when no params

### DIFF
--- a/app/views/shared/form_answers/_admin_award_year.html.slim
+++ b/app/views/shared/form_answers/_admin_award_year.html.slim
@@ -1,42 +1,33 @@
 - current_year = AwardYear.current.year
-- selected_year = params[:year] ? params[:year].to_i : current_year
+- selected_year = params[:year] ? params[:year].to_i : namespace_name == :admin ? 'all_years' : current_year
 - other_years = AwardYear.admin_switch.keys.select{ |year| year <= current_year }
 
 fieldset.award-year-z-index.applications-filter.award-year-radios
   label.applications-filter__label
     ' Award year
   .input__award-years
-    .if-no-js-hide
-      input type="radio" id="current_year" name="award_year" value="#{current_year}" checked=(current_year == params[:year].to_i || (namespace_name == :assessor && other_years.exclude?(params[:year].to_i)))
-      label for="current_year"
-        | Current year
-      input type="radio" id="all_years" name="award_year" value="all_years" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && other_years.exclude?(params[:year].to_i)))
-      label for="all_years"
-        | All years
-      input type="radio" id="other" name="award_year" value="#{selected_year}" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
-      label for="other"
-        | Other
+    input type="radio" id="current_year" name="year" value="#{current_year}" checked=(current_year == params[:year].to_i || (namespace_name == :assessor && other_years.exclude?(params[:year].to_i)))
+    label for="current_year"
+      | Current year
+    input type="radio" id="all_years" name="year" value="all_years" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && other_years.exclude?(params[:year].to_i)))
+    label for="all_years"
+      | All years
+    input type="radio" id="other" name="year" value="#{selected_year}" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
+    label for="other"
+      | Other
 
-      .dropdown.other-years-dropdown class="#{(current_year != selected_year && other_years.include?(params[:year].to_i) ? '' : 'hide')}"
-        a.dropdown-toggle.btn.btn-block.btn-default href="#" data-toggle="dropdown" role="button" aria-expanded="false"
-          - current_year_text = params[:year].to_s == "all_years" || !params[:year] || !other_years.include?(params[:year].to_i) ? "All Years" : "#{selected_year - 1} - #{selected_year}"
+    .dropdown.other-years-dropdown class="#{(current_year != selected_year && other_years.include?(params[:year].to_i) ? '' : 'hide')}"
+      a.dropdown-toggle.btn.btn-block.btn-default href="#" data-toggle="dropdown" role="button" aria-expanded="false"
+        - current_year_text = params[:year].to_s == "all_years" || !params[:year] || !other_years.include?(params[:year].to_i) ? "All Years" : "#{selected_year - 1} - #{selected_year}"
 
-          = current_year_text
-          span.caret-container
-            span.caret
-        ul.dropdown-menu.dropdown-menu-right
-          li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}" id="all_years"
-            = link_to "All Years", "#"
+        = current_year_text
+        span.caret-container
+          span.caret
+      ul.dropdown-menu.dropdown-menu-right
+        li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}" id="all_years"
+          = link_to "All Years", "#"
 
-          - AwardYear.admin_switch.each do |year, label|
-            - if year <= current_year
-              li class="#{'active' if label == current_year_text}" id="#{year}"
-                = link_to label, "#"
-
-    select name="year" id="award_year" class="form-control if-js-hide"
-      option value="all_years" selected=(params[:year].to_s == 'all_years' || (namespace_name == :admin && other_years.exclude?(params[:year].to_i)))
-        | All years
-      - AwardYear.admin_switch.each do |year, label|
-        - if year <= current_year
-          option value="#{year}" selected=(year == selected_year)
-            = label
+        - AwardYear.admin_switch.each do |year, label|
+          - if year <= current_year
+            li class="#{'active' if label == current_year_text}" id="#{year}"
+              = link_to label, "#"


### PR DESCRIPTION
Signed-off-by: Louis Kirkham <louis.kirkham@bitzesty.com>

## 📝 A short description of the changes

Fixes year being switched to current year when admins enter search terms and submit.

* Changes selected year to "all_years" for admin search default 
* params[:year] is being assigned twice due to the non-javascript year select. This PR select is removed so the param is only passed once.
* Changed :award_year param to :year

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207921559820519/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

