### PR TITLE
fix: Fix NaN issue in matrix question calculation

### DIFF
--- a/forms/qae_form_builder/matrix_question.rb
+++ b/forms/qae_form_builder/matrix_question.rb
@@ -104,7 +104,7 @@ class QaeFormBuilder
       disadvantaged ||= 0
       total = answers["#{question_key}_#{x_heading}_calculated_total"].to_f
       proportion = (disadvantaged.to_f / total * 100).round(2)
-      answers["#{question_key}_#{x_heading}_calculated_proportion"] = proportion
+      answers["#{question_key}_#{x_heading}_calculated_proportion"] = proportion.nan? ? 0 : proportion
     end
 
     def assign_autocalculated_value(question_key, x_headings, y_headings, answers, disabled_input, x_heading, y_heading)


### PR DESCRIPTION
## 📝 A short description of the changes

* Fixes an error on matrix question when total is NaN

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1208254704738300

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits
