### PR TITLE
Reverts changes to RAG ratings

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -1560,7 +1560,6 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
 // RAG dropdown
 .form-label-rag {
   display: block;
-  position: relative;
   margin-top: pxToRem(10);
   margin-bottom: pxToRem(10);
 
@@ -1583,9 +1582,11 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
 }
 
 .btn-rag {
-  position: absolute;
-  right: 0;
-  top: pxToRem(-5);
+  display: block;
+
+  button {
+    float: none !important;
+  }
 
   @include screen-xs-max {
     display: block;

--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -1583,9 +1583,9 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
 }
 
 .btn-rag {
+  position: absolute;
   right: 0;
   top: pxToRem(-5);
-  padding-right: pxToRem(5);
 
   @include screen-xs-max {
     display: block;
@@ -1595,25 +1595,6 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
   &.open {
     .lte-ie7 & {
       z-index: 9999;
-    }
-  }
-
-  .btn {
-    padding-left: pxToRem(5) !important;
-
-    &.rag-positive {
-      background-color: #CCE1D8;
-      color: #015A30 !important;
-    }
-
-    &.rag-average {
-      background-color: #C0D3E8;
-      color: #152C48 !important;
-    }
-
-    &.rag-negative {
-      background-color: #F6D7D2;
-      color: #942415 !important;
     }
   }
 
@@ -1643,7 +1624,7 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
   .caret {
     position: absolute;
     top: 50%;
-    right: pxToRem(5);
+    right: 0;
     margin-top: pxToRem(-2);
   }
 
@@ -1654,7 +1635,7 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
   }
 
   .dropdown-toggle {
-    padding-right: pxToRem(20);
+    padding-right: pxToRem(25);
     padding-left: 0;
 
     @include screen-xs-max {
@@ -1672,6 +1653,10 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
         width: 100%;
       }
     }
+  }
+
+  &.rag-editable .dropdown-toggle {
+    padding-right: pxToRem(40);
   }
 
   .dropdown-menu {
@@ -1707,14 +1692,88 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
     color: #a94442 !important;
   }
 
-  .rag-blank, .rag-neutral, .rag-positive, .rag-average, .rag-negative {
+  .rag-blank {
     &,
     a,
     a:hover,
     a:focus {
       color: $black;
-      text-decoration: none;
-      font: normal pxToRem(16) 'Arial', sans-serif;
+    }
+
+    .icon-rag {
+      background-image: image-url("icon-grade-blank.png");
+
+      @include is-retina {
+        background-image: image-url("icon-grade-blank@2.png");
+      }
+    }
+  }
+
+  .rag-neutral {
+    &,
+    a,
+    a:hover,
+    a:focus {
+      color: $black;
+    }
+
+    .icon-rag {
+      background-image: image-url("icon-grade-neutral.png");
+
+      @include is-retina {
+        background-image: image-url("icon-grade-neutral@2.png");
+      }
+    }
+  }
+
+  .rag-positive {
+    &,
+    a,
+    a:hover,
+    a:focus {
+      color: $green;
+    }
+
+    .icon-rag {
+      background-image: image-url("icon-grade-green.png");
+
+      @include is-retina {
+        background-image: image-url("icon-grade-green@2.png");
+      }
+    }
+  }
+
+  .rag-average {
+    &,
+    a,
+    a:hover,
+    a:focus {
+      color: $amber;
+    }
+
+    .icon-rag {
+      background-image: image-url("icon-grade-amber.png");
+
+      @include is-retina {
+        background-image: image-url("icon-grade-amber@2.png");
+      }
+    }
+  }
+
+  .rag-negative {
+    &,
+    a,
+    a:hover,
+    a:focus {
+      color: $red;
+    }
+
+    .icon-rag {
+      background-image: image-url("icon-grade-red.png");
+
+      @include is-retina {
+        background-image: image-url("icon-grade-red@2.png");
+      }
     }
   }
 
@@ -1726,7 +1785,6 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
     a:hover,
     a:focus {
       text-decoration: none;
-      font-weight: normal;
     }
   }
 }

--- a/app/models/reports/form_answer.rb
+++ b/app/models/reports/form_answer.rb
@@ -188,9 +188,9 @@ class Reports::FormAnswer
 
   def rag(var)
     {
-      "negative" => "Not recommended",
-      "positive" => "Recommended",
-      "average" => "Reserved",
+      "negative" => "R",
+      "positive" => "G",
+      "average" => "A",
     }[var]
   end
 

