### PR TITLE
Reset `required_rows` array before each assignment [PRODUCTION]

### DIFF
--- a/forms/qae_form_builder/matrix_question.rb
+++ b/forms/qae_form_builder/matrix_question.rb
@@ -35,6 +35,8 @@ class QaeFormBuilder
       errors = super
 
       if delegate_obj.required_row_parent
+        delegate_obj.required_rows = []
+
         step.form[delegate_obj.required_row_parent].input_value&.each { |a| delegate_obj.required_rows << a["type"] }
       end
 


### PR DESCRIPTION
## 📝 A short description of the changes

Cherry-picked from #3038.

This PR should fix issue with triggering validations on matrix questions in cases when no validation should be performed. Looks like when assigning to `required_rows`, this value needs to be reset first, otherwise it will also contain required_rows values.

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1208049970317716/f 

## :shipit: Deployment implications

None 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

