### PR TITLE
chore: Update CarrierWave cache directory configuration

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -13,10 +13,10 @@ CarrierWave.configure do |config|
     config.fog_directory = ENV["AWS_S3_BUCKET_NAME"]
     config.storage = :fog
     config.fog_public = false
+    config.cache_dir = "/tmp/carrierwave"
   else
     config.storage = :file
+    config.cache_dir = Rails.root.join("tmp/uploads")
   end
-
   config.cache_storage = :file
-  config.cache_dir = Rails.root.join("tmp/uploads")
 end


### PR DESCRIPTION
## 📝 A short description of the changes

* This commit updates the CarrierWave configuration in the `config/initializers/carrierwave.rb` file. It sets the cache directory to "/tmp/carrierwave" when using the AWS S3 storage, and to "Rails.root.join("tmp/uploads")" when using the file storage. This change ensures that the cache directory is properly configured based on the storage type.


## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1207904458299124/1208064820368724

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

