### PR TITLE
fix: Use most recent financial yr in pdf if available

### DIFF
--- a/app/form_pointers/latest_year_generator.rb
+++ b/app/form_pointers/latest_year_generator.rb
@@ -1,16 +1,19 @@
 module LatestYearGenerator
   def calculate_last_year(form_answer, day, month)
-    # Conditional latest year
-    # If from 7th of September to December -> then previous year
-    # If from January to 6th of September -> then current year
-    #
-
-    @form_answer_award_year = form_answer.award_year.year if @form_answer_award_year.blank?
-
-    if form_answer.financial_year_changeable? || (month.to_i == 9 && day.to_i > 6) || month.to_i > 9
-      @form_answer_award_year - 2
+    if form_answer.document["most_recent_financial_year"]
+      @form_answer_award_year = form_answer.document["most_recent_financial_year"].to_i
     else
-      @form_answer_award_year - 1
+      # Conditional latest year
+      # If from 7th of September to December -> then previous year
+      # If from January to 6th of September -> then current year
+      #
+      @form_answer_award_year = form_answer.award_year.year if @form_answer_award_year.blank?
+
+      if form_answer.financial_year_changeable? || (month.to_i == 9 && day.to_i > 6) || month.to_i > 9
+        @form_answer_award_year - 2
+      else
+        @form_answer_award_year - 1
+      end
     end
   end
 end


### PR DESCRIPTION
fix: Update calculate_last_year method to use most_recent_financial_year if available

## 📝 A short description of the changes

* The code changes in `latest_year_generator.rb` modify the `calculate_last_year` method to check if the `form_answer` has a `most_recent_financial_year` value in its document. If it does, the method uses that value as the `@form_answer_award_year`. Otherwise, it falls back to the previous logic of calculating the award year based on the month and day.

This change improves the accuracy of determining the award year and ensures that the most recent financial year is used when available.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1208062683229741/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="802" alt="Screenshot 2024-08-18 at 17 50 22" src="https://github.com/user-attachments/assets/c2265b85-df80-402a-b829-ea2524d26c62">
