### PR TITLE
fix: Handle division by zero in growth calculation

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/custom_questions/financial_table_summary.rb
+++ b/app/pdf_generators/qae_pdf_forms/custom_questions/financial_table_summary.rb
@@ -420,8 +420,12 @@ module QaePdfForms::CustomQuestions::FinancialTableSummary
     growth_percentages = ["-"]
 
     (1...values.length).each do |i|
-      growth = ((values[i] - values[i - 1]) / values[i - 1]) * 100
-      growth_percentages << growth.round.to_s
+      if values[i - 1] != 0
+        growth = ((values[i] - values[i - 1]) / values[i - 1]) * 100
+        growth_percentages << growth.round.to_s
+      else
+        growth_percentages << "-" # Handle division by zero
+      end
     end
 
     growth_percentages


### PR DESCRIPTION
## 📝 A short description of the changes

* This commit modifies the `FinancialTableSummary` module to handle division by zero in the growth calculation. Previously, if the previous value was zero, the calculation would result in an error. Now, if the previous value is zero, the growth percentage is set to "-" to indicate no growth. This prevents the division by zero error and ensures accurate growth calculations.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1208112729561960/f
* https://appsignal.com/bit-zesty/sites/601bfb8714ad665fb298effe/exceptions/incidents/3603/samples/last

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
