### PR TITLE
Add model validations for phone_numbers

### DIFF
--- a/app/models/palace_attendee.rb
+++ b/app/models/palace_attendee.rb
@@ -11,6 +11,7 @@ class PalaceAttendee < ApplicationRecord
     :postcode,
     presence: true
 
+  validates :phone_number, phone: { allow_blank: true }
   validates :disabled_access, inclusion: { in: [true, false], message: "This field cannot be blank" }
   validates :has_royal_family_connections, inclusion: { in: [true, false], message: "This field cannot be blank" }
 

--- a/app/models/press_summary.rb
+++ b/app/models/press_summary.rb
@@ -3,8 +3,13 @@ class PressSummary < ApplicationRecord
 
   validates :form_answer, :token, presence: true
   validates :body, presence: true, unless: :contact_details_update?
-  validates :name, :email, :phone_number,
+  validates :name, :email,
     presence: true,
+    unless: proc { |c| c.body_update.present? },
+    if: :applicant_submitted?
+
+  validates :phone_number,
+    phone: true,
     unless: proc { |c| c.body_update.present? },
     if: :applicant_submitted?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,20 +22,10 @@ class User < ApplicationRecord
   validates :first_name, presence: true, if: -> { first_step? }
   validates :last_name, presence: true, if: -> { first_step? }
   validates :job_title, presence: true, if: -> { first_step? }
-  validates :phone_number, presence: true, if: -> { first_step? }
   validates :password, confirmation: true
 
-  validates :phone_number, length: {
-    minimum: 7,
-    maximum: 20,
-    message: "This is not a valid telephone number",
-  }, if: -> { first_step? }
-
-  validates :company_phone_number, length: {
-    minimum: 7,
-    maximum: 20,
-    message: "This is not a valid telephone number",
-  }, allow_blank: true, if: -> { second_step? }
+  validates :phone_number, phone: { allow_blank: true }, if: -> { first_step? }
+  validates :company_phone_number, phone: { allow_blank: true }, if: -> { second_step? }
 
   validates_with AdvancedEmailValidator
 

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,1 @@
+Phonelib.default_country = "GB"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,10 @@ en:
       models:
         user:
           attributes:
+            phone_number:
+              invalid: Enter a phone number, like 01635 960 001, 07701 900 982 or +44 808 157 0192
+            company_phone_number:
+              invalid: Enter a phone number, like 01635 960 001, 07701 900 982 or +44 808 157 0192
             email:
               invalid: 'Email is invalid - enter a valid email address'
             role:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,10 @@ en:
         confirmation: "%{attribute} doesn't match."
         not_a_number: 'Please enter a number.'
       models:
+        palace_attendee:
+          attributes:
+            phone_number:
+              invalid: Enter a phone number, like 01635 960 001, 07701 900 982 or +44 808 157 0192
         user:
           attributes:
             phone_number:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,10 @@ en:
           attributes:
             phone_number:
               invalid: Enter a phone number, like 01635 960 001, 07701 900 982 or +44 808 157 0192
+        press_summary:
+          attributes:
+            phone_number:
+              invalid: Enter a phone number, like 01635 960 001, 07701 900 982 or +44 808 157 0192
         user:
           attributes:
             phone_number:

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -4,7 +4,7 @@ describe AccountsController do
   let(:old_password) { "^#ur9EkLm@1W+OaDvgTT" }
   let(:new_password) { "^#ur9EkLm@1W+OaDvg" }
 
-  let(:user) { create(:user, :completed_profile, password: "^#ur9EkLm@1W+OaDvgTT", password_confirmation: "^#ur9EkLm@1W+OaDvgTT") }
+  let(:user) { create(:user, :completed_profile, password: old_password, password_confirmation: old_password) }
 
   before do
     sign_in user

--- a/spec/factories/palace_attendees.rb
+++ b/spec/factories/palace_attendees.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     address_3 { "MyString" }
     address_4 { "MyString" }
     postcode { "MyString" }
-    phone_number { "MyString" }
+    sequence(:phone_number) { |n| "020 4551 008#{n.to_s[-1]}" }
     disabled_access { false }
     additional_info { "MyText" }
     has_royal_family_connections { false }

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     email
     role { "regular" }
     agreed_with_privacy_policy { "1" }
-    sequence(:phone_number) { |n| "1111111#{n}" }
+    sequence(:phone_number) { |n| "020 4551 008#{n.to_s[-1]}" }
     confirmed_at { Time.zone.now }
 
     trait :completed_profile do
@@ -18,7 +18,7 @@ FactoryBot.define do
       company_city { "London" }
       company_country { "GB" }
       company_postcode { "SE16 3SA" }
-      sequence(:company_phone_number) { |n| "7777777#{n}" }
+      sequence(:company_phone_number) { |n| "020 4551 008#{n.to_s[-1]}" }
       prefered_method_of_contact { "phone" }
       qae_info_source { "govuk" }
       role { "regular" }

