### PR TITLE
Upgrade gems so ffi can be installed on the latest osx

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     ast (2.4.2)
     authy (3.0.1)
       httpclient (>= 2.5.3.3)
-    autoprefixer-rails (10.4.13.0)
+    autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -199,7 +199,7 @@ GEM
     et-orbi (1.2.11)
       tzinfo
     excon (0.100.0)
-    execjs (2.8.1)
+    execjs (2.10.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -232,7 +232,10 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    ffi (1.15.5)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     fog-aws (3.19.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -720,6 +723,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-darwin-23


### PR DESCRIPTION
## 📝 A short description of the changes

Fixes: Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/matt/.asdf/installs/ruby/3.2.4/lib/ruby/gems/3.2.0/gems/ffi-1.15.5/ext/ffi_c

