### PR TITLE
chore: Update Cloud Foundry CLI installation in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           npm install -g yarn
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          echo "deb [trusted=yes] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt-get update
           sudo apt-get install cf7-cli
           cf -v


### PR DESCRIPTION
## 📝 A short description of the changes

* The Cloud Foundry repository was using an expired GPG key, causing apt to reject the repository because it could not verify the authenticity of the packages. This led to errors during the Docker build process.
