### PR TITLE
Add Admin/Judge/Assessor footer and new Admin Accessibility Statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ This ensures the necessary environment variables set before running the Docker c
 #### Running with docker
 
 1. Build the containers:
-   
+
    ```
    docker-compose build
    ```
 
 2. In a new terminal, set up and migrate the database:
-   
+
    ```
    docker-compose run --rm web bundle exec rails db:prepare
    ```
@@ -99,6 +99,7 @@ software, and may be redistributed under the terms specified in the
 [license]: https://github.com/bitzesty/qae/blob/master/LICENSE
 
 ## Helpful links
+
 - [GDS service standards](https://www.gov.uk/service-manual/service-standard)
 - [GDS design principles](https://www.gov.uk/design-principles)
 
@@ -107,4 +108,3 @@ software, and may be redistributed under the terms specified in the
 ![Bit Zesty](https://bitzesty.com/wp-content/uploads/2017/01/logo_dark.png)
 
 QAE is maintained by [Bit Zesty Limited](https://bitzesty.com/).
-

--- a/app/controllers/content_only_controller.rb
+++ b/app/controllers/content_only_controller.rb
@@ -13,6 +13,7 @@ class ContentOnlyController < ApplicationController
       :privacy,
       :cookies,
       :accessibility_statement,
+      :admin_accessibility_statement,
       :apply_for_queens_award_for_enterprise,
       :sign_up_complete,
       :submitted_nomination_successful,

--- a/app/javascript/packs/application-admin.scss
+++ b/app/javascript/packs/application-admin.scss
@@ -1,0 +1,3 @@
+$govuk-assets-path: "~govuk-frontend/dist/govuk/assets/";
+@import "node_modules/govuk-frontend/dist/govuk/components/footer/footer";
+@import "node_modules/govuk-frontend/dist/govuk/objects/width-container";

--- a/app/views/content_only/admin_accessibility_statement.html.slim
+++ b/app/views/content_only/admin_accessibility_statement.html.slim
@@ -1,0 +1,138 @@
+- title "Accessibility Statement"
+
+h1.govuk-heading-xl
+  ' Accessibility statement for The King's Awards for Enterprise Application Management Interface
+
+.article-container
+  article.group role="article"
+    p.govuk-body
+      | This website is run by the Department for Business and Trade (DBT). We are committed to ensuring that our application management interface is accessible to all users, including those with disabilities. We strive to adhere to the Web Content Accessibility Guidelines (WCAG) 2.1, Level AA, to ensure our platform is usable by as many people as possible.
+
+    h2.govuk-heading-m
+      | Measures to Support Accessibility
+    p.govuk-body
+      | We take the following measures to ensure accessibility:
+    ul.govuk-list.govuk-list--bullet
+      li
+        strong
+          => "Conformance to Standards:"
+        | We aim to comply with WCAG 2.1, Level AA standards.
+      li
+        strong
+          => "Regular Audits:"
+        | We conduct regular accessibility audits to identify and fix issues.
+      li
+        strong
+          => "User feedback:"
+        | We encourage feedback from users to improve accessibility.
+
+    h2.govuk-heading-m
+      | Accessibility Features
+    ul.govuk-list.govuk-list--bullet
+      li
+        strong
+          => "Keyboard Navigation:"
+        | Our interface is fully navigable using a keyboard.
+      li
+        strong
+          => "Screen Reader Compatibility:"
+        | We ensure compatibility with screen readers.
+      li
+        strong
+          => "Contrast and Colour:"
+        | We use high-contrast colors and ensure text is readable.
+      li
+        strong
+          => "Resizable Text:"
+        | Text can be resized without loss of content or functionality.
+    p.govuk-body
+      => link_to "AbilityNet", 'https://mcmw.abilitynet.org.uk/', target: '_blank', title: 'opens in a new window', rel: 'noreferrer nofollow'
+      | has advice on making your device easier to use if you have a disability.
+
+    h2.govuk-heading-m
+      | Known Issues
+    p.govuk-body
+      | We are aware of the following accessibility issues and are working to resolve them:
+    ul.govuk-list.govuk-list--bullet
+      li
+        strong
+          => "PDFs:"
+        | Some PDFs may not be fully accessible. We are working to provide accessible alternatives.
+      li
+        strong
+          => "Tables:"
+        | Some tables displaying statistical data may not be fully accessible. We are working to provide accessible alternatives.
+      li
+        strong
+          => "Javascript:"
+        | Some interactive elements may not be fully accessible without javascript enabled. We are working to ensure the application is fully accessible without javascript.
+
+    h2.govuk-heading-m
+      | Assessment Approach
+    p.govuk-body
+      | We assess the accessibility of our application management interface through:
+    ul.govuk-list.govuk-list--bullet
+      li
+        strong
+          => "Automated Testing:"
+        | We use automated tools to identify and fix accessibility issues.
+      li
+        strong
+          => "Manual Testing:"
+        | We conduct manual testing to ensure the interface is accessible to all users.
+
+    h2.govuk-heading-m
+      | Technical Information about this website's Accessibility
+    p.govuk-body
+      | DBT is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+    p.govuk-body
+      | The accessibility of our application management interface relies on the following technologies:
+    ul.govuk-list.govuk-list--bullet
+      li
+        | HTML (HyperText Markup Language)
+      li
+        | CSS (Cascading Style Sheets)
+      li
+        | JavaScript
+      li
+        | WAI-ARIA (Accessible Rich Internet Applications)
+
+    h2.govuk-heading-m
+      | Feedback and Contact Information
+    p.govuk-body
+      | We welcome your feedback on the accessibility of our application management interface. If you encounter any accessibility barriers, please contact us:
+    ul.govuk-list.govuk-list--bullet
+      li
+        strong
+          => "Telephone:"
+        | 020 4551 0081
+      li
+        strong
+          => "E-mail:"
+        =< link_to 'kingsawards@businessandtrade.gov.uk', 'mailto:kingsawards@businessandtrade.gov.uk', class: 'govuk-link'
+    p.govuk-body
+      | We'll consider your request and aim to respond in 15 days.
+    p.govuk-body
+      | We provide a text relay service for people who are deaf, hearing impaired or have a speech impediment.
+    p.govuk-body
+      | Our offices have audio induction loops, or if you contact us before your visit we can arrange a British Sign Language (BSL) interpreter.
+
+    h2.govuk-heading-m
+      | Enforcement Procedure
+    p.govuk-body
+      | The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint,
+      =< link_to ' contact the Equality Advisory and Support Service (EASS).', 'https://www.equalityadvisoryservice.com/', target: '_blank', title: 'opens in a new window', rel: 'noreferrer nofollow'
+
+    h2.govuk-heading-m
+      | Compliance status
+    p.govuk-body
+      | This website is fully compliant with the
+      =< link_to 'Web Content Accessibility Guidelines version 2.1', 'https://www.w3.org/TR/WCAG21/', target: '_blank', title: 'opens in a new window', rel: 'noreferrer nofollow'
+      |  AA standard.
+
+    h2.govuk-heading-m
+      | Date
+    p.govuk-body
+      | This statement was last updated on 1st November 2023.
+    p.govuk-body
+      | This website was last tested in September 2023. The test was carried out by Bit Zesty Limited.

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,37 @@
+<footer class="govuk-footer" role="contentinfo">
+  <div class="govuk-width-container">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <h2 class="govuk-visually-hidden">Support links</h2>
+        <ul class="govuk-footer__inline-list">
+          <li class="govuk-footer__inline-list-item">
+            <%= link_to "Help", "https://www.gov.uk/help", class: 'govuk-footer__link' %>
+          </li>
+          <li class="govuk-footer__inline-list-item">
+            <%= link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link' %>
+          </li>
+          <li class="govuk-footer__inline-list-item">
+            <%= link_to "Accessibility Statement", admin_accessibility_statement_path, class: 'govuk-footer__link' %>
+          </li>
+          <li class="govuk-footer__inline-list-item">
+            <%= link_to "Cookie Policy", cookies_path, class: 'govuk-footer__link' %>
+          </li>
+          <li class="govuk-footer__inline-list-item">
+            Built by
+            <%= link_to "The King's Awards Office", "https://kingsawards.blog.gov.uk/", class: 'govuk-footer__link' %>
+          </li>
+        </ul>
+        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/layouts/application-admin.html.slim
+++ b/app/views/layouts/application-admin.html.slim
@@ -23,6 +23,7 @@ html.no-js
     / <!--<![endif]-->
 
     = stylesheet_link_tag "application-admin", media: "all"
+    = stylesheet_pack_tag "application-admin"
 
     = yield :section_meta_tags
     = csrf_meta_tags
@@ -140,6 +141,7 @@ html.no-js
 
     #site-footer
       .footer-container
+        = render partial: "layouts/footer"
 
     - if should_enable_js?
       = javascript_include_tag 'application-admin'

--- a/app/views/layouts/application-assessor.html.slim
+++ b/app/views/layouts/application-assessor.html.slim
@@ -23,6 +23,7 @@ html.no-js
     / <!--<![endif]-->
 
     = stylesheet_link_tag "application-admin", media: "all"
+    = stylesheet_pack_tag "application-admin"
 
     = yield :section_meta_tags
     = csrf_meta_tags
@@ -116,6 +117,7 @@ html.no-js
 
     #site-footer
       .footer-container
+        = render partial: "layouts/footer"
 
     - if should_enable_js?
       = javascript_include_tag 'application-admin'

--- a/app/views/layouts/application-judge.html.slim
+++ b/app/views/layouts/application-judge.html.slim
@@ -23,6 +23,7 @@ html.no-js
     / <!--<![endif]-->
 
     = stylesheet_link_tag "application-admin", media: "all"
+    = stylesheet_pack_tag "application-admin"
 
     = yield :section_meta_tags
     = csrf_meta_tags
@@ -112,6 +113,7 @@ html.no-js
 
     #site-footer
       .footer-container
+        = render partial: "layouts/footer"
 
     - if should_enable_js?
       = javascript_include_tag 'application-admin'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -103,7 +103,10 @@ title = content_for?(:title) ? "#{'Appraisal view of ' if admin_in_read_only_mod
     li.govuk-footer__inline-list-item
       = link_to "Privacy Statement", privacy_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
-      = link_to "Accessibility Statement", accessibility_statement_path, class: 'govuk-footer__link'
+      - if request.path.include?("/users")
+        = link_to "Accessibility Statement", accessibility_statement_path, class: 'govuk-footer__link'
+      - else 
+        = link_to "Accessibility Statement", admin_accessibility_statement_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item
       = link_to "Cookie Policy", cookies_path, class: 'govuk-footer__link'
     li.govuk-footer__inline-list-item

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   get "/privacy" => "content_only#privacy", :as => "privacy"
   get "/cookies" => "content_only#cookies", :as => "cookies"
   get "/accessibility-statement" => "content_only#accessibility_statement", :as => "accessibility_statement"
+  get "/admin-accessibility-statement" => "content_only#admin_accessibility_statement", :as => "admin_accessibility_statement"
 
   post "/new_innovation_form" => "form#new_innovation_form", :as => "new_innovation_form"
   post "/new_international_trade_form" => "form#new_international_trade_form", :as => "new_international_trade_form"


### PR DESCRIPTION
…in accessibility statement

## 📝 A short description of the changes

* Adds the footer to the admin-y sections of the app
* On these admin footers, and the sign in footers where an admin is signing in (where path is /admins /assessors or /judges) then the footer points to the admin accessibility statement
* Adds the new admin acc. statement

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1207293385583854/f

## :shipit: Deployment implications

* none

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

