### PR TITLE
Change warning when multiple collaborators are working on the same form

### DIFF
--- a/app/assets/javascripts/frontend/application_collaborators/editor_bar.js.coffee
+++ b/app/assets/javascripts/frontend/application_collaborators/editor_bar.js.coffee
@@ -2,23 +2,35 @@ window.ApplicationCollaboratorsEditorBar =
 
   render_collaborators_bar: () ->
     editor = ApplicationCollaboratorsAccessManager.current_editor()
-    current_editor_name = editor.info.name + " (" + editor.info.email + ")"
+    currentEditorName = editor.info.name + " (" + editor.info.email + ")"
 
     members = window.pusher_current_channel.members
     me = members.me
 
     if me.info.email == editor.info.email
-      message = "It seems you already opened this section on another tab or browser!"
+      header = "You cannot edit this section unless you close it elsewhere first."
+      message = "It looks like you have already opened this section in another tab or window. To avoid data-saving issues, you can only have it open in one tab or window at a time. Please close the other tabs or windows to continue editing."
     else
-      message = "Currently, " + current_editor_name + " is working on this section! Try later!"
+      header = "You are not able to work on this section at the moment."
+      message = "Currently, #{currentEditorName} is working on this section. To avoid data-saving issues, only one person can work on a section at a time. Please work on another section or try this section later."
 
-    $(".js-collaborators-bar").removeClass('hidden')
-                              .text(message)
+    $(".js-collaborators-bar").removeClass('hidden').html('
+<div aria-labelledby="govuk-warning-banner-title" class="govuk-notification-banner" data-module="govuk-notification-banner" role="region">
+  <div class="govuk-notification-banner__header">
+    <div class="govuk-notification-banner__title" id="govuk-warning-banner-title">' + header + '</div>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-body">' + message + '</p>
+  </div>
+</div>
+    ')
 
   hide_collaborators_bar: () ->
-    $(".js-collaborators-bar").addClass('hidden')
-                              .text("")
+    $(".js-collaborators-bar").addClass('hidden').text("")
 
   show_loading_bar: () ->
-    $(".js-collaborators-bar").removeClass('hidden')
-                              .text("Loading ...")
+    $(".js-collaborators-bar").removeClass('hidden').html('
+<div class="govuk-warning-text">
+  <strong class="govuk-warning-text__text">Loading…</strong>
+</div>
+    ')

--- a/app/assets/javascripts/frontend/application_collaborators/form_locker.js.coffee
+++ b/app/assets/javascripts/frontend/application_collaborators/form_locker.js.coffee
@@ -19,6 +19,12 @@ window.ApplicationCollaboratorsFormLocker =
                                                       .prop('disabled', true)
     $(".js-save-and-come-back").hide()
 
+    # Disable instances of CKEditor
+    #
+    for i of CKEDITOR.instances
+      instance = CKEDITOR.instances[i]
+      instance.setReadOnly(true)
+
     # Update 'Back' link with form_refresh option
     # in order to avoid redirection to NON JS version
     #

--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -1053,16 +1053,33 @@ select.js-trigger-autosave.custom-select.sic_code-selector {
 }
 
 .js-collaborators-bar {
-  padding-left: 32px;
-  font-weight: bold;
-  font-size: 18px;
-  position: fixed;
-  top: 0;
-  z-index:10000;
-  padding: 10px;
+  position: sticky;
+  top: 5px;
+  z-index: 10000;
+  padding: 0;
   margin: 0 auto;
-  background-color: #FFFAFA;
-  border-radius: 0 0 5px 0;
+
+  .govuk-notification-banner {
+    border: 5px solid #d4351c;
+    background-color: #d4351c;
+
+    .govuk-notification-banner__content > * {
+      max-width: 900px;
+    }
+  }
+
+  .govuk-warning-text {
+    position: fixed;
+    top: 5px;
+    left: 5px;
+    z-index: 10000;
+    background-color: #ffffff;
+    padding: 10px;
+
+    .govuk-warning-text__text {
+      padding: 0 !important;
+    }
+  }
 }
 
 .js-ckeditor-spinner-block {

--- a/app/assets/stylesheets/frontend/views/award_form.scss
+++ b/app/assets/stylesheets/frontend/views/award_form.scss
@@ -392,8 +392,3 @@ select.read-only {
     margin-right: 0.5em;
   }
 }
-
-.form-banner {
-  max-width: 100%;
-  font-size: 1.25em;
-}

--- a/app/views/qae_form/show.html.slim
+++ b/app/views/qae_form/show.html.slim
@@ -3,19 +3,7 @@
 - provide(:page_wrapper_class, "page-award-form #{'page-read-only-form' if current_form_is_not_editable?}")
 
 - if application_collaborator_group_mode?(@form_answer)
-  - provide(:body_end) do
-    .js-collaborators-bar.hidden
-
-.govuk-notification-banner role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
-  .govuk-notification-banner__header
-    .govuk-notification-banner__title#govuk-notification-banner-title
-      | Important
-  .govuk-notification-banner__content
-    p.govuk-body.form-banner
-      | Collaborators can work on the form simultaneously in different sections.
-      strong
-        =< "However, we advise that one person works on a section at a time to avoid data saving issues"
-      | .
+  .js-collaborators-bar.hidden
 
 form.qae-form.award-form data-autosave-url=save_form_url(@form_answer) action=save_form_url(@form_answer, next_step: next_step(@form, params[:step]), current_step: params[:step]) method="POST" data-attachments-url=attachments_url(@form_answer) novalidate=true
 


### PR DESCRIPTION
## 📝 A short description of the changes

 - updated styling of warning which is displayed when multiple collaborators are working on the same application.
 - removed the generic banner
 - fixed disabling of CKEditor instances

## 🔗 Link to the relevant story (or stories)

Asana card here: https://app.asana.com/0/1200504523179343/1208164465455902/f

## :shipit: Deployment implications

None 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

