### PR TITLE
Modify validations behaviour

### DIFF
--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -1,5 +1,6 @@
 window.FormValidation =
   validates: true
+  validate_only_touched_inputs: true
   # validates numbers, including floats and negatives
   numberRegex: /^-?\d*\,?\d*\,?\d*\,?\d*\,?\d*\.?\,?\d*$/
 
@@ -10,8 +11,8 @@ window.FormValidation =
     $(".steps-progress-bar a.js-step-link").parent().removeClass("step-errors")
 
   clearErrors: (container) ->
-    if container.closest(".question-financial").length > 0
-      container.closest("label").find(".govuk-error-message").empty()
+    if container.closest(".span-financial").length > 0
+      container.closest(".span-financial").find(".govuk-error-message").empty()
     else if container.closest('.question-matrix').length > 0
       container.closest("td").find(".govuk-error-message").empty()
     else
@@ -31,10 +32,11 @@ window.FormValidation =
 
   appendMessage: (container, message) ->
     el = container.find(".govuk-error-message").first()
-    if el.text.length > 0
-      el.append(message)
-    else
-      el.append(" #{message}")
+    if not el.text().includes(message)
+      if el.text().length > 0
+        el.append(" #{message}")
+      else
+        el.append(message)
     @validates = false
 
   extractText: (identifier) ->
@@ -202,12 +204,17 @@ window.FormValidation =
 
     if subquestions.length
       for subquestion in subquestions
-        if not @validateSingleQuestion($(subquestion))
+        if (@validate_only_touched_inputs and @hasBeenTouched($(subquestion))) and not @validateSingleQuestion($(subquestion))
+          @addSubfieldError(question, subquestion)
+        else if not @validate_only_touched_inputs and not @validateSingleQuestion($(subquestion))
           @addSubfieldError(question, subquestion)
     else
       if not @validateSingleQuestion(question)
         @addQuestionError(question)
 
+  hasBeenTouched: (question) ->
+    question.find("input").hasClass("dirty") || question.find("select").hasClass("dirty")
+      
   addSubfieldError: (question, subquestion) ->
     questionRef = question.attr("data-question_ref")
     input = $(subquestion).find('input,textarea,select')
@@ -286,18 +293,24 @@ window.FormValidation =
     questionDay = question.find(".js-date-input-day").val()
     questionDate = "#{questionDay}/#{questionMonth}/#{questionYear}"
 
+    questionYearTouched = !!question.find('.js-date-input-year.dirty').length
+    questionMonthTouched = !!question.find(".js-date-input-month.dirty").length
+    questionDayTouched = !!question.find(".js-date-input-day.dirty").length
+    allTouched = questionYearTouched && questionMonthTouched && questionDayTouched
+
     if not val
       return
 
     expDate = question.data("date-max")
     diff = @compareDateInDays(questionDate, expDate)
 
-    if not questionYear or not questionMonth or not questionDay
-      errorMessage = "Question #{questionRef} is incomplete. It is required and must be filled in. Use the format DD/MM/YYYY."
-      @logThis(question, "validateMaxDate", errorMessage)
-      @addErrorMessage(question, errorMessage)
-      return
-    if not @toDate(questionDate).isValid()
+    if allTouched
+      if not questionYear or not questionMonth or not questionDay
+        errorMessage = "Question #{questionRef} is incomplete. It is required and must be filled in. Use the format DD/MM/YYYY."
+        @logThis(question, "validateMaxDate", errorMessage)
+        @addErrorMessage(question, errorMessage)
+        return
+    if questionYear and questionMonth and questionDay and not @toDate(questionDate).isValid()
       errorMessage = "Question #{questionRef} is incomplete. The date entered is not valid. Use the format DD/MM/YYYY."
       @logThis(question, "validateMaxDate", errorMessage)
       @addErrorMessage(question, errorMessage)
@@ -417,7 +430,12 @@ window.FormValidation =
 
   validateEmployeeMin: (question) ->
     questionRef = question.attr("data-question_ref")
-    for subquestion in question.find("input")
+    selector = if @validate_only_touched_inputs
+      "input.dirty"
+    else 
+      "input"
+
+    for subquestion in question.find(selector)
       shownQuestion = true
       for conditional in $(subquestion).parents('.js-conditional-question')
         if !$(conditional).hasClass('show-question')
