### PR TITLE
Disables duplicate inputs on submit

### DIFF
--- a/app/assets/javascripts/admin/applications-filter.js.coffee
+++ b/app/assets/javascripts/admin/applications-filter.js.coffee
@@ -132,10 +132,16 @@ filterApplicationsDropdowns = () ->
       dropdownWrapper.removeClass("hide")
       dropdown = dropdownWrapper.find(".dropdown-toggle")
       dropdown.focus().click()
+      $(this).prop('disabled', true);
     else
       selected_year = $(this).val()
       $(this).closest(".input__award-years").find("select option[value='#{selected_year}']").attr('selected', true).change()
+      $(this).prop('disabled', true);
       $(this).closest('form').submit()
+
+  # If other option is selected on page load, disable the radio button
+  if $(".applications-filter .input__award-years input[type='radio']:checked").attr('id') == "other"
+    $(".applications-filter .input__award-years input[type='radio']:checked").prop('disabled', true);
 
   # On clicking the award year from the other year dropdown
   $(document).on "click", ".applications-filter .other-years-dropdown .dropdown-menu li", (e) ->
@@ -144,6 +150,13 @@ filterApplicationsDropdowns = () ->
     # Set value of other radio button to selected year and submit
     selected_year = $(this).attr('id')
     $(this).closest(".input__award-years").find("select option[value='#{selected_year}']").attr('selected', true).change()
+    $(this).closest('form').submit()
+
+  # On clicking the search button disable the radio button input
+  $(document).on "click", ".applications-filter .search-input input.search-submit", (e) ->
+    e.stopPropagation()
+    e.preventDefault()
+    $(".applications-filter .input__award-years input[type='radio']:checked").prop('disabled', true);
     $(this).closest('form').submit()
 
 $(document).ready(ready)

--- a/app/views/shared/form_answers/_admin_award_year.html.slim
+++ b/app/views/shared/form_answers/_admin_award_year.html.slim
@@ -6,28 +6,37 @@ fieldset.award-year-z-index.applications-filter.award-year-radios
   label.applications-filter__label
     ' Award year
   .input__award-years
-    input type="radio" id="current_year" name="year" value="#{current_year}" checked=(current_year == params[:year].to_i || (namespace_name == :assessor && other_years.exclude?(params[:year].to_i)))
-    label for="current_year"
-      | Current year
-    input type="radio" id="all_years" name="year" value="all_years" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && other_years.exclude?(params[:year].to_i)))
-    label for="all_years"
-      | All years
-    input type="radio" id="other" name="year" value="#{selected_year}" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
-    label for="other"
-      | Other
+    .if-no-js-hide
+      input type="radio" id="current_year" name="year" value="#{current_year}" checked=(current_year == params[:year].to_i || (namespace_name == :assessor && other_years.exclude?(params[:year].to_i)))
+      label for="current_year"
+        | Current year
+      input type="radio" id="all_years" name="year" value="all_years" checked=(params[:year].to_s == 'all_years' || (namespace_name == :admin && other_years.exclude?(params[:year].to_i)))
+      label for="all_years"
+        | All years
+      input type="radio" id="other" name="year" value="#{selected_year}" checked=(current_year != selected_year && other_years.include?(params[:year].to_i))
+      label for="other"
+        | Other
 
-    .dropdown.other-years-dropdown class="#{(current_year != selected_year && other_years.include?(params[:year].to_i) ? '' : 'hide')}"
-      a.dropdown-toggle.btn.btn-block.btn-default href="#" data-toggle="dropdown" role="button" aria-expanded="false"
-        - current_year_text = params[:year].to_s == "all_years" || !params[:year] || !other_years.include?(params[:year].to_i) ? "All Years" : "#{selected_year - 1} - #{selected_year}"
+      .dropdown.other-years-dropdown class="#{(current_year != selected_year && other_years.include?(params[:year].to_i) ? '' : 'hide')}"
+        a.dropdown-toggle.btn.btn-block.btn-default href="#" data-toggle="dropdown" role="button" aria-expanded="false"
+          - current_year_text = params[:year].to_s == "all_years" || !params[:year] || !other_years.include?(params[:year].to_i) || selected_year == "all_years" ? "All Years" : "#{selected_year - 1} - #{selected_year}"
 
-        = current_year_text
-        span.caret-container
-          span.caret
-      ul.dropdown-menu.dropdown-menu-right
-        li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}" id="all_years"
-          = link_to "All Years", "#"
+          = current_year_text
+          span.caret-container
+            span.caret
+        ul.dropdown-menu.dropdown-menu-right
+          li class="#{'active' if params[:year].to_s == 'all_years' || !params[:year]}" id="all_years"
+            = link_to "All Years", "#"
 
-        - AwardYear.admin_switch.each do |year, label|
-          - if year <= current_year
-            li class="#{'active' if label == current_year_text}" id="#{year}"
-              = link_to label, "#"
+          - AwardYear.admin_switch.each do |year, label|
+            - if year <= current_year
+              li class="#{'active' if label == current_year_text}" id="#{year}"
+                = link_to label, "#"
+
+    select name="year" id="award_year" class="form-control if-js-hide"
+      option value="all_years" selected=(params[:year].to_s == 'all_years' || (namespace_name == :admin && other_years.exclude?(params[:year].to_i)))
+        | All years
+      - AwardYear.admin_switch.each do |year, label|
+        - if year <= current_year
+          option value="#{year}" selected=(year == selected_year)
+            = label


### PR DESCRIPTION
Signed-off-by: Louis Kirkham <louis.kirkham@bitzesty.com>

## 📝 A short description of the changes

* Adds back select element. The non-js select is used to pass the year params, so we disable the checked radio input on submit to not duplicate the year param.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1207921559820519/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
