### PR TITLE
Add scripts to export/remove invalid User phone numbers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ gem "simple_form", "~> 5.0"
 gem "country_select", "~> 3.1"
 gem "email_validator"
 gem "enumerize"
+gem "phonelib"
 
 # PDF generation
 gem "prawn"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,6 +403,7 @@ GEM
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    phonelib (0.9.3)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
@@ -780,6 +781,7 @@ DEPENDENCIES
   pdf-inspector
   pg
   pg_search (~> 2.3.3)
+  phonelib
   poltergeist
   prawn
   prawn-table

--- a/lib/tasks/temprary/remove_invalid_user_phone_numbers.rake
+++ b/lib/tasks/temprary/remove_invalid_user_phone_numbers.rake
@@ -1,0 +1,47 @@
+namespace :db do
+  desc "Remove invalid user phone_numbers"
+  task remove_invalid_user_phone_numbers: :environment do
+    User.find_each do |user|
+      invalid = false
+
+      if user.phone_number && Phonelib.invalid_for_country?(user.phone_number, "GB")
+        user.phone_number = nil
+        invalid = true
+      end
+
+      if user.company_phone_number && Phonelib.invalid_for_country?(user.company_phone_number, "GB")
+        user.company_phone_number = nil
+        invalid = true
+      end
+
+      user.save! if invalid
+    end
+  end
+
+  desc "Export users with invalid phone numbers"
+  task export_user_phone_numbers: :environment do
+    CSV.open("user_phone_numbers.csv", "w") do |csv|
+      csv << ["Email", "Name", "Number", "Field"]
+
+      User.find_each do |user|
+        if user.phone_number && Phonelib.invalid_for_country?(user.phone_number, "GB")
+          csv << [
+            user.email,
+            user.full_name,
+            user.phone_number,
+            "phone_number",
+          ]
+        end
+
+        if user.company_phone_number && Phonelib.invalid_for_country?(user.company_phone_number, "GB")
+          csv << [
+            user.email,
+            user.full_name,
+            user.company_phone_number,
+            "company_phone_number",
+          ]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 📝 A short description of the changes

* Adds the phonelib gem and scripts to export/fix invalidated user records

## 🔗 Link to the relevant story (or stories)

* Preparation for #3114

## :shipit: Deployment implications

* 

## ✅ Checklist

- [ ] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [ ] I have checked that commit messages make sense and explain the reasoning for each change
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