@@ -538,9 +556,14 @@ window.FormValidation =
     $(".govuk-error-message", question).empty()
     questionRef = question.attr("data-question_ref")
 
+    selectors = if @validate_only_touched_inputs
+      "select.dirty, input.dirty, textarea.dirty"
+    else
+      "select, input, textarea"
+
     for subquestion in question.find(".list-add li")
       errors = false
-      for input in $(subquestion).find("select, input, textarea")
+      for input in $(subquestion).find(selectors)
         $(input).closest('.govuk-form-group').find('.govuk-error-message').empty()
         if !$(input).val()
           fieldName = $(input).data("dependable-option-siffix")
@@ -555,8 +578,12 @@ window.FormValidation =
   validateNumberByYears: (question) ->
     inputCellsCounter = 0
     questionRef = question.attr("data-question_ref")
+    selector = if @validate_only_touched_inputs
+      "input.dirty"
+    else 
+      "input"
 
-    for subquestion in question.find("input")
+    for subquestion in question.find(selector)
       subq = $(subquestion)
       qParent = subq.closest(".js-fy-entries")
       errContainer = subq.closest(".span-financial")
@@ -586,7 +613,12 @@ window.FormValidation =
     if typeof(firstYearMinValue) != typeof(undefined)
       firstYearMinValidation = true
 
-    for subquestion in question.find("input")
+    selector = if @validate_only_touched_inputs
+      "input.dirty"
+    else 
+      "input"
+
+    for subquestion in question.find(selector)
       subq = $(subquestion)
       qParent = subq.closest(".js-fy-entries")
       errContainer = subq.closest(".span-financial")
@@ -853,6 +885,8 @@ window.FormValidation =
     self = @
 
     $(document).on "change", ".question-block input, .question-block select, .question-block textarea", ->
+      self.validate_only_touched_inputs = true
+      $(@).addClass('dirty')
       self.clearErrors $(this)
       self.clearAriaDescribedby $(this)
       self.validateIndividualQuestion($(@).closest(".question-block"), $(@))
@@ -966,7 +1000,7 @@ window.FormValidation =
 
   validateStep: (step = null) ->
     @validates = true
-
+    @validate_only_touched_inputs = false
     currentStep = step || $(".js-step-link.step-current").attr("data-step")
 
     stepContainer = $(".article-container[data-step='" + currentStep + "']")

--- a/app/assets/javascripts/frontend/form-validation.js.coffee
+++ b/app/assets/javascripts/frontend/form-validation.js.coffee
@@ -293,10 +293,9 @@ window.FormValidation =
     questionDay = question.find(".js-date-input-day").val()
     questionDate = "#{questionDay}/#{questionMonth}/#{questionYear}"
 
-    questionYearTouched = !!question.find('.js-date-input-year.dirty').length
-    questionMonthTouched = !!question.find(".js-date-input-month.dirty").length
-    questionDayTouched = !!question.find(".js-date-input-day.dirty").length
-    allTouched = questionYearTouched && questionMonthTouched && questionDayTouched
+    [yearTouched, monthTouched, dayTouched] = ['.js-date-input-year', '.js-date-input-month', '.js-date-input-day'].map (cls) ->
+      !!question.find("#{cls}.dirty").length
+    allTouched = yearTouched and monthTouched and dayTouched
 
     if not val
       return


### PR DESCRIPTION
See [ticket](https://app.asana.com/0/1200504523179345/1207272963176223/f) for changes need, they do a good job of explaining the issues this PR attempts to solve. There is also a list of form questions this is relevant to (basically they are date, financial info, personal details and previous award wins).

## 📝 A short description of the changes

* If form starts off empty, then we don't add validation errors for all the inputs the user has not yet touched.
* however, if we go back and delete an input, then it should show the validation error for that input.
* If the user navigates between different steps of the form (using save or the navigation menu on the left) then all validation errors should show, as before. However, now the behaviour has changed to only remove validation errors for the inputs that the user has touched, not clearing them wholesale like before.

There are two main modes to understand when reviewing the code - `@validate_only_touched_inputs` will be false when navigating around the different form steps (because we want to validate everything) and will be true once they start to interact with the inputs on a form (since we only care about validating what they touch).

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207272963176223/f

## :shipit: Deployment implications

* Very little, this is just JS changes

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

