### PR TITLE
chore: Use subheadings for govuk templates

### DIFF
--- a/app/views/account_mailers/notify_non_shortlisted_mailer/notify.text.erb
+++ b/app/views/account_mailers/notify_non_shortlisted_mailer/notify.text.erb
@@ -7,7 +7,7 @@ The Awards application process is rigorous and comprehensive and we are aware th
 
 Previous applicants have found the feedback useful in strengthening their application and we hope this will assist you with future applications.
 
-#Please note that The King's Awards Office do not have any further information on the assessment at this stage so will not be able to discuss anything related to your <%= @current_year %> application until you have received the feedback.
+##Please note that The King's Awards Office do not have any further information on the assessment at this stage so will not be able to discuss anything related to your <%= @current_year %> application until you have received the feedback.
 
 Thank you for taking the time to enter The King's Awards for Enterprise.
 
@@ -17,5 +17,6 @@ Yours sincerely,
 
 Nichola Bruno
 Head of The King's Awards Office
+
 
 <%= render 'account_mailers/notify_shortlisted_mailer/appendix_a' %>

--- a/app/views/account_mailers/notify_non_shortlisted_mailer/preview/notify.html.slim
+++ b/app/views/account_mailers/notify_non_shortlisted_mailer/preview/notify.html.slim
@@ -12,11 +12,10 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' Previous applicants have found the feedback useful in strengthening their application and we hope this will assist you with future applications.
 
-p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
-  strong
-    ' Please note that The King's Awards Office do not have any further information on the assessment at this stage so will not be able to discuss anything related to your
-    => @current_year
-    | application until you have received the feedback.
+h1 style="font-size: 19px; font-weight: 600, line-height: 1.315789474; margin: 0 0 30px 0;"
+  ' Please note that The King's Awards Office do not have any further information on the assessment at this stage so will not be able to discuss anything related to your
+  => @current_year
+  | application until you have received the feedback.
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' Thank you for taking the time to enter The King's Awards for Enterprise.
@@ -31,5 +30,6 @@ p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;"
   ' Nichola Bruno
   br
   ' Head of The King's Awards Office
+
 
 = render "account_mailers/notify_shortlisted_mailer/preview/appendix_a"

--- a/app/views/account_mailers/notify_shortlisted_mailer/_appendix_a.text.erb
+++ b/app/views/account_mailers/notify_shortlisted_mailer/_appendix_a.text.erb
@@ -1,8 +1,8 @@
-Appendix A
+#Appendix A
 
-#Annex A: Useful contacts
+##Annex A: Useful contacts
 
-#Helping businesses access the finance they need
+##Helping businesses access the finance they need
 
 Explore the different types of finance which may be available during your business' journey to start, grow, stay ahead, to innovate, and to trade overseas:
 
@@ -15,7 +15,7 @@ Explore the different types of finance which may be available during your busine
 * UK Export Finance https://www.gov.uk/government/organisations/uk-export-finance
 * Growth Hubs (in England) https://www.lepnetwork.net/growth-hubs/
 
-#Access advice and support to continue your business' success:
+##Access advice and support to continue your business' success:
 
 * Help to Grow: Management https://smallbusinesscharter.org/help-to-grow-management - an intensive training programme that looks to boost SME performance and resilience by improving leadership and management skills.
 * Get exporting and grow your business https://exports.campaign.gov.uk
@@ -25,14 +25,14 @@ Explore the different types of finance which may be available during your busine
 * Innovate UK Business Connect https://iuk.ktn-uk.org - which helps connect ideas, people and communities to respond to global challenges and drive positive change through innovation.
 * SME Climate Hub https://smeclimatehub.org/ - free tools and resources to help SMEs reduce emissions.
 
-#Additional business support and awards
+##Additional business support and awards
 
 * Enterprise Nation https://www.enterprisenation.com/
 * Be The Business https://www.bethebusiness.com
 * Made Smarter https://www.madesmarter.uk - uniting UK manufacturers with the digital tools, innovation & skills to make an everyday business difference.
 * Made in Britain https://www.madeinbritain.co/
 
-#Opportunities for Business - Government contracts
+##Opportunities for Business - Government contracts
 
 Contracts Finder lets you search for information about contracts worth over £10,000 with the government and its agencies.
 * Contract finder https://www.gov.uk/contracts-finder to bid on Government contracts

--- a/app/views/account_mailers/notify_shortlisted_mailer/preview/_appendix_a.html.slim
+++ b/app/views/account_mailers/notify_shortlisted_mailer/preview/_appendix_a.html.slim
@@ -1,13 +1,11 @@
-p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
+h1 style="font-size: 19px; font-weight: 800; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Appendix A
 
-p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  strong
-    | Annex A: Useful contacts
+h2 style="font-size: 19px; font-weight: 500; line-height: 1.315789474; margin: 30px 0 30px 0;"
+  | Annex A: Useful contacts
 
-p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  strong
-    | Helping businesses access the finance they need
+h3 style="font-size: 19px; font-weight: 500; line-height: 1.315789474; margin: 30px 0 30px 0;"
+  | Helping businesses access the finance they need
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Explore the different types of finance which may be available during your business' journey to start, grow, stay ahead, to innovate, and to trade overseas:
@@ -38,9 +36,8 @@ ul style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
     | Growth Hubs (in England)
     =< link_to "https://www.lepnetwork.net/growth-hubs/", "https://www.lepnetwork.net/growth-hubs/"
 
-p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  strong
-    | Access advice and support to continue your business' success:
+h3 style="font-size: 19px; font-weight: 500; line-height: 1.315789474; margin: 30px 0 30px 0;"
+  | Access advice and support to continue your business' success:
 
 ul style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   li
@@ -71,9 +68,8 @@ ul style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
     =<> link_to "https://smeclimatehub.org/", "https://smeclimatehub.org/"
     | - free tools and resources to help SMEs reduce emissions.
 
-p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  strong
-    | Additional business support and awards
+h3 style="font-size: 19px; font-weight: 500; line-height: 1.315789474; margin: 30px 0 30px 0;"
+  | Additional business support and awards
 
 ul style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   li
@@ -90,16 +86,20 @@ ul style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
     | Made in Britain
     =< link_to "https://www.madeinbritain.co/", "https://www.madeinbritain.co/"
 
-p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-  strong
-    | Opportunities for Business - Government contracts
+h3 style="font-size: 19px; font-weight: 500; line-height: 1.315789474; margin: 30px 0 30px 0;"
+  | Opportunities for Business - Government contracts
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Contracts Finder lets you search for information about contracts worth over £10,000 with the government and its agencies.
   ul style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-    li Contract finder https://www.gov.uk/contracts-finder to bid on Government contracts
+    li
+      | Contract finder
+      =<> link_to "https://www.gov.uk/contracts-finder", "https://www.gov.uk/contracts-finder"
+      | to bid on Government contracts
 
 p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
   | Find a Tender service lets you find and apply for high-value contracts (usually above £118,000) in the UK .
   ul style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;"
-    li Find a tender https://www.gov.uk/find-tender
+    li
+      | Find a tender
+      =< link_to "https://www.gov.uk/find-tender", "https://www.gov.uk/find-tender"


### PR DESCRIPTION
## 📝 A short description of the changes

* We use headings to show important information in gov.uk notify mailers as bold formatting is not available. This replaces the headings with subheadings for less important information.
* Adds missing links to the appendix A preview

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1208579820614028

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
<img width="1051" alt="Screenshot 2024-10-21 at 08 51 13" src="https://github.com/user-attachments/assets/43997ba0-073a-4aa4-84f4-d1cf9dd5649c">

