### PR TITLE
Fix: Replace CF_PACKAGE_URL variable with direct URL in deployment 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,4 +25,3 @@ GOV_UK_NOTIFY_API_TEMPLATE_ID=id
 SESSION_TIMEOUT=1
 HOST=http://localhost:3000
 ENABLE_ASIM_LOGGER=false
-CF_PACKAGE_URL="https://packages.cloudfoundry.org/stable\?release\=debian64\&version\=8.8.3\&source\=github-rel"

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -36,7 +36,7 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          curl -v -L -o cf-cli_amd64.deb "$CF_PACKAGE_URL"
+          curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable\?release\=debian64\&version\=8.8.3\&source\=github-rel'
           sudo dpkg -i cf-cli_amd64.deb
           cf -v
           cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -37,7 +37,7 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          curl -v -L -o cf-cli_amd64.deb "$CF_PACKAGE_URL"
+          curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable\?release\=debian64\&version\=8.8.3\&source\=github-rel'
           sudo dpkg -i cf-cli_amd64.deb
           cf -v
           cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -37,7 +37,7 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          curl -v -L -o cf-cli_amd64.deb "$CF_PACKAGE_URL"
+          curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable\?release\=debian64\&version\=8.8.3\&source\=github-rel'
           sudo dpkg -i cf-cli_amd64.deb
           cf -v
           cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org


### PR DESCRIPTION
## 📝 A short description of the changes

* Hardcode URL for CF package