### PR TITLE
Fix: Update Cloud Foundry CLI installation method in deployment workf…

### DIFF
--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -36,9 +36,12 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable\?release\=debian64\&version\=8.8.3\&source\=github-rel'
-          sudo dpkg -i cf-cli_amd64.deb
-          cf -v
+          (apt update && apt install --yes curl gnupg) > /dev/null 2>&1
+          curl -fsSL https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor -o /usr/share/keyrings/cloudfoundry-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/cloudfoundry-keyring.gpg] https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry.list
+          apt update > /dev/null 2>&1
+          apt install --yes cf8-cli
+          cf8 version
           cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
           cf install-plugin blue-green-deploy -r CF-Community -f
           ./bin/deploy

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -37,9 +37,12 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable\?release\=debian64\&version\=8.8.3\&source\=github-rel'
-          sudo dpkg -i cf-cli_amd64.deb
-          cf -v
+          (apt update && apt install --yes curl gnupg) > /dev/null 2>&1
+          curl -fsSL https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor -o /usr/share/keyrings/cloudfoundry-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/cloudfoundry-keyring.gpg] https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry.list
+          apt update > /dev/null 2>&1
+          apt install --yes cf8-cli
+          cf8 version
           cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
           cf install-plugin blue-green-deploy -r CF-Community -f
           ./bin/deploy

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -37,9 +37,12 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable\?release\=debian64\&version\=8.8.3\&source\=github-rel'
-          sudo dpkg -i cf-cli_amd64.deb
-          cf -v
+          (apt update && apt install --yes curl gnupg) > /dev/null 2>&1
+          curl -fsSL https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor -o /usr/share/keyrings/cloudfoundry-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/cloudfoundry-keyring.gpg] https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry.list
+          apt update > /dev/null 2>&1
+          apt install --yes cf8-cli
+          cf8 version
           cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
           cf install-plugin blue-green-deploy -r CF-Community -f
           ./bin/deploy


### PR DESCRIPTION
…lows

## 📝 A short description of the changes

url for CF package is broken

* https://github.com/cloudfoundry/cli/wiki/V8-CLI-Installation-Guide

Debian and Ubuntu based Linux distributions. Supported versions include Ubuntu 22.04 Jammy with apt version 2.4.13 or newer:

`(apt update && apt install --yes curl gnupg) > /dev/null 2>&1`

Add the Cloud Foundry GPG key
`curl -fsSL https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor -o /usr/share/keyrings/cloudfoundry-keyring.gpg`

Add the Cloud Foundry repository
`echo "deb [signed-by=/usr/share/keyrings/cloudfoundry-keyring.gpg] https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry.list`

`apt update > /dev/null 2>&1`

Install the Cloud Foundry CLI
`apt install --yes cf8-cli`

Verify installation
`cf8 version`
