### PR TITLE
chore: Revert changes to RAG ratings

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -1602,18 +1602,18 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
     padding-left: pxToRem(5) !important;
 
     &.rag-positive {
-      background-color: #CCE1D8;
-      color: #015A30 !important;
+      background-color: #6B8E23;
+      color: white !important;
     }
 
     &.rag-average {
-      background-color: #C0D3E8;
-      color: #152C48 !important;
+      background-color: #DAA520;
+      color: white !important;
     }
 
     &.rag-negative {
-      background-color: #F6D7D2;
-      color: #942415 !important;
+      background-color: #FF0000;
+      color: white !important;
     }
   }
 

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -188,9 +188,9 @@ class Reports::FormAnswer
 
   def rag(var)
     {
-      "negative" => "Not recommended",
-      "positive" => "Recommended",
-      "average" => "Reserved",
+      "negative" => "R",
+      "positive" => "G",
+      "average" => "A",
     }[var]
   end
 

--- a/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
@@ -4,9 +4,9 @@ module CaseSummaryPdfs::General::DataPointer
                       "sustainable_development" => "Sustainable Development" }
 
   COLOR_LABELS = %w[positive average negative neutral]
-  POSITIVE_COLOR = "017E44"
-  AVERAGE_COLOR = "2C5C96"
-  NEGATIVE_COLOR = "B72C1A"
+  POSITIVE_COLOR = "6B8E23"
+  AVERAGE_COLOR = "DAA520"
+  NEGATIVE_COLOR = "FF0000"
   NEUTRAL_COLOR = "ECECEC"
   LINK_REGEXP = /((?:https?:\/\/|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>`!{}:;'"\[\]]*))/im
 

--- a/forms/appraisal_form.rb
+++ b/forms/appraisal_form.rb
@@ -59,9 +59,9 @@ class AppraisalForm
   ]
 
   RAG_OPTIONS_2025 = [
-    ["Does not meet expectations", "negative"],
-    ["Meets expectations", "average"],
-    ["Exceeds expectations", "positive"],
+    %w[Red negative],
+    %w[Amber average],
+    %w[Green positive],
   ]
 
   CSR_RAG_OPTIONS_2016 = [
@@ -263,7 +263,7 @@ class AppraisalForm
 
     option = options.detect do |opt|
       opt[1] == object.public_send(section.rate)
-    end || ["Select evaluation", "blank"]
+    end || ["Select RAG", "blank"]
 
     OpenStruct.new(
       options: options,

--- a/spec/models/reports/form_answer_spec.rb
+++ b/spec/models/reports/form_answer_spec.rb
@@ -95,7 +95,7 @@ describe Reports::FormAnswer do
     it "should return correct grade" do
       allow_any_instance_of(Reports::FormAnswer).to receive(:pick_assignment) { build(:assessor_assignment_moderated) }
       allow_any_instance_of(Reports::FormAnswer).to receive(:pick_assignment).with("moderated") { build(:assessor_assignment_moderated, document: { w_rate_1: "positive", w_rate_2: "average" }) }
-      expect(Reports::FormAnswer.new(build(:form_answer)).send(:mso_grade_agreed)).to eq "Recommended,Reserved"
+      expect(Reports::FormAnswer.new(build(:form_answer)).send(:mso_grade_agreed)).to eq "G,A"
     end
   end
 

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -72,14 +72,14 @@ def assert_rag_change(section_id, header_id)
 
   expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
-    expect(page).to have_selector(rag, text: "Select evaluation", count: 4)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 4)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
 
     first(".btn-rag").click
     find(".dropdown-menu .rag-negative").click
     wait_for_ajax
-    expect(page).to have_selector(rag, text: "Select evaluation", count: 3)
-    expect(page).to have_selector(rag, text: "Does not meet expectations", count: 1)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 3)
+    expect(page).to have_selector(rag, text: "Red", count: 1)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
   end
 
@@ -89,8 +89,8 @@ def assert_rag_change(section_id, header_id)
   take_a_nap
 
   within section_id do
-    expect(page).to have_selector(rag, text: "Select evaluation", count: 3)
-    expect(page).to have_selector(rag, text: "Does not meet expectations", count: 1)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 3)
+    expect(page).to have_selector(rag, text: "Red", count: 1)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
   end
   visit show_path


### PR DESCRIPTION
## 📝 A short description of the changes

* Reverts copy changes made to RAG ratings labels, PDF reports and changes colours back to previous values.

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1208311373967293

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="903" alt="Screenshot 2024-09-17 at 14 00 05" src="https://github.com/user-attachments/assets/6d25a74a-ca3a-4d8b-a7ba-16941754bc56">