--- a/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
@@ -4,9 +4,9 @@ module CaseSummaryPdfs::General::DataPointer
                       "sustainable_development" => "Sustainable Development" }
 
   COLOR_LABELS = %w[positive average negative neutral]
-  POSITIVE_COLOR = "017E44"
-  AVERAGE_COLOR = "2C5C96"
-  NEGATIVE_COLOR = "B72C1A"
+  POSITIVE_COLOR = "6B8E23"
+  AVERAGE_COLOR = "DAA520"
+  NEGATIVE_COLOR = "FF0000"
   NEUTRAL_COLOR = "ECECEC"
   LINK_REGEXP = /((?:https?:\/\/|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>`!{}:;'"\[\]]*))/im
 
@@ -186,9 +186,9 @@ module CaseSummaryPdfs::General::DataPointer
       end
 
       pdf_doc.text entry[0], header_text_properties
-      pdf_doc.move_down 3.mm
 
       pdf_doc.text entry[2], header_text_properties.merge({ color: color_by_value(entry[2], year) })
+
       pdf_doc.move_down 5.mm
 
       pdf_doc.text entry[1], header_text_properties.merge({ style: :normal })

--- a/app/views/admin/feedbacks/_strength_field.html.slim
+++ b/app/views/admin/feedbacks/_strength_field.html.slim
@@ -10,16 +10,16 @@
 
     label.form-label.form-label-rag for="feedback_#{field}_rate"
       = value[:label]
-      .btn-group.btn-rag class="#{'rag-editable' unless feedback.locked?}"
-        button.btn.btn-link.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
-          span.rag-text= form.option[0]
-          span.glyphicon.icon-rag
-          - if !feedback.locked?
-            span.caret
+    .btn-group.btn-rag class="#{'rag-editable' unless feedback.locked?}"
+      button.btn.btn-link.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
+        span.rag-text= form.option[0]
+        span.glyphicon.icon-rag
         - if !feedback.locked?
-          ul.dropdown-menu.pull-right role="menu"
-            - form.options.each do |opt|
-              li class="rag-#{opt[1]}"
-                = link_to "#"
-                  span.icon-rag
-                  span.rag-text= opt[0]
+          span.caret
+      - if !feedback.locked?
+        ul.dropdown-menu role="menu"
+          - form.options.each do |opt|
+            li class="rag-#{opt[1]}"
+              = link_to "#"
+                span.icon-rag
+                span.rag-text= opt[0]

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -4,28 +4,28 @@
 
 .form-group.rag-section[class="#{'form-edit' if f.object.public_send(section.desc).blank? && editable} form-#{section.label.parameterize}" data-controller="element-focus"]
   .form-container
-    label.form-label.form-label-rag for="#{f.object.position}_#{section.desc}_comment"
-      span.rag_section_label
-        = section.label
-
     = f.input section.rate,
               as: :select,
               label: false,
               collection: form.options,
               input_html: { class: "if-js-hide", "data-updated-section" => section.rate, id: "#{f.object.position}_#{section.desc}_select" }
 
-    .btn-group.btn-rag.if-no-js-hide class="#{'rag-editable' if editable}"
-      button.btn.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]} rag_#{f.object.public_send(section.rate)}"
-        span.rag-text= form.option[0]
+    label.form-label.form-label-rag for="#{f.object.position}_#{section.desc}_comment"
+      span.rag_section_label
+        = section.label
+      .btn-group.btn-rag class="#{'rag-editable' if editable}"
+        button.btn.btn-link.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
+          span.rag-text= form.option[0]
+          span.glyphicon.icon-rag
+          - if editable
+            span.caret
         - if editable
-          span.caret
-      - if editable
-        ul.dropdown-menu role="menu"
-          - form.options.each do |opt|
-            li class="rag-#{opt[1]}"
-              = link_to "#"
-                span.icon-rag
-                span.rag-text= opt[0]
+          ul.dropdown-menu.pull-right role="menu"
+            - form.options.each do |opt|
+              li class="rag-#{opt[1]}"
+                = link_to "#"
+                  span.icon-rag
+                  span.rag-text= opt[0]
 
     .form-value
       p

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -13,19 +13,19 @@
     label.form-label.form-label-rag for="#{f.object.position}_#{section.desc}_comment"
       span.rag_section_label
         = section.label
-      .btn-group.btn-rag class="#{'rag-editable' if editable}"
-        button.btn.btn-link.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
-          span.rag-text= form.option[0]
-          span.glyphicon.icon-rag
-          - if editable
-            span.caret
+    .btn-group.btn-rag class="#{'rag-editable' if editable}"
+      button.btn.btn-link.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
+        span.rag-text= form.option[0]
+        span.glyphicon.icon-rag
         - if editable
-          ul.dropdown-menu.pull-right role="menu"
-            - form.options.each do |opt|
-              li class="rag-#{opt[1]}"
-                = link_to "#"
-                  span.icon-rag
-                  span.rag-text= opt[0]
+          span.caret
+      - if editable
+        ul.dropdown-menu role="menu"
+          - form.options.each do |opt|
+            li class="rag-#{opt[1]}"
+              = link_to "#"
+                span.icon-rag
+                span.rag-text= opt[0]
 
     .form-value
       p

--- a/app/views/admin/form_answers/appraisal_form_components/_strengths_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_strengths_section.html.slim
@@ -11,16 +11,16 @@
 
     label.form-label.form-label-rag
       = section.label
-      .btn-group.btn-rag class="#{'rag-editable' if editable}"
-        button.btn.btn-link.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
-          span.rag-text= form.option[0]
-          span.glyphicon.icon-rag
-          - if editable
-            span.caret
+    .btn-group.btn-rag class="#{'rag-editable' if editable}"
+      button.btn.btn-link.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
+        span.rag-text= form.option[0]
+        span.glyphicon.icon-rag
         - if editable
-          ul.dropdown-menu.pull-right role="menu"
-            - form.options.each do |opt|
-              li class="rag-#{opt[1]}"
-                = link_to "#"
-                  span.icon-rag
-                  span.rag-text= opt[0]
+          span.caret
+      - if editable
+        ul.dropdown-menu role="menu"
+          - form.options.each do |opt|
+            li class="rag-#{opt[1]}"
+              = link_to "#"
+                span.icon-rag
+                span.rag-text= opt[0]

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -12,19 +12,19 @@
 
     label.form-label.form-label-rag for="#{f.object.position}_verdict"
       = section.label
-      .btn-group.btn-rag class="#{'rag-editable' if rag_editable}"
-        button.btn.btn-link.dropdown-toggle class="#{'non-editable' if !rag_editable}" type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
-          span.rag-text= form.option[0]
-          span.glyphicon.icon-rag
-          - if rag_editable
-            span.caret
+    .btn-group.btn-rag class="#{'rag-editable' if rag_editable}"
+      button.btn.btn-link.dropdown-toggle class="#{'non-editable' if !rag_editable}" type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
+        span.rag-text= form.option[0]
+        span.glyphicon.icon-rag
         - if rag_editable
-          ul.dropdown-menu.pull-right role="menu"
-            - form.options.each do |opt|
-              li class="rag-#{opt[1]}"
-                = link_to "#"
-                  span.icon-rag
-                  span.rag-text= opt[0]
+          span.caret
+      - if rag_editable
+        ul.dropdown-menu role="menu"
+          - form.options.each do |opt|
+            li class="rag-#{opt[1]}"
+              = link_to "#"
+                span.icon-rag
+                span.rag-text= opt[0]
 
     .form-value
       p

--- a/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_verdict_section.html.slim
@@ -4,16 +4,15 @@
 
 .form-group.verdict-section[class="#{'form-edit' if f.object.public_send(section.desc).blank? && editable} form-#{section.label.parameterize}" data-controller="element-focus"]
   .form-container
-    label.form-label.form-label-rag for="#{f.object.position}_verdict"
-      = section.label
-
     = f.input section.rate,
               as: :select,
               label: false,
               collection: form.options,
               input_html: { class: "if-js-hide", "data-updated-section"  => section.desc, id: "#{f.object.position}_#{section.desc}_select"}
 
-    .btn-group.btn-rag.if-no-js-hide class="#{'rag-editable' if rag_editable}"
+    label.form-label.form-label-rag for="#{f.object.position}_verdict"
+      = section.label
+      .btn-group.btn-rag class="#{'rag-editable' if rag_editable}"
         button.btn.btn-link.dropdown-toggle class="#{'non-editable' if !rag_editable}" type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
           span.rag-text= form.option[0]
           span.glyphicon.icon-rag

--- a/forms/appraisal_form.rb
+++ b/forms/appraisal_form.rb
@@ -263,7 +263,7 @@ class AppraisalForm
 
     option = options.detect do |opt|
       opt[1] == object.public_send(section.rate)
-    end || ["Select evaluation", "blank"]
+    end || ["Select RAG", "blank"]
 
     OpenStruct.new(
       options: options,

--- a/forms/appraisal_form.rb
+++ b/forms/appraisal_form.rb
@@ -59,9 +59,9 @@ class AppraisalForm
   ]
 
   RAG_OPTIONS_2025 = [
-    ["Does not meet expectations", "negative"],
-    ["Meets expectations", "average"],
-    ["Exceeds expectations", "positive"],
+    %w[Red negative],
+    %w[Amber average],
+    %w[Green positive],
   ]
 
   CSR_RAG_OPTIONS_2016 = [

--- a/spec/models/reports/form_answer_spec.rb
+++ b/spec/models/reports/form_answer_spec.rb
@@ -95,7 +95,7 @@ describe Reports::FormAnswer do
     it "should return correct grade" do
       allow_any_instance_of(Reports::FormAnswer).to receive(:pick_assignment) { build(:assessor_assignment_moderated) }
       allow_any_instance_of(Reports::FormAnswer).to receive(:pick_assignment).with("moderated") { build(:assessor_assignment_moderated, document: { w_rate_1: "positive", w_rate_2: "average" }) }
-      expect(Reports::FormAnswer.new(build(:form_answer)).send(:mso_grade_agreed)).to eq "Recommended,Reserved"
+      expect(Reports::FormAnswer.new(build(:form_answer)).send(:mso_grade_agreed)).to eq "G,A"
     end
   end
 

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -75,7 +75,7 @@ def assert_rag_change(section_id, header_id)
     expect(page).to have_selector(rag, text: "Select RAG", count: 4)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
 
-    first(".btn-rag").click
+    first(".btn-rag .btn").click
     find(".dropdown-menu .rag-negative").click
     wait_for_ajax
     expect(page).to have_selector(rag, text: "Select RAG", count: 3)
@@ -163,7 +163,7 @@ def assert_verdict_change(section_id, header_id)
 
   within section_id do
     expect(page).to have_selector(".rag-text", text: "Select verdict", count: 1)
-    all(".btn-rag").last.click
+    all(".btn-rag .btn").last.click
     find(".dropdown-menu .rag-positive a").click
     wait_for_ajax
   end

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -72,13 +72,13 @@ def assert_rag_change(section_id, header_id)
 
   expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
-    expect(page).to have_selector(rag, text: "Select evaluation", count: 4)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 4)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
 
     first(".btn-rag").click
     find(".dropdown-menu .rag-negative").click
     wait_for_ajax
-    expect(page).to have_selector(rag, text: "Select evaluation", count: 3)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 3)
     expect(page).to have_selector(rag, text: "Does not meet expectations", count: 1)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
   end
@@ -89,7 +89,7 @@ def assert_rag_change(section_id, header_id)
   take_a_nap
 
   within section_id do
-    expect(page).to have_selector(rag, text: "Select evaluation", count: 3)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 3)
     expect(page).to have_selector(rag, text: "Does not meet expectations", count: 1)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
   end

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -79,7 +79,7 @@ def assert_rag_change(section_id, header_id)
     find(".dropdown-menu .rag-negative").click
     wait_for_ajax
     expect(page).to have_selector(rag, text: "Select RAG", count: 3)
-    expect(page).to have_selector(rag, text: "Does not meet expectations", count: 1)
+    expect(page).to have_selector(rag, text: "Red", count: 1)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
   end
 
@@ -90,7 +90,7 @@ def assert_rag_change(section_id, header_id)
 
   within section_id do
     expect(page).to have_selector(rag, text: "Select RAG", count: 3)
-    expect(page).to have_selector(rag, text: "Does not meet expectations", count: 1)
+    expect(page).to have_selector(rag, text: "Red", count: 1)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
   end
   visit show_path


### PR DESCRIPTION
## 📝 A short description of the changes

* Reverts changes to RAG ratings and colours and PDF reports.
* Moves RAG dropdown to left of blocks

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1208311373967293

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="880" alt="Screenshot 2024-09-17 at 14 22 26" src="https://github.com/user-attachments/assets/6e64c3a2-5531-44ee-8e8b-21d6663593e8">
