### PR TITLE
chore: Update average color for ESG section ratings

### DIFF
--- a/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
+++ b/app/pdf_generators/case_summary_pdfs/general/data_pointer.rb
@@ -6,6 +6,7 @@ module CaseSummaryPdfs::General::DataPointer
   COLOR_LABELS = %w[positive average negative neutral]
   POSITIVE_COLOR = "6B8E23"
   AVERAGE_COLOR = "DAA520"
+  AVERAGE_BLUE_COLOR = "3276b1"
   NEGATIVE_COLOR = "FF0000"
   NEUTRAL_COLOR = "ECECEC"
   LINK_REGEXP = /((?:https?:\/\/|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>`!{}:;'"\[\]]*))/im
@@ -88,7 +89,7 @@ module CaseSummaryPdfs::General::DataPointer
   def rag_source(value)
     case value[:type]
     when :rag
-      if value[:label].include?("Corporate social responsibility")
+      if value[:label].include?("Environmental, social and corporate governance")
         AppraisalForm.const_get("CSR_RAG_OPTIONS_#{@award_year.year}")
       else
         AppraisalForm.const_get("RAG_OPTIONS_#{@award_year.year}")
@@ -186,9 +187,9 @@ module CaseSummaryPdfs::General::DataPointer
       end
 
       pdf_doc.text entry[0], header_text_properties
+      pdf_doc.move_down 3.mm
 
       pdf_doc.text entry[2], header_text_properties.merge({ color: color_by_value(entry[2], year) })
-
       pdf_doc.move_down 5.mm
 
       pdf_doc.text entry[1], header_text_properties.merge({ style: :normal })
@@ -199,7 +200,11 @@ module CaseSummaryPdfs::General::DataPointer
   def color_by_value(val, year)
     COLOR_LABELS.map do |label|
       if CaseSummaryPdfs::Pointer.const_get("#{label.upcase}_LABELS_#{year}").include?(val)
-        return self.class.const_get("#{label.upcase}_COLOR")
+        if val == "Meets"
+          return self.class.const_get(:AVERAGE_BLUE_COLOR)
+        else
+          return self.class.const_get("#{label.upcase}_COLOR")
+        end
       end
     end
   end


### PR DESCRIPTION
## 📝 A short description of the changes

* Displays rating in blue colour instead of amber for ESG section

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179343/1208311373967293

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

<img width="1195" alt="Screenshot 2024-09-20 at 10 37 13" src="https://github.com/user-attachments/assets/ab43e93b-7ebd-47cc-9356-2a23ab190b70">
