### PR TITLE
fix: Refactor word limit error message in QaeFormBuilder and Textarea Question

### DIFF
--- a/forms/qae_form_builder/question.rb
+++ b/forms/qae_form_builder/question.rb
@@ -48,7 +48,7 @@ class QaeFormBuilder
 
     def limit_with_buffer(limit)
       if limit > 15
-        (limit + limit * 0.1).to_i + 1
+        (limit + limit * 0.1).to_i
       else
         limit
       end

--- a/forms/qae_form_builder/textarea_question.rb
+++ b/forms/qae_form_builder/textarea_question.rb
@@ -9,12 +9,12 @@ class QaeFormBuilder
 
       limit = question.delegate_obj.words_max
 
-      if limit && limit_with_buffer(limit) && length && length > (limit_with_buffer(limit) - 1)
+      if limit && limit_with_buffer(limit) && length && length > (limit_with_buffer(limit))
         result[question.hash_key] ||= ""
         error = if limit_with_buffer(limit) > 15
-          " Question #{question.ref} has a word limit of #{limit}. Your answer has to be #{limit_with_buffer(limit) - 1} words or less (as we allow 10% leeway)."
+          " Question #{question.ref} has a word limit of #{limit}. Your answer has to be #{limit_with_buffer(limit)} words or less (as we allow 10% leeway)."
         else
-          " Question #{question.ref} has a word limit of #{limit}. Your answer has to be #{limit_with_buffer(limit) - 1} word or less."
+          " Question #{question.ref} has a word limit of #{limit}. Your answer has to be #{limit_with_buffer(limit)} words or less."
         end
         result[question.hash_key] << error
       end


### PR DESCRIPTION
## 📝 A short description of the changes

* For questions with word limits of 15, the back end validation was incorrectly showing an error message that the word limit was 14 words. The limit_with_buffer method is also used in AwardHolderQuestionValidator which was last used in 2018 forms. 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1208254704738291/f

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