--- a/spec/features/admin/form_answers/palace_attendees_fulfilling_spec.rb
+++ b/spec/features/admin/form_answers/palace_attendees_fulfilling_spec.rb
@@ -33,9 +33,21 @@ describe "Admin fulfills the Palace Attendees" do
   end
 
   context "js enabled", js: true do
-    it "adds the single Palace Attendee" do
-      field_values = []
+    let(:title) { "Mr" }
+    let(:first_name) { "Bob" }
+    let(:last_name) { "Buttons" }
+    let(:job_name) { "Fisherman" }
+    let(:post_nominals) { "Yeah that" }
+    let(:royal_family_connection_details) { "Cleaner" }
+    let(:address_1) { "123 Fake Street" }
+    let(:address_2) { "Electric Avenue" }
+    let(:address_3) { "Mordoor" }
+    let(:address_4) { "The World" }
+    let(:postcode) { "DA7 4HE" }
+    let(:phone_number) { "02083015556" }
+    let(:dietary_requirements) { "Meat eater" }
 
+    it "adds the single Palace Attendee" do
       find("#palace-attendees-heading .panel-title a").click
       within "#section-palace-attendees" do
         find(".form-edit-link").click
@@ -44,12 +56,19 @@ describe "Admin fulfills the Palace Attendees" do
           find("input#palace_attendee_phone_number")
           find("input#palace_attendee_has_royal_family_connections_true").set(true)
           find("input#palace_attendee_disabled_access_true").set(true)
-          fill_in "palace_attendee_royal_family_connection_details", with: "connection details"
-          all("input.form-control").each_with_index do |input, index|
-            val = "val-#{index}"
-            field_values << val
-            input.set(val)
-          end
+          fill_in "palace_attendee_royal_family_connection_details", with: royal_family_connection_details
+          find("#palace_attendee_title").set(title)
+          find("#palace_attendee_first_name").set(first_name)
+          find("#palace_attendee_last_name").set(last_name)
+          find("#palace_attendee_job_name").set(job_name)
+          find("#palace_attendee_post_nominals").set(post_nominals)
+          find("#palace_attendee_address_1").set(address_1)
+          find("#palace_attendee_address_2").set(address_2)
+          find("#palace_attendee_address_3").set(address_3)
+          find("#palace_attendee_address_4").set(address_4)
+          find("#palace_attendee_postcode").set(postcode)
+          find("#palace_attendee_phone_number").set(phone_number)
+          find("#palace_attendee_dietary_requirements").set(dietary_requirements)
         end
 
         click_button "Save"
@@ -60,11 +79,19 @@ describe "Admin fulfills the Palace Attendees" do
       find("#palace-attendees-heading .panel-title a").click
 
       within "#section-palace-attendees" do
-        field_values.each do |val|
-          expect(page).to have_content(val)
-        end
-
-        expect(page).to have_content("connection details")
+        expect(page).to have_content(title)
+        expect(page).to have_content(first_name)
+        expect(page).to have_content(last_name)
+        expect(page).to have_content(job_name)
+        expect(page).to have_content(post_nominals)
+        expect(page).to have_content(address_1)
+        expect(page).to have_content(address_2)
+        expect(page).to have_content(address_3)
+        expect(page).to have_content(address_4)
+        expect(page).to have_content(postcode)
+        expect(page).to have_content(phone_number)
+        expect(page).to have_content(dietary_requirements)
+        expect(page).to have_content(royal_family_connection_details)
       end
     end
   end

--- a/spec/features/palace_attendees_spec.rb
+++ b/spec/features/palace_attendees_spec.rb
@@ -138,7 +138,7 @@ So that I provide a full list of attendees for Buckingham Palace reception
         fill_in "City or town", with: "Test"
         fill_in "County", with: "Test"
         fill_in "Postcode", with: "Test"
-        fill_in "Telephone number", with: "Test"
+        fill_in "Telephone number", with: "02083015556"
         disabled_access = find('input[name="palace_invite[palace_attendees_attributes][0][disabled_access]"]', match: :first)
         disabled_access.set(true)
 

--- a/spec/features/users/account_creation_spec.rb
+++ b/spec/features/users/account_creation_spec.rb
@@ -32,27 +32,30 @@ describe "Account forms" do
   end
 
   context "Account details fulfillment" do
+    def fill_in_and_submit_account_details_form
+      fill_in("Title", with: "Mr")
+      fill_in("First name", with: "FirstName")
+      fill_in("Last name", with: "LastName")
+      fill_in("Your job title", with: "job title")
+      fill_in("Your telephone number", with: phone_number)
+
+      click_button("Save and continue")
+    end
+
     context "regular user" do
       let!(:user) { create(:user, role: "regular") }
 
       before do
         create(:settings, :submission_deadlines)
         login_as(user, scope: :user)
+        visit root_path
+        fill_in_and_submit_account_details_form
       end
 
-      let(:phone_number) { "1231233214354235" }
+      let(:phone_number) { "020 4551 0081" }
       let(:company_name) { "BitZestyOrg" }
 
       it "adds the Account details" do
