### PR TITLE
Fix: fixes 'skip to main content' links

### DIFF
--- a/app/assets/stylesheets/application-admin.scss
+++ b/app/assets/stylesheets/application-admin.scss
@@ -54,13 +54,29 @@ $todo-black: #333;
   }
 }
 
-.skip-main-content {
-  position: absolute;
-    top: -100px;
-    z-index: 9999999999999999999999;
+.skip-link:not(:active):not(:focus) {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
 
-    &:focus {
-      top: 20px;
-      left: 20px;
-    }
+.skip-link:focus {
+  outline: 3px solid #ffdd00;
+  outline-offset: 0;
+  background-color: #ffdd00;
+}
+
+.skip-link:link, .skip-link:visited, .skip-link:active, .skip-link:focus {
+  color: #0b0c0c;
 }

--- a/app/views/account/collaborators/index.html.slim
+++ b/app/views/account/collaborators/index.html.slim
@@ -1,7 +1,7 @@
 - title "Collaborators and account owner"
 
 - provide(:page_content_class, "multi-page page-account")
-s
+
 h1.govuk-heading-xl
   ' Account details
 

--- a/app/views/layouts/application-admin.html.slim
+++ b/app/views/layouts/application-admin.html.slim
@@ -39,8 +39,7 @@ html.no-js
   body#admin-layout data-autosave-token="#{current_admin.try(:autosave_token)}" class="admin-layout #{controller_name}-page #{action_name}-page #{controller_name}-#{action_name}-page #{yield :page_class} #{'layout-dev' if Rails.env.development?}"
     #site-wrapper
       #site-wrapper-margin
-        a href="#main-container" class="btn btn-lg skip-main-content" onclick="document.getElementById('main-container').focus()" role="button"
-          | Skip to main content
+        = link_to "Skip to main content", "#main-container", class: "govuk-skip-link skip-link"
         #site-header.clearfix
           .navbar.clearfix role="navigation"
             .container.clearfix

--- a/app/views/layouts/application-assessor.html.slim
+++ b/app/views/layouts/application-assessor.html.slim
@@ -39,6 +39,7 @@ html.no-js
   body#assessor-layout data-autosave-token="#{current_assessor.try(:autosave_token)}" class="assessor-layout #{controller_name}-page #{action_name}-page #{controller_name}-#{action_name}-page #{yield :page_class} #{'layout-dev' if Rails.env.development?}"
     #site-wrapper
       #site-wrapper-margin
+        = link_to "Skip to main content", "#main-container", class: "govuk-skip-link skip-link"
         #site-header
           .navbar.clearfix role="navigation"
             .container

--- a/app/views/layouts/application-judge.html.slim
+++ b/app/views/layouts/application-judge.html.slim
@@ -39,6 +39,7 @@ html.no-js
   body#assessor-layout data-autosave-token="#{current_judge.try(:autosave_token)}" class="assessor-layout #{controller_name}-page #{action_name}-page #{controller_name}-#{action_name}-page #{yield :page_class} #{'layout-dev' if Rails.env.development?}"
     #site-wrapper
       #site-wrapper-margin
+        = link_to "Skip to main content", "#main-container", class: "govuk-skip-link skip-link"
         #site-header
           .navbar.clearfix role="navigation"
             .container


### PR DESCRIPTION
## 📝 A short description of the changes

Fixes to the 'Skip to Main Content' link as part of accessibility fixes
* The link has been added to judges and assessors layouts where this was previously missing
* Copies styles from govuk-skip-link component
* Remove onClick and button role from old link as focus remained on element
* Removes a typo - an 's' was being rendered as an empty strikethrough tag and read as a deletion element by screen readers

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1200504523179345/1208733738852414

## :shipit: Deployment implications

* None

## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

![Screenshot 2024-11-13 at 13 52 10](https://github.com/user-attachments/assets/67f2d3bd-3fce-4732-999b-d2c0a35e81c0)
