### PR TITLE
chore: Refactor ESG RAG section dropdown in appraisal form

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -1656,7 +1656,7 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
     }
   }
 
-  &.rag-editable .dropdown-toggle {
+  &.rag-editable:not(.csr-btn-rag) .dropdown-toggle {
     padding-right: pxToRem(40);
   }
 
@@ -1673,7 +1673,7 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
       }
     }
 
-    a {
+    a:not(.esg-item) {
       padding-top: pxToRem(6);
       padding-bottom: pxToRem(6);
       padding-left: pxToRem(37);
@@ -1775,6 +1775,15 @@ label.govuk-label.govuk-checkboxes__label.boolean.optional.govuk-label {
       @include is-retina {
         background-image: image-url("icon-grade-red@2.png");
       }
+    }
+  }
+
+  .csr-rag-average {
+    &,
+    a,
+    a:hover,
+    a:focus {
+      color: $blue;
     }
   }
 

--- a/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
+++ b/app/views/admin/form_answers/appraisal_form_components/_rag_section.html.slim
@@ -1,6 +1,7 @@
 - form = AppraisalForm.rag_options_for(f.object, section)
 
 - editable = f.object.editable_for?(current_subject)
+- esg_section = section.desc == "corporate_social_responsibility_desc"
 
 .form-group.rag-section[class="#{'form-edit' if f.object.public_send(section.desc).blank? && editable} form-#{section.label.parameterize}" data-controller="element-focus"]
   .form-container
@@ -13,18 +14,20 @@
     label.form-label.form-label-rag for="#{f.object.position}_#{section.desc}_comment"
       span.rag_section_label
         = section.label
-    .btn-group.btn-rag class="#{'rag-editable' if editable}"
+    .btn-group.btn-rag class="#{'rag-editable' if editable} #{"csr-btn-rag" if esg_section}"
       button.btn.btn-link.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false" class="rag-#{form.option[1]}"
         span.rag-text= form.option[0]
-        span.glyphicon.icon-rag
+        - if !esg_section
+          span.glyphicon.icon-rag
         - if editable
           span.caret
       - if editable
         ul.dropdown-menu role="menu"
           - form.options.each do |opt|
-            li class="rag-#{opt[1]}"
-              = link_to "#"
-                span.icon-rag
+            li class="#{"rag-#{opt[1]}"} #{"csr-rag-#{opt[1]}" if esg_section}"
+              = link_to "#", class: "#{'esg-item' if esg_section}"
+                - if !esg_section
+                  span.icon-rag
                 span.rag-text= opt[0]
 
     .form-value

--- a/forms/appraisal_form.rb
+++ b/forms/appraisal_form.rb
@@ -119,9 +119,9 @@ class AppraisalForm
   ]
 
   CSR_RAG_OPTIONS_2025 = [
-    ["Weak (0-15)", "negative"],
-    ["Satisfactory (16-31)", "average"],
-    ["Exceptional (32-40)", "positive"],
+    ["Doesn't Meet", "negative"],
+    ["Meets", "average"],
+    ["Exceeds", "positive"],
   ]
 
   STRENGTH_OPTIONS_2016 = [
@@ -263,7 +263,10 @@ class AppraisalForm
 
     option = options.detect do |opt|
       opt[1] == object.public_send(section.rate)
-    end || ["Select RAG", "blank"]
+    end || (section.desc.include?("corporate_social_responsibility") &&
+      section.desc.exclude?("strategy")) ?
+      ["Select evaluation", "blank"] :
+      ["Select RAG", "blank"]
 
     OpenStruct.new(
       options: options,

--- a/spec/support/shared_contexts/appraisal_form_context.rb
+++ b/spec/support/shared_contexts/appraisal_form_context.rb
@@ -72,13 +72,13 @@ def assert_rag_change(section_id, header_id)
 
   expect(page).to have_css(section_id) # Forces capybara to wait for the section to become visible
   within section_id do
-    expect(page).to have_selector(rag, text: "Select RAG", count: 4)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 3)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
 
     first(".btn-rag .btn").click
     find(".dropdown-menu .rag-negative").click
     wait_for_ajax
-    expect(page).to have_selector(rag, text: "Select RAG", count: 3)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 2)
     expect(page).to have_selector(rag, text: "Red", count: 1)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
   end
@@ -89,10 +89,11 @@ def assert_rag_change(section_id, header_id)
   take_a_nap
 
   within section_id do
-    expect(page).to have_selector(rag, text: "Select RAG", count: 3)
+    expect(page).to have_selector(rag, text: "Select RAG", count: 2)
     expect(page).to have_selector(rag, text: "Red", count: 1)
     expect(page).to have_selector(rag, text: "Select verdict", count: 1)
   end
+
   visit show_path
 end
 


### PR DESCRIPTION
## 📝 A short description of the changes

* Changes ESG section of appraisal to use updated copy
* Removes icons for ESG section and changes colour of average rating from amber to blue 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1208311373967293

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="867" alt="Screenshot 2024-09-18 at 13 41 04" src="https://github.com/user-attachments/assets/5ebd7f8f-07c4-424a-bc48-6cb0cce255ff">