-        visit root_path
-        fill_in("Title", with: "Mr")
-        fill_in("First name", with: "FirstName")
-        fill_in("Last name", with: "LastName")
-        fill_in("Your job title", with: "job title")
-        fill_in("Your telephone number", with: phone_number)
-
-        click_button("Save and continue")
-
         expect(page).to have_content("Contact preferences")
         click_button("Save and continue")
 
@@ -63,6 +66,16 @@ describe "Account forms" do
         expect(user.phone_number).to eq(phone_number)
         expect(user.completed_registration?).to eq(true)
       end
+
+      context "with an invalid phone number" do
+        let(:phone_number) { "020 4551 008" }
+
+        it "displays an error message" do
+          expect(page).to have_content(
+            I18n.t("activerecord.errors.models.user.attributes.phone_number.invalid"),
+          )
+        end
+      end
     end
 
     context "admin user" do
@@ -71,27 +84,20 @@ describe "Account forms" do
       before do
         create(:settings, :submission_deadlines)
         login_as(user, scope: :user)
+        visit root_path
+        fill_in_and_submit_account_details_form
       end
 
-      let(:phone_number) { "1231233214354235" }
+      let(:phone_number) { "020 4551 0081" }
       let(:company_name) { "BitZestyOrg" }
 
       it "adds the Account details" do
-        visit root_path
-        fill_in("Title", with: "Mr")
-        fill_in("First name", with: "FirstName")
-        fill_in("Last name", with: "LastName")
-        fill_in("Your job title", with: "job title")
-        fill_in("Your telephone number", with: phone_number)
-
-        click_button("Save and continue")
-
         expect(page).to have_content("Contact preferences")
         click_button("Save and continue")
 
         expect(page).to have_content("Organisation details")
         fill_in("Name of the organisation", with: company_name)
-        fill_in("The organisation's main telephone number", with: "9876544")
+        fill_in("The organisation's main telephone number", with: "020 4551 0082")
 
         click_button("Save and continue")
 
@@ -101,6 +107,16 @@ describe "Account forms" do
 
         expect(user.phone_number).to eq(phone_number)
         expect(user.company_name).to eq(company_name)
+      end
+
+      context "with an invalid phone number" do
+        let(:phone_number) { "020 4551 008" }
+
+        it "displays an error message" do
+          expect(page).to have_content(
+            I18n.t("activerecord.errors.models.user.attributes.phone_number.invalid"),
+          )
+        end
       end
     end
   end

--- a/spec/features/users/collaborator_registration_flow_spec.rb
+++ b/spec/features/users/collaborator_registration_flow_spec.rb
@@ -8,9 +8,6 @@ describe "Collaborator registration flow" do
 
   before do
     create(:settings, :submission_deadlines)
-  end
-
-  it "creates and account and collaborator is able to collaborate" do
     login_as(acc_admin, scope: :user)
 
     visit new_account_collaborator_path
@@ -19,7 +16,7 @@ describe "Collaborator registration flow" do
     fill_in("First name", with: "First Name")
     fill_in("Last name", with: "Last Name")
     fill_in("Job title", with: "job title")
-    fill_in("Telephone number", with: "1231233214354235")
+    fill_in("Telephone number", with: "020 4551 0081")
     fill_in("Email", with: "collab@example.com")
     first("input#collaborator_role_account_admin").set(true)
 
@@ -35,17 +32,34 @@ describe "Collaborator registration flow" do
     visit root_path
 
     click_button("Save and continue")
+  end
 
+  it "creates and account and collaborator is able to collaborate" do
     expect(page).to have_content("Contact preferences")
     click_button("Save and continue")
 
     fill_in "Name of the organisation", with: "Disney"
-    fill_in "The organisation's main telephone number", with: "012312312"
+    fill_in "The organisation's main telephone number", with: "020 4551 0082"
     click_button("Save and continue")
 
     # collaborator page
     click_button("Save and continue")
 
     expect(page).to have_content("Applying for a King's Award for your organisation")
+  end
+
+  context "when the company_phone_number is invalid" do
+    it "displays an error message" do
+      expect(page).to have_content("Contact preferences")
+      click_button("Save and continue")
+
+      fill_in "Name of the organisation", with: "Disney"
+      fill_in "The organisation's main telephone number", with: "020 4551 008"
+      click_button("Save and continue")
+
+      expect(page).to have_content(
+        I18n.t("activerecord.errors.models.user.attributes.company_phone_number.invalid"),
+      )
+    end
   end
 end


### PR DESCRIPTION
## 📝 A short description of the changes

* Uses the [phonelib gem](https://github.com/daddyz/phonelib) to add validations for phone numbers to the User model

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1208540659066029/1207272963176225

## :shipit: Deployment implications

* **The attached rake task should be run as soon as this is deployed**: `bundle exec rake db:remove_invalid_user_phone_numbers`. It will fix invalidated User records by removing the invalid phone_numbers.

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):
![image](https://github.com/user-attachments/assets/886a074f-2be4-4629-bd31-4eee261ea1dd)
![image](https://github.com/user-attachments/assets/480c4049-641d-4a09-af02-3e122e534aa2)
![image](https://github.com/user-attachments/assets/e95d6986-3267-4697-8be9-8c80ba4250ad)